### PR TITLE
Fix `math-arbitrary-point-on-elliptical-arc` aria/fallback description formulas

### DIFF
--- a/master/implnote.html
+++ b/master/implnote.html
@@ -412,8 +412,8 @@ arc can be described by the 2-dimensional matrix equation:</p>
     </mrow>
   </math>
   <pre id="math-arbitrary-point-on-elliptical-arc">
-    x = (cos(&#966;), -sin(&#966;))&#183;(rx*cos(&#952;) + cx
-    y = (sin(&#966;), cos(&#966;))&#183;(ry*sin(&#952;) + cy
+    x = rx*cos(&#952;)*cos(&#966;) - ry*sin(&#952;)*sin(&#966;) + cx
+    y = rx*cos(&#952;)*sin(&#966;) + ry*sin(&#952;)*cos(&#966;) + cy
   </pre>
 </div>
 


### PR DESCRIPTION
I expanded the F.6.3.1 matrices wrong. These are the correct formulas.

Confirmed by [here](http://fridrich.blogspot.com/2011/06/bounding-box-of-svg-elliptical-arc.html) and [here](http://stackoverflow.com/a/8202677/796832).

![](http://www.w3.org/TR/SVG/images/implnote/arcs/image002.png)

```
x = rx*cos(theta)*cos(phi) - ry*sin(theta)*sin(phi) + cx
y = rx*cos(theta)*sin(phi) + ry*sin(theta)*cos(phi) + cy

x = rx*cos(&#952;)*cos(&#966;) - ry*sin(&#952;)*sin(&#966;) + cx
y = rx*cos(&#952;)*sin(&#966;) + ry*sin(&#952;)*cos(&#966;) + cy
```