### PR TITLE
Clarify focus management for SVG & define rendered/non-rendered elements

### DIFF
--- a/master/coords.html
+++ b/master/coords.html
@@ -868,13 +868,13 @@ excluded from the bounding box.</p>
   of the control points.</p>
 </div>
 
-<p>Even if an element is not in the rendering tree – due to it being
+<p>Even if an element is not in the <a>rendering tree</a> – due to it being
 <span class='prop-value'>'display: none'</span>, within a <a>'defs'</a>
 element, not usually rendered like a <a>'symbol'</a> element or not
 currently present in the document tree – it still has a bounding box.
 A call to <a href="types.html#__svg__SVGGraphicsElement__getBBox">getBBox</a>
 on the element will return the same rectangle as if the element were
-rendered.  However, an element that is not in the rendering tree
+rendered.  However, an element that is not in the <a>rendering tree</a>
 does not contribute to the bounding box of any ancestor element.</p>
 
 <div class='example'>
@@ -952,7 +952,7 @@ point (0,0) for the purposes of calculating a bounding box.</p>
 (such as gradient elements) do not have a bounding box, and thus have no
 interface to request a bounding box.</p>
 
-<p>Elements in the rendering tree which reference unresolved resources shall
+<p>Elements in the <a>rendering tree</a> which reference unresolved resources shall
 still have a bounding box, defined by the position and dimensions specified in
 their attributes, or by the <a>initial value</a> for those attributes if no
 values are supplied. For example, the element <code>&lt;use href="#bad" x="10" y="10"/&gt;</code>

--- a/master/definitions-compositing.xml
+++ b/master/definitions-compositing.xml
@@ -30,6 +30,7 @@
   <term name='isolation' href='http://www.w3.org/TR/2015/CR-compositing-1-20150113/#isolatedgroups'/>
   <term name='isolated' href='http://www.w3.org/TR/2015/CR-compositing-1-20150113/#isolatedgroups'/>
   <term name='non-isolated groups' href='http://www.w3.org/TR/2015/CR-compositing-1-20150113/#isolatedgroups'/>
+  <term name='non-isolated group' href='http://www.w3.org/TR/2015/CR-compositing-1-20150113/#isolatedgroups'/>
   <term name='group backdrop' href='http://www.w3.org/TR/2015/CR-compositing-1-20150113/#groupbackdrop'/>
   <term name='initial backdrop' href='http://www.w3.org/TR/2015/CR-compositing-1-20150113/#initialbackdrop'/>
   <term name='page group' href='http://www.w3.org/TR/2015/CR-compositing-1-20150113/#pagebackdrop'/>

--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -1050,9 +1050,20 @@
   <term name='Conforming SVG Generators' href='conform.html#ConformingSVGGenerators'/>
   <term name='Conforming SVG Generator' href='conform.html#ConformingSVGGenerators'/>
     
+  <!-- ... defined in render.html ... -->
+  <term name='rendering tree' href='render.html#RenderingTree' />
   <term name='not rendered' href='render.html#NonRenderedElements' />
+  <term name='non-rendered element' href='render.html#TermNonRenderedElements' />
+  <term name='non-rendered elements' href='render.html#TermNonRenderedElements' />
+  <term name='renderable element' href='render.html#TermRenderableElements' />
+  <term name='renderable elements' href='render.html#TermRenderableElements' />
   <term name='never directly rendered' href='render.html#TermNeverRenderedElements'/>
-
+  <term name='never-rendered element' href='render.html#TermNeverRenderedElements' />
+  <term name='never-rendered elements' href='render.html#TermNeverRenderedElements' />
+  <term name='rendered element' href='render.html#TermRenderedElements' />
+  <term name='rendered element' href='render.html#TermRenderedElements' />
+  <term name='re-used graphics' href='render.html#TermReusedGraphics' />
+                 
   <!-- ... defined in types.html ... -->
   <term name='reflect' href='types.html#TermReflect'/>
   <term name='reflects' href='types.html#TermReflect'/>
@@ -1076,6 +1087,10 @@
   <term name='event attributes' href='interact.html#TermEventAttribute'/>
   <term name='graphical event attribute' href='interact.html#EventAttributes'/>
   <term name='graphical event attributes' href='interact.html#EventAttributes'/>
+  <term name='focus' href='interact.html#Focus'/>
+  <term name='keyboard focus' href='interact.html#Focus'/>
+  <term name='focusable' href='interact.html#TermFocusable'/>
+   
 
   <!-- ... defined in struct.html ... -->
   <term name='container element' href='struct.html#TermContainerElement'/>

--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -520,7 +520,7 @@
 
   <!-- ... element categories ............................................ -->
 
-  <elementcategory name='container' href='struct.html#TermContainerElement' elements='svg, g, defs, symbol, mask, pattern, marker, a, switch'/>
+  <elementcategory name='container' href='struct.html#TermContainerElement' elements='svg, g, defs, symbol, clipPath, mask, pattern, marker, a, switch'/>
   <elementcategory name='descriptive' href='struct.html#TermDescriptiveElement' elements='desc, title, metadata'/>
   <elementcategory name='gradient' href='pservers.html#TermGradientElement' elements='linearGradient, radialGradient, mesh'/>
   <elementcategory name='graphics' href='struct.html#TermGraphicsElement' elements='path, text, rect, circle, ellipse, line, polyline, polygon, image, use, foreignObject, iframe, video, audio, canvas'/>
@@ -532,6 +532,8 @@
   <elementcategory name='structurally external' href='struct.html#TermStructurallyExternalElement' elements='script, image, use, iframe, video, audio, foreignObject'/>
   <elementcategory name='text content' href='text.html#TermTextContentElement' elements='text, tspan, textPath'/>
   <elementcategory name='text content child' href='text.html#TermTextContentChildElement' elements='tspan, textPath'/>
+  <elementcategory name='never-rendered' href='render.html#TermNeverRenderedElements' elements='defs, symbol, clipPath, mask, pattern, marker, desc, title, metadata, linearGradient, radialGradient, script'/>
+  <elementcategory name='renderable' href='render.html#TermRenderableElements' elements='svg, g, a, switch, mesh, path, text, rect, circle, ellipse, line, polyline, polygon, image, use, foreignObject, iframe, video, audio, canvas, tspan, textPath'/>
 
   <!-- ... attributes common to multiple elements ........................ -->
 
@@ -828,7 +830,7 @@
   <property name='font-kerning'     href='http://www.w3.org/TR/css-fonts-3/#font-kerning-prop'/>
   <property name='font'             href='http://www.w3.org/TR/css-fonts-3/#font-prop'/>
   <property name='font-family'      href='http://www.w3.org/TR/css-fonts-3/#font-family-prop'/>
-  <property name='font-feature-settings' href="http://www.w3.org/TR/css-fonts-3/#font-feature-settings-prop"/>
+  <property name='font-feature-settings' href='http://www.w3.org/TR/css-fonts-3/#font-feature-settings-prop'/>
   <property name='font-size'        href='http://www.w3.org/TR/css-fonts-3/#font-size-prop'/>
   <property name='font-size-adjust' href='http://www.w3.org/TR/css-fonts-3/#font-size-adjust-prop'/>
   <property name='font-stretch'     href='http://www.w3.org/TR/css-fonts-3/#font-stretch-prop'/>
@@ -864,7 +866,7 @@
   <property name='unicode-bidi'     href='http://www.w3.org/TR/css-writing-modes-3/#unicode-bidi'/>
   <property name='writing-mode'     href='text.html#WritingModeProperty'/>
   <property name='text-orientation' href='http://www.w3.org/TR/css3-writing-modes/#text-orientation'/>
-  <property name='text-combine-upright' href="http://www.w3.org/TR/css-writing-modes-3/#text-combine-upright" />
+  <property name='text-combine-upright' href='http://www.w3.org/TR/css-writing-modes-3/#text-combine-upright' />
 
   <!-- ... text decoration properites defined in CSS Text Decorations -->
   <property name='text-decoration'       href='text.html#TextDecorationProperties'/>
@@ -984,8 +986,8 @@
   <symbol name='time' href='http://www.w3.org/TR/css3-values/#time'/>
   <symbol name='transform-list' href='http://dev.w3.org/csswg/css-transforms/#typedef-transform-list'/>
   <symbol name='url' href='http://www.w3.org/TR/css3-values/#url-value'/>
-  <symbol name='XML-Name' href="http://www.w3.org/TR/xml/#NT-Name"/>
-  <symbol name='string' href="https://www.w3.org/TR/css3-values/#strings"/>
+  <symbol name='XML-Name' href='http://www.w3.org/TR/xml/#NT-Name'/>
+  <symbol name='string' href='https://www.w3.org/TR/css3-values/#strings'/>
 
   <!-- ... terms (these will be generated later) .......................... -->
   <!-- ... elements, in alphabetic order ... -->
@@ -1047,6 +1049,9 @@
   <term name='Conforming Static SVG Viewers' href='conform.html#ConformingStaticSVGViewers'/>
   <term name='Conforming SVG Generators' href='conform.html#ConformingSVGGenerators'/>
   <term name='Conforming SVG Generator' href='conform.html#ConformingSVGGenerators'/>
+    
+  <term name='not rendered' href='render.html#NonRenderedElements' />
+  <term name='never directly rendered' href='render.html#TermNeverRenderedElements'/>
 
   <!-- ... defined in types.html ... -->
   <term name='reflect' href='types.html#TermReflect'/>
@@ -1220,8 +1225,8 @@
   <!-- ... Wrapped text ................................................... -->
   <term name='CSS basic shape'  href='http://dev.w3.org/csswg/css-shapes/#basic-shape-functions'/>
   <term name='CSS basic shapes' href='http://dev.w3.org/csswg/css-shapes/#basic-shape-functions'/>
-  <term name="forced line break" href="http://dev.w3.org/csswg/css-text/#forced-line-break"/>
-  <term name="typographic character unit" href="https://drafts.csswg.org/css-text-3/#typographic-character-unit"/>
+  <term name='forced line break' href='http://dev.w3.org/csswg/css-text/#forced-line-break'/>
+  <term name='typographic character unit' href='https://drafts.csswg.org/css-text-3/#typographic-character-unit'/>
 
   <!-- ... grammar symbols ................................................ -->
   <symbol name='angle' href='http://www.w3.org/TR/2012/WD-css3-values-20120308/#angles'/>

--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -532,8 +532,8 @@
   <elementcategory name='structurally external' href='struct.html#TermStructurallyExternalElement' elements='script, image, use, iframe, video, audio, foreignObject'/>
   <elementcategory name='text content' href='text.html#TermTextContentElement' elements='text, tspan, textPath'/>
   <elementcategory name='text content child' href='text.html#TermTextContentChildElement' elements='tspan, textPath'/>
-  <elementcategory name='never-rendered' href='render.html#TermNeverRenderedElements' elements='defs, symbol, clipPath, mask, pattern, marker, desc, title, metadata, linearGradient, radialGradient, script'/>
-  <elementcategory name='renderable' href='render.html#TermRenderableElements' elements='svg, g, a, switch, mesh, path, text, rect, circle, ellipse, line, polyline, polygon, image, use, foreignObject, iframe, video, audio, canvas, tspan, textPath'/>
+  <elementcategory name='never-rendered' href='render.html#TermNeverRenderedElement' elements='defs, symbol, clipPath, mask, pattern, marker, desc, title, metadata, linearGradient, radialGradient, script'/>
+  <elementcategory name='renderable' href='render.html#TermRenderableElement' elements='svg, g, a, switch, mesh, path, text, rect, circle, ellipse, line, polyline, polygon, image, use, foreignObject, iframe, video, audio, canvas, tspan, textPath'/>
 
   <!-- ... attributes common to multiple elements ........................ -->
 
@@ -810,9 +810,9 @@
 
   <!-- ... properties defined elsewhere but described in this spec ........ -->
 
-  <property name='display' href='painting.html#VisibilityControl'/>
+  <property name='display' href='render.html#VisibilityControl'/>
   <property name='opacity' href='render.html#ObjectAndGroupOpacityProperties'/>
-  <property name='visibility' href='painting.html#VisibilityControl'/>
+  <property name='visibility' href='render.html#VisibilityControl'/>
   <property name='height' href='geometry.html#Sizing'/>
   <property name='width' href='geometry.html#Sizing'/>
   <property name='z-index' href='render.html#ZIndexProperty'/>
@@ -1052,17 +1052,20 @@
     
   <!-- ... defined in render.html ... -->
   <term name='rendering tree' href='render.html#RenderingTree' />
-  <term name='not rendered' href='render.html#NonRenderedElements' />
-  <term name='non-rendered element' href='render.html#TermNonRenderedElements' />
-  <term name='non-rendered elements' href='render.html#TermNonRenderedElements' />
-  <term name='renderable element' href='render.html#TermRenderableElements' />
-  <term name='renderable elements' href='render.html#TermRenderableElements' />
-  <term name='never directly rendered' href='render.html#TermNeverRenderedElements'/>
-  <term name='never-rendered element' href='render.html#TermNeverRenderedElements' />
-  <term name='never-rendered elements' href='render.html#TermNeverRenderedElements' />
-  <term name='rendered element' href='render.html#TermRenderedElements' />
-  <term name='rendered element' href='render.html#TermRenderedElements' />
+  <term name='not rendered' href='render.html#Rendered-vs-NonRendered' />
+  <term name='non-rendered element' href='render.html#TermNonRenderedElement' />
+  <term name='non-rendered elements' href='render.html#TermNonRenderedElement' />
+  <term name='renderable element' href='render.html#TermRenderableElement' />
+  <term name='renderable elements' href='render.html#TermRenderableElement' />
+  <term name='never directly rendered' href='render.html#TermNeverRenderedElement'/>
+  <term name='never-rendered element' href='render.html#TermNeverRenderedElement' />
+  <term name='never-rendered elements' href='render.html#TermNeverRenderedElement' />
+  <term name='rendered element' href='render.html#TermRenderedElement' />
+  <term name='rendered elements' href='render.html#TermRenderedElement' />
+  <term name='rendered' href='render.html#TermRenderedElement' />
   <term name='re-used graphics' href='render.html#TermReusedGraphics' />
+  <term name='stacking context' href='render.html#TermStackingContext' />
+  <term name='stacking contexts' href='render.html#TermStackingContext' />
                  
   <!-- ... defined in types.html ... -->
   <term name='reflect' href='types.html#TermReflect'/>

--- a/master/interact.html
+++ b/master/interact.html
@@ -905,20 +905,20 @@ that the cursor can be visible over most backgrounds.</p>
 </p>
 <p> When an element is focused, 
     the element matches the <a href="https://www.w3.org/TR/css3-selectors/#the-user-action-pseudo-classes-hover-act">CSS <code>:focus</code> pseudo-class</a>. 
-    Interactive user agents MUST visually indicate focus (usually with an outline)
+    Interactive user agents must visually indicate focus (usually with an outline)
     when the focus changes because of a user input event 
     from the keyboard or other non-pointing device
-    and MAY indicate focus at all times.
-    Authors MAY use the <code>:focus</code> pseudo-class to 
+    and may indicate focus at all times.
+    Authors may use the <code>:focus</code> pseudo-class to 
     replace the visual indication with one more suitable to the graphic,
     (such as a stroke on a shape)
-    but SHOULD NOT use it to remove visual indications of focus completely.
+    but should not use it to remove visual indications of focus completely.
 </p>
 <p>
     The following SVG elements are <dfn id="TermFocusable">focusable</dfn>
     in an interactive document.
     For the purpose of the HTML focus model, 
-    interactive user agents MUST treat them as
+    interactive user agents must treat them as
     <a href="https://www.w3.org/TR/html51/editing.html#focusable-area">focusable areas</a> 
     whose <a href="https://www.w3.org/TR/html51/editing.html#specially-focusable">tabindex focus flag</a> should be set:
 </p>
@@ -938,27 +938,27 @@ that the cursor can be visible over most backgrounds.</p>
     for each sub-control.
 </p>
 <p> In addition, all <a>'a'</a> elements that are valid links are <a>focusable</a>,
-    and their <a href="https://www.w3.org/TR/html51/editing.html#specially-focusable">tabindex focus flag</a> MUST be set 
+    and their <a href="https://www.w3.org/TR/html51/editing.html#specially-focusable">tabindex focus flag</a> must be set 
     <em>unless</em> the user agent normally provides an alternative method
     of keyboard traversal of links.
 </p>
 <p>
     For compatibility with content that used the 
     <a href="https://www.w3.org/TR/SVGTiny12/interact.html#focusable-attr">SVG Tiny 1.2 <span class="attr-name">focusable</span> attribute</a>,
-    user agents SHOULD treat an element with a value of
+    user agents should treat an element with a value of
     <span class="attr-value">true</span> for that attribute as focusable.
-    In new content, authors SHOULD either omit the <span class="attr-name">focusable</span> attribute
+    In new content, authors should either omit the <span class="attr-name">focusable</span> attribute
     or use it only in combination with a corresponding 
     <span class="attr-name">tabindex</span> value of <span class="attr-value">0</span>.
 </p>
 <p>
-    User agents MAY treat other elements as focusable,
+    User agents may treat other elements as focusable,
     particularly if keyboard interaction is the only or primary means of user input.
     In particular, user agents may support using keyboard focus 
     to reveal <a>'title'</a> element text as tooltips,
     and may allow focus to reach elements which have been assigned 
     listeners for mouse, pointer, or focus events.
-    Authors SHOULD NOT rely on this behavior;
+    Authors should not rely on this behavior;
     all interactive elements should directly support keyboard interaction.
 </p>
 <p>
@@ -976,7 +976,7 @@ that the cursor can be visible over most backgrounds.</p>
 </div>
 <p> When the user agent supports scrolling or panning of the SVG document,
     and focus moves to an element that is currently outside the viewport,
-    the user agent SHOULD scroll or pan the document
+    the user agent should scroll or pan the document
     until the focused element is within the viewport.
 </p>
     

--- a/master/interact.html
+++ b/master/interact.html
@@ -988,7 +988,7 @@ that the cursor can be visible over most backgrounds.</p>
 </p>
 <p class="note">
     This means that an element that is only focusable 
-    because of its <a>tabindex</a> attribute 
+    because of its <a>'tabindex'</a> attribute 
     will fire a <code>click</code> event 
     in response to a non-mouse activation 
     (e.g. hitting the "enter" key while the element has <a>focus</a>).

--- a/master/interact.html
+++ b/master/interact.html
@@ -896,12 +896,110 @@ that the cursor can be visible over most backgrounds.</p>
 <div class='ready-for-wg-review'>
 <h2 id="Focus">Focus</h2>
 
-<p>SVG uses the same <a href="https://www.w3.org/TR/html51/editing.html#focus">focus model</a>
-as HTML.  All <a>'tabindex'</a> attributes on SVG elements must be processed in the same way
-as <a href="https://www.w3.org/TR/html51/editing.html#the-tabindex-attribute">tabindex attributes
-on HTML elements</a>.  For documents that contain a mix of inline HTML and SVG, focus is handled
-for the document as a whole, not with each inline SVG or HTML fragment as being an isolated
-subdocument.</p>
+<p>
+    SVG uses the same <a href="https://www.w3.org/TR/html51/editing.html#focus">focus model</a>
+    as HTML, modified for SVG as described in this section.  
+    At most one element in each document is <a href="https://www.w3.org/TR/html51/editing.html#focused">focused</a> at a time;
+    if the document as a whole has system focus, 
+    this element becomes the target of all keyboard events.
+</p>
+<p> When an element is focused, 
+    the element matches the <a href="https://www.w3.org/TR/css3-selectors/#the-user-action-pseudo-classes-hover-act">CSS <code>:focus</code> pseudo-class</a>. 
+    Interactive user agents MUST visually indicate focus (usually with an outline)
+    when the focus changes because of a user input event 
+    from the keyboard or other non-pointing device
+    and MAY indicate focus at all times.
+    Authors MAY use the <code>:focus</code> pseudo-class to 
+    replace the visual indication with one more suitable to the graphic,
+    (such as a stroke on a shape)
+    but SHOULD NOT use it to remove visual indications of focus completely.
+</p>
+<p>
+    The following SVG elements are <dfn id="TermFocusable">focusable</dfn>
+    in an interactive document.
+    For the purpose of the HTML focus model, 
+    interactive user agents MUST treat them as
+    <a href="https://www.w3.org/TR/html51/editing.html#focusable-area">focusable areas</a> 
+    whose <a href="https://www.w3.org/TR/html51/editing.html#specially-focusable">tabindex focus flag</a> should be set:
+</p>
+<ul>
+    <li>the document root element</li>
+    <li>an <a>'svg'</a> element which has <a href="ZoomAndPanAttribute">zoom and pan</a> controls</li>
+    <li>any element (such as within a <a>'foreignObject'</a>) 
+        that generates a scrollable region
+    </li>
+    <li><a>'iframe'</a> elements that are <a href="https://www.w3.org/TR/html51/browsers.html#browsing-context-container"></a>browsing context containers</li>
+    <li><a>'audio'</a> and <a>'video'</a> elements with user controls</li>
+    <li>any directly <a>rendered element</a> 
+        with a valid integer <a>'tabindex'</a> attribute</li>
+</ul>
+<p> In the case of user-agent supplied controls, 
+    the element may have more than one focusable area,
+    for each sub-control.
+</p>
+<p> In addition, all <a>'a'</a> elements that are valid links are <a>focusable</a>,
+    and their <a href="https://www.w3.org/TR/html51/editing.html#specially-focusable">tabindex focus flag</a> MUST be set 
+    <em>unless</em> the user agent normally provides an alternative method
+    of keyboard traversal of links.
+</p>
+<p>
+    For compatibility with content that used the 
+    <a href="https://www.w3.org/TR/SVGTiny12/interact.html#focusable-attr">SVG Tiny 1.2 <span class="attr-name">focusable</span> attribute</a>,
+    user agents SHOULD treat an element with a value of
+    <span class="attr-value">true</span> for that attribute as focusable.
+    In new content, authors SHOULD either omit the <span class="attr-name">focusable</span> attribute
+    or use it only in combination with a corresponding 
+    <span class="attr-name">tabindex</span> value of <span class="attr-value">0</span>.
+</p>
+<p>
+    User agents MAY treat other elements as focusable,
+    particularly if keyboard interaction is the only or primary means of user input.
+    In particular, user agents may support using keyboard focus 
+    to reveal <a>'title'</a> element text as tooltips,
+    and may allow focus to reach elements which have been assigned 
+    listeners for mouse, pointer, or focus events.
+    Authors SHOULD NOT rely on this behavior;
+    all interactive elements should directly support keyboard interaction.
+</p>
+<p>
+    The sequential focus order is generated from the set of all <a>focusable</a> elements,
+    processing <a>'tabindex'</a> attributes on SVG elements
+    in the same way as <a href="https://www.w3.org/TR/html51/editing.html#the-tabindex-attribute">tabindex attributes on HTML elements</a>.
+</p>
+<div class='note'>
+    A <a>non-rendered element</a> can never receive focus, 
+    regardless of the value of the <a>'tabindex'</a> attribute,
+    If a script programmatically assigns focus to a non-rendered 
+    or otherwise un-focusable element, the focusing call is aborted.
+    Note, however, that an element that is not visible or onscreen
+    may still be <a>rendered</a>.
+</div>
+<p> When the user agent supports scrolling or panning of the SVG document,
+    and focus moves to an element that is currently outside the viewport,
+    the user agent SHOULD scroll or pan the document
+    until the focused element is within the viewport.
+</p>
+    
+<p> As in HTML, an SVG element that is <a>focusable</a>
+    but does not have a defined
+    <a href="https://www.w3.org/TR/html51/editing.html#activation-behaviour">activation behaviour</a>
+    has an activation behaviour that does nothing 
+    (unless a script specifically responds to it).
+</p>
+<p class="note">
+    This means that an element that is only focusable 
+    because of its <a>tabindex</a> attribute 
+    will fire a <code>click</code> event 
+    in response to a non-mouse activation 
+    (e.g. hitting the "enter" key while the element has <a>focus</a>).
+</p>
+    
+<p>
+    For documents that contain a mix of inline HTML and SVG, 
+    focus is handled for the document as a whole 
+    (with a combined sequential focus order), 
+    not with each inline SVG or HTML fragment as being an isolated subdocument.
+</p>
 
 <div class='note'>
   <p>For example, in the following document, pressing Tab would cycle the focus

--- a/master/painting.html
+++ b/master/painting.html
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional+edit//EN" "xhtml1-transitional+edit.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:edit="http://xmlns.grorg.org/SVGT12NG/">
 <head>
@@ -2032,77 +2032,9 @@ a subpath is determined as follows:</p>
   <var>P<sub>2</sub></var> and <var>P<sub>3</sub></var> are degenerate, the
   curvature will be infinite and a line should be used in constructing the join.</p>
 
-<h2 id="VisibilityControl">Controlling visibility: the effect of the <span
-class="property">'display'</span> and <span class="property">'visibility'</span>
-properties</h2>
-
-<p class="note">See the CSS 2.1 specification for the definitions
-of <a>'display'</a> and <a>'visibility'</a>.
-[<a href="refs.html#ref-CSS21">CSS21</a>]</p>
-
-<p>SVG uses two properties to control the visibility of
-<a>container elements</a>, <a>graphics elements</a>
-and <a>text content elements</a>:
-<a>'display'</a> and <a>'visibility'</a>.</p>
-
-<p>When applied to certain <a>container elements</a>, <a>graphics elements</a>
-or <a>text content elements</a>, setting <a>'display'</a> to
-<span class="prop-value">none</span> results in the element not becoming part of
-the rendering tree.  Such elements and all of their descendants (regardless of
-their own <a>'display'</a> property value):</p>
-
-<ul>
-  <li>are not rendered</li>
-
-  <li>are not sensitive to <a href="interact.html#UIEvents">pointer events</a></li>
-
-  <li>do not contribute to <a href="coords.html#ObjectBoundingBox">bounding box
-  calculations</a></li>
-
-  <li>do not contribute to <a>masks</a> or
-  <a>clipping paths</a>, when descendants of a
-  <a>'mask element'</a> or <a>'clipPath'</a> element</li>
-
-  <li>are not considered when performing <a href="text.html#TextLayout">text layout</a></li>
-</ul>
-
-<p>Elements that have any other <a>'display'</a> value than
-<span class="prop-value">none</span> behave normally with
-respect to all of the above.</p>
-
-<p>The <a>'display'</a> property only applies to the following SVG elements:
-<a>'svg'</a>, <a>'g'</a>, <a>'switch'</a>, <a>'a'</a>,
-<a>'foreignObject'</a>, <a>graphics elements</a> and
-<a>text content elements</a>.  Note that <a>'display'</a>
-is not an inherited property.</p>
-
-<p>The <a>'display'</a> property affects the direct processing
-of a given element, but it does not prevent it from
-being referenced by other elements. For example, setting
-<span class="prop-value">display: none</span> on a <a>'path'</a> element
-will prevent that element from getting rendered directly onto the
-canvas, but the <a>'path'</a> element can still be referenced by a
-<a>'textPath'</a> element; furthermore, its geometry will be used
-in text-on-a-path processing even if the <a>'path'</a> has
-<span class="prop-value">display: none</span>.</p>
-
-<p>When applied to a <a>graphics element</a> or <a>text content element</a>,
-setting <a>'visibility'</a> to <span class="prop-value">hidden</span>
-or <span class="prop-value">collapse</span>
-results in the element not being painted.  It is, however,
-still part of the rendering tree, is sensitive
-to pointer events (depending on the value of <a>'pointer-events'</a>),
-contributes to bounding box calculations and clipping paths,
-and does affect text layout.</p>
-
-<p>The <a>'visibility'</a> property only applies to
-<a>graphics elements</a> and <a>text content elements</a>.
-Note that since <a>'visibility'</a> is an inherited property,
-although it has no effect on a <a>container element</a> itself,
-its inherited value can affect descendant elements.</p>
 
 </div>
-
+    
 <h2 id="PaintingVectorEffects">Vector effects</h2>
 
 <p>This chapter explains <a>'vector-effect'</a> related to Painting. Please refer to <a href="coords.html#VectorEffects">this</a> for the perspective of <a>'vector-effect'</a>. </p>

--- a/master/render.html
+++ b/master/render.html
@@ -106,7 +106,7 @@ match the conformance requirements).</p>
         and inserting additional fragments for <a>re-used graphics</a>.
         Graphics are painted and composited in rendering-tree order,
         subject to stacking and re-ordering based on the
-        <a>z-index</a> and <a>paint-order</a> properties.
+        <a>'z-index'</a> and <a>'paint-order'</a> properties.
         Note that elements that have no visual paint may still be in the rendering tree.
     </p>
   </dd>
@@ -117,7 +117,7 @@ match the conformance requirements).</p>
         <a>rendering tree</a> for the current document.
         Does not include elements that are only
         in the rendering tree as re-used graphics.
-        See <a href="#Rendered-versus-NonRendered">Rendered versus non-rendered elements</a>
+        See <a href="#Rendered-vs-NonRendered">Rendered versus non-rendered elements</a>
     </p>
   </dd>
   <dt id="TermNonRenderedElement">non-rendered element</dt>
@@ -127,10 +127,10 @@ match the conformance requirements).</p>
         <a>rendering tree</a> for the current document.
         It may nonetheless affect the rendering tree as re-used graphics
         or graphical effects.
-        See <a href="#Rendered-versus-NonRendered">Rendered versus non-rendered elements</a>.
+        See <a href="#Rendered-vs-NonRendered">Rendered versus non-rendered elements</a>.
     </p>
   </dd>
-  <dt id="TermReusedElement">re-used graphics</dt>
+  <dt id="TermReusedGraphics">re-used graphics</dt>
   <dd>
     <p>
         Graphical components that are included in the rendering tree
@@ -138,11 +138,11 @@ match the conformance requirements).</p>
         in the document model.
         Includes <a>markers</a>, paint server content,
         and content duplicated by <a>'use'</a> elements,
-        as well as graphics used in <a>'clipPath'</a> and <a>'mask' elements</a>.
+        as well as graphics used in <a>'clipPath'</a> or <a>'mask element'</a>.
     </p>
   </dd>
 
-  <dt id="TermNeverRenderedElements">never-rendered element</dt>
+  <dt id="TermNeverRenderedElement">never-rendered element</dt>
   <dd>
       <p>
           Any element type that is <em>never directly rendered</em>,
@@ -151,7 +151,7 @@ match the conformance requirements).</p>
           <edit:elementcategory name='never-rendered'/>
       </p>
   </dd>
-  <dt id="TermRenderableElements">renderable element</dt>
+  <dt id="TermRenderableElement">renderable element</dt>
   <dd>
     <p>
         Any element type that <em>can</em> have a direct representation
@@ -167,7 +167,7 @@ match the conformance requirements).</p>
 
 </dl>
     
-<h3 id="Rendered-versus-NonRendered">Rendered versus non-rendered elements</h3>
+<h3 id="Rendered-vs-NonRendered">Rendered versus non-rendered elements</h3>
     
 <p> The elements in an SVG document are each either 
     rendered or non-rendered at a given point in time.
@@ -177,12 +177,12 @@ match the conformance requirements).</p>
 </p>
     
 <p>
-    Non-rendered elements arise in four situations:
+    An element is <em>not rendered</em> in any of these four situations:
 </p>
 <ul>
     <li><a>never-rendered element</a> types</li>
-    <li>elements excluded because of <a>conditional processing</a> attributes 
-        or <a>switch</a> structures
+    <li>elements excluded because of <a>conditional processing attributes</a> 
+        or <a>'switch'</a> structures
     </li>
     <li>elements with a computed style value of <code>none</code>
         for the <a>'display'</a> property
@@ -198,9 +198,10 @@ match the conformance requirements).</p>
       except when they are used in the rendering of another element 
       that references them.</li>
 
-  <li>do not contribute to the net geometry of a <a>mask</a> or
-      <a>clipping path</a> when they are descendants of a
-      <a>'mask' element</a> or <a>'clipPath'</a> element</li>
+  <li>do not contribute to the net geometry of 
+      <a>clipping paths</a> or <a>masks</a> 
+      when they are descendants of a
+      <a>'clipPath'</a> or <a>'mask element'</a> </li>
 
   <li>are not sensitive to <a href="interact.html#UIEvents">pointer events</a></li>
     
@@ -298,7 +299,7 @@ of <a>'display'</a> and <a>'visibility'</a>.
     (or in another document)
     may be used to render other elements.
     This includes the graphics created by style properties
-    (such as a <a>pattern</a> paint server, or line <a>markers</a>)
+    (such as a <a>'pattern'</a> paint server, or line <a>markers</a>)
     as well as graphics that are instantiated with a <a>'use'</a> element.
     In the case of <a>'use'</a> instances,
     the original graphical elements may or may not be rendered themselves.
@@ -348,7 +349,7 @@ position on the x and y axis of the <a>SVG viewport</a>, SVG elements are also
 positioned on the z axis. The position on the z-axis defines the order that 
 they are painted.</p>
 
-<p>Along the z axis, elements are grouped into 'stacking contexts', each stacking
+<p>Along the z axis, elements are grouped into <dfn id="TermStackingContext">stacking contexts</dfn>, each stacking
 context has an associated stack level.
 A stack level may contain one or more child nodes - either child
 stack levels, <a>graphics elements</a>, or <a>'g'</a> elements.
@@ -556,7 +557,7 @@ created by <a>'foreignObject'</a> elements are the rules in Appendix E of CSS 2.
 <h2 id="Elements">How elements are rendered</h2>
 <div class="ready-for-wider-review">
 <p>
-Individual <a>graphics elements</a> are treated as if they are <a>non-isolated groups</a>,
+Individual <a>graphics elements</a> are treated as if they are a <a>non-isolated group</a>,
 the components (fill, stroke, etc) that make up a graphic element
 (See  <a href="#PaintingShapesAndText">Painting shapes and text</a>) being
 members of that group. See <a href="#Grouping">How groups are rendered</a>.

--- a/master/render.html
+++ b/master/render.html
@@ -82,7 +82,7 @@ match the conformance requirements).</p>
     In dynamic documents, certain components of the graphic
     may be rendered or not, depending on interaction or animation.
     These non-rendered elements are not directly included
-    in the rendering tree.
+    in the <a>rendering tree</a>.
 </p>
 <p>
     Because SVG supports the reuse of graphical sub-components,
@@ -93,17 +93,59 @@ match the conformance requirements).</p>
     and are not directly manipulable by script or user interaction.
 </p>
     
-<h3 id="NonRenderedElements">Non-rendered elements</h3>
+<h3 id="Definitions">Definitions</h3>
     
-<p> All SVG elements can be grouped into two categories, 
-    based on whether they are or are not ever rendered directly:
-</p>
 <dl class='definitions'  data-dfn-type="dfn" data-export="">
+    <dt>rendering tree</dt>
+    <dd>
+    <p>
+        The rendering tree is the set of elements being rendered
+        in an <a>SVG document fragment</a>.
+        It is generated from the document tree 
+        by excluding <a>non-rendered elements</a>
+        and inserting additional fragments for <a>re-used graphics</a>.
+        Graphics are painted and composited in rendering-tree order,
+        subject to stacking and re-ordering based on the
+        <a>z-index</a> and <a>paint-order</a> properties.
+        Note that elements that have no visual paint may still be in the rendering tree.
+    </p>
+  </dd>
+  <dt id="TermRenderedElement">rendered element</dt>
+  <dd>
+    <p>
+        An element that has a direct representation in the
+        <a>rendering tree</a> for the current document.
+        Does not include elements that are only
+        in the rendering tree as re-used graphics.
+        See <a href="#Rendered-versus-NonRendered">Rendered versus non-rendered elements</a>
+    </p>
+  </dd>
+  <dt id="TermNonRenderedElement">non-rendered element</dt>
+  <dd>
+    <p>
+        An element that does not have a direct representation in the
+        <a>rendering tree</a> for the current document.
+        It may nonetheless affect the rendering tree as re-used graphics
+        or graphical effects.
+        See <a href="#Rendered-versus-NonRendered">Rendered versus non-rendered elements</a>.
+    </p>
+  </dd>
+  <dt id="TermReusedElement">re-used graphics</dt>
+  <dd>
+    <p>
+        Graphical components that are included in the rendering tree
+        but do not have a single direct equivalent element
+        in the document model.
+        Includes <a>markers</a>, paint server content,
+        and content duplicated by <a>'use'</a> elements,
+        as well as graphics used in <a>'clipPath'</a> and <a>'mask' elements</a>.
+    </p>
+  </dd>
 
   <dt id="TermNeverRenderedElements">never-rendered element</dt>
   <dd>
       <p>
-          An element type that is <em>never directly rendered</em>,
+          Any element type that is <em>never directly rendered</em>,
           regardless of context or <a>'display'</a> style value.
           It includes the following elements: 
           <edit:elementcategory name='never-rendered'/>
@@ -112,29 +154,40 @@ match the conformance requirements).</p>
   <dt id="TermRenderableElements">renderable element</dt>
   <dd>
     <p>
-        An element that can have a direct representation
-        in the document, 
+        Any element type that <em>can</em> have a direct representation
+        in the <a>rendering tree</a>, 
         as a graphic, container, text, audio, or animation.  
         It includes the following elements: 
         <edit:elementcategory name='renderable'/>
     </p>
+    <p> A renderable element may or may not be rendered
+        in a given document or point in time.
+    </p>  
   </dd>
 
 </dl>
+    
+<h3 id="Rendered-versus-NonRendered">Rendered versus non-rendered elements</h3>
+    
+<p> The elements in an SVG document are each either 
+    rendered or non-rendered at a given point in time.
+    Whether an element is currently rendered or not affects
+    not only its visual display but also interactivity
+    and geometric calculations.
+</p>
+    
 <p>
-    In addition to never-rendered elements, 
-    non-rendered elements arise in three other situations:
+    Non-rendered elements arise in four situations:
 </p>
 <ul>
-    <li><a>Conditional processing</a> attributes 
-        and <a>switch</a> structures can cause content to not be rendered.
+    <li><a>never-rendered element</a> types</li>
+    <li>elements excluded because of <a>conditional processing</a> attributes 
+        or <a>switch</a> structures
     </li>
-    <li>Any element with a computed style value of <code>none</code>
-        for the <a>'display'</a> property is not rendered.
+    <li>elements with a computed style value of <code>none</code>
+        for the <a>'display'</a> property
     </li>
-    <li>Any child elements of non-rendered elements
-        are themselves not rendered
-        (regardless of their own <a>'display'</a> property value).
+    <li>descendent elements of other non-rendered elements
     </li>
 </ul>
     
@@ -147,11 +200,11 @@ match the conformance requirements).</p>
 
   <li>do not contribute to the net geometry of a <a>mask</a> or
       <a>clipping path</a> when they are descendants of a
-      <a>'mask'</a> or <a>'clipPath'</a> element</li>
+      <a>'mask' element</a> or <a>'clipPath'</a> element</li>
 
   <li>are not sensitive to <a href="interact.html#UIEvents">pointer events</a></li>
     
-  <li>cannot receive <a>keyboard focus</a></li>
+  <li>cannot receive <a>focus</a></li>
 
   <li>do not contribute to <a href="coords.html#ObjectBoundingBox">bounding box
   calculations</a></li>
@@ -191,7 +244,7 @@ of <a>'display'</a> and <a>'visibility'</a>.
     and <a>container elements</a> that are normally rendered,
     setting <a>'display'</a> to <span class="prop-value">none</span> 
     results in the element (and all its descendents) 
-    not becoming part of the rendering tree. 
+    not becoming part of the <a>rendering tree</a>. 
     Note that <a>'display'</a> is not an inherited property.
 </p>
 <p>
@@ -223,7 +276,7 @@ of <a>'display'</a> and <a>'visibility'</a>.
     setting <a>'visibility'</a> to <span class="prop-value">hidden</span>
     or <span class="prop-value">collapse</span>
     results in the element not being painted.  
-    It is, however, still part of the rendering tree. 
+    It is, however, still part of the <a>rendering tree</a>. 
     It may be sensitive to pointer events 
     (depending on the value of <a>'pointer-events'</a>),
     may receive focus (depending on the value of <a>'tabindex'</a>),
@@ -251,7 +304,7 @@ of <a>'display'</a> and <a>'visibility'</a>.
     the original graphical elements may or may not be rendered themselves.
 </p>
 <p>
-    Each instance of the re-used graphics creates a fragment of the rendering tree.
+    Each instance of the re-used graphics creates a fragment of the <a>rendering tree</a>.
     The component graphics may need their styles resolved based on context,
     then they are rendered and composited as described in this chapter.
     The re-used fragment as a whole is treated as a <a>stacking context</a>

--- a/master/render.html
+++ b/master/render.html
@@ -64,6 +64,8 @@ realistic performance curves are approximated by straight
 lines, the approximation need only be sufficiently precise to
 match the conformance requirements).</p>
     
+
+<div class='ready-for-wg-review'>
 <h2 id="RenderingTree">The rendering tree</h2>
     
 <p> The components of the final rendered representation of an SVG document
@@ -323,7 +325,7 @@ of <a>'display'</a> and <a>'visibility'</a>.
     when the original DOM elements themselves are not rendered
     because of a value of <code>display: none</code> on an ancestor.
 </p>
-
+</div>
 
 <div class="ready-for-wider-review">
 

--- a/master/render.html
+++ b/master/render.html
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional+edit//EN" "xhtml1-transitional+edit.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:edit="http://xmlns.grorg.org/SVGT12NG/">
 <head>
@@ -63,6 +63,213 @@ in implementing a precise mathematical model (e.g. for
 realistic performance curves are approximated by straight
 lines, the approximation need only be sufficiently precise to
 match the conformance requirements).</p>
+    
+<h2 id="RenderingTree">The rendering tree</h2>
+    
+<p> The components of the final rendered representation of an SVG document
+    do not have a one-to-one relationship with the underlying 
+    elements in the document model.
+    The appearance of the graphic instead reflects a parallel structure,
+    the rendering tree,
+    in which some elements are excluded and others are repeated.
+</p>
+    
+<p> Many elements in the SVG namespace do not directly represent 
+    a component of the graphical document.  
+    Instead, they define graphical effects, metadata,
+    content to be used to represent other elements,
+    or alternatives to be displayed under certain conditions.
+    In dynamic documents, certain components of the graphic
+    may be rendered or not, depending on interaction or animation.
+    These non-rendered elements are not directly included
+    in the rendering tree.
+</p>
+<p>
+    Because SVG supports the reuse of graphical sub-components,
+    some elements are rendered multiple times.
+    The individual renderings may have context-dependent styling
+    and may be rasterized at different scales or transformations.
+    However, they are always reflections of the original element,
+    and are not directly manipulable by script or user interaction.
+</p>
+    
+<h3 id="NonRenderedElements">Non-rendered elements</h3>
+    
+<p> All SVG elements can be grouped into two categories, 
+    based on whether they are or are not ever rendered directly:
+</p>
+<dl class='definitions'  data-dfn-type="dfn" data-export="">
+
+  <dt id="TermNeverRenderedElements">never-rendered element</dt>
+  <dd>
+      <p>
+          An element type that is <em>never directly rendered</em>,
+          regardless of context or <a>'display'</a> style value.
+          It includes the following elements: 
+          <edit:elementcategory name='never-rendered'/>
+      </p>
+  </dd>
+  <dt id="TermRenderableElements">renderable element</dt>
+  <dd>
+    <p>
+        An element that can have a direct representation
+        in the document, 
+        as a graphic, container, text, audio, or animation.  
+        It includes the following elements: 
+        <edit:elementcategory name='renderable'/>
+    </p>
+  </dd>
+
+</dl>
+<p>
+    In addition to never-rendered elements, 
+    non-rendered elements arise in three other situations:
+</p>
+<ul>
+    <li><a>Conditional processing</a> attributes 
+        and <a>switch</a> structures can cause content to not be rendered.
+    </li>
+    <li>Any element with a computed style value of <code>none</code>
+        for the <a>'display'</a> property is not rendered.
+    </li>
+    <li>Any child elements of non-rendered elements
+        are themselves not rendered
+        (regardless of their own <a>'display'</a> property value).
+    </li>
+</ul>
+    
+<p> Non-rendered elements:
+</p>
+<ul>
+  <li>have no visual effect on the graphic,
+      except when they are used in the rendering of another element 
+      that references them.</li>
+
+  <li>do not contribute to the net geometry of a <a>mask</a> or
+      <a>clipping path</a> when they are descendants of a
+      <a>'mask'</a> or <a>'clipPath'</a> element</li>
+
+  <li>are not sensitive to <a href="interact.html#UIEvents">pointer events</a></li>
+    
+  <li>cannot receive <a>keyboard focus</a></li>
+
+  <li>do not contribute to <a href="coords.html#ObjectBoundingBox">bounding box
+  calculations</a></li>
+
+  <li>are not considered when performing <a href="text.html#TextLayout">text layout</a></li>
+</ul>
+    
+<p> Non-rendered elements likewise have no counterpart 
+    in an accessible alternative view of the document.
+    Nonetheless, they remain part of the document model, and
+    participate in <a href="styling.html">style inheritance and cascade</a>.
+</p>
+    
+    
+<h3 id="VisibilityControl">Controlling visibility: the effect of the <span
+class="property">'display'</span> and <span class="property">'visibility'</span>
+properties</h3>
+    
+<p>
+    SVG uses two properties to toggle the visible display of
+    elements that are normally rendered:
+    <a>'display'</a> and <a>'visibility'</a>.
+    Although they have a similar visible effect in static documents,
+    they are conceptually distinct.
+</p>
+
+<p class="note">See the CSS 2.1 specification for the definitions
+of <a>'display'</a> and <a>'visibility'</a>.
+[<a href="refs.html#ref-CSS21">CSS21</a>]</p>
+    
+<p>
+    Setting  <a>'display'</a> to <span class="prop-value">none</span> 
+    results in the element not being rendered.
+    When applied to 
+    <a>graphics elements</a>,
+    <a>text content elements</a>,
+    and <a>container elements</a> that are normally rendered,
+    setting <a>'display'</a> to <span class="prop-value">none</span> 
+    results in the element (and all its descendents) 
+    not becoming part of the rendering tree. 
+    Note that <a>'display'</a> is not an inherited property.
+</p>
+<p>
+    Elements that have any other <a>'display'</a> value than
+<span class="prop-value">none</span> are rendered as normal.
+</p>
+<p>
+    The <a>'display'</a> property only applies to <a>renderable elements</a>.
+    Setting <code>display: none</code> on an element
+    that is <a>never directly rendered</a>
+    or <a>not rendered</a> based on conditional processing
+    has no effect.
+</p>
+
+<p>
+    The <a>'display'</a> property affects the direct processing
+    of a given element, but it does not prevent it from
+    being referenced by other elements. 
+    For example, setting
+    <span class="prop-value">display: none</span> on a <a>'path'</a> element
+    will prevent that element from getting rendered directly onto the
+    canvas, but the <a>'path'</a> element can still be referenced by a
+    <a>'textPath'</a> element and its geometry will be used
+    in text-on-a-path processing.
+</p>
+
+<p>
+    When applied to a <a>graphics element</a> or <a>text content element</a>,
+    setting <a>'visibility'</a> to <span class="prop-value">hidden</span>
+    or <span class="prop-value">collapse</span>
+    results in the element not being painted.  
+    It is, however, still part of the rendering tree. 
+    It may be sensitive to pointer events 
+    (depending on the value of <a>'pointer-events'</a>),
+    may receive focus (depending on the value of <a>'tabindex'</a>),
+    contributes to bounding box calculations and clipping paths,
+    and does affect text layout.
+</p>
+
+<p>
+    The <a>'visibility'</a> property only directly applies to
+    <a>graphics elements</a> and <a>text content elements</a>.
+    Since <a>'visibility'</a> is an inherited property, however,
+    although it has no effect on a <a>container element</a> itself,
+    its inherited value can affect descendant elements.
+</p>
+    
+<h3 id="ReusedGraphics">Re-used graphics</h3>
+    
+<p> Graphical content defined in one part of the document
+    (or in another document)
+    may be used to render other elements.
+    This includes the graphics created by style properties
+    (such as a <a>pattern</a> paint server, or line <a>markers</a>)
+    as well as graphics that are instantiated with a <a>'use'</a> element.
+    In the case of <a>'use'</a> instances,
+    the original graphical elements may or may not be rendered themselves.
+</p>
+<p>
+    Each instance of the re-used graphics creates a fragment of the rendering tree.
+    The component graphics may need their styles resolved based on context,
+    then they are rendered and composited as described in this chapter.
+    The re-used fragment as a whole is treated as a <a>stacking context</a>
+    and a <a>non-isolated group</a>.
+</p>
+<p> 
+    The <a>'display'</a> property on any child content of re-used graphics
+    has its normal effect when set to <code>none</code>,
+    preventing that branch of the document fragment from being used in rendering.
+    Similarly, when a <a>'use'</a> element references a
+    <a>renderable element</a> (as opposed to a <a>'symbol'</a>),
+    a value of <code>display: none</code> on the referenced element
+    will result in an empty rendering-tree fragment for that 'use' element.
+    However, re-used graphics are never affected
+    when the original DOM elements themselves are not rendered
+    because of a value of <code>display: none</code> on an ancestor.
+</p>
+
 
 <div class="ready-for-wider-review">
 

--- a/master/struct.html
+++ b/master/struct.html
@@ -408,7 +408,7 @@ of a <a>'defs'</a>.</p>
 <a>'g'</a> can also be a child of a <a>'defs'</a>, and vice versa.</p>
 
 <p>Elements that are descendants of a <a>'defs'</a> are not rendered directly;
-they are prevented from becoming part of the rendering tree
+they are prevented from becoming part of the <a>rendering tree</a>
 just as if the <a>'defs'</a> element were a <a>'g'</a> element and the
 <a>'display'</a> property were set to <span class="prop-value">none</span>.
 Note, however, that the descendants of a <a>'defs'</a> are
@@ -1150,7 +1150,7 @@ other elements (such as via a <a>'use'</a>).</p>
   <li><a>'requiredExtensions'</a> and <a>'systemLanguage'</a> attributes do not
   apply to the <a>'defs'</a>, and
   <a>'cursor element'</a> elements because
-  they are not part of the rendering tree.</li>
+  they are not part of the <a>rendering tree</a>.</li>
 </ul>
 
 <h3 id="ConditionalProcessingDefinitions">Definitions</h3>


### PR DESCRIPTION
This pull request consists of two new sections, at least one of which (focus management) **needs discussion & approval by the working group** because it's introducing new normative requirements. Links are to compiled versions of the specs.

## [Rendering definitions](http://ameliabr.github.io/svgwg/build/publish/render.html#RenderingTree): 

Shouldn't be controversial. Gathers up content and implicit behavior into clear definitions. Some links/bookmarks in other specs may be broken by moving the section on display/visibility properties to the rendering chapter from the painting chapter.

## [Focus management](http://ameliabr.github.io/svgwg/build/publish/interact.html#Focus)

Addresses the issues brought up by @richschwer in Issue #50. 

Introduces the following normative requirements (based on usability problems in current implementations of keyboard focus control in SVG):

- User agents SHOULD apply visible focus styles. I've worded it to allow these styles to only be applied when the focus is changed based on keyboard input, to match current behavior in e.g. Blink.  With that limitation, I'd be happy to upgrade the main requirement to "MUST".

- Interactive elements MUST be focusable by default, except I added in an exception for platform conventions for links (to support the Presto behavior of having a separate link-focus sequence distinct from the main tabindex). Suggestions for re-wording/clarifying that distinction welcome.

- User agents SHOULD support the SVG Tiny 1.2 `focusable` attribute, but authors should not use it.  I wouldn't object to downgrading "should" to "may", but I don't think it would be a large implementation burden to add.

- User agents SHOULD scroll/pan focused elements into view, _if_ scrolling or panning is supported for the document.

In addition, I've added a few important clarifications / consequences which aren't new requirements (in some cases, text is directly copied from HTML) but are relevant to SVG authors:

- `:focus` can be used to change focus styles, but SHOULD NOT be used to remove visual focus indicators

- Non-rendered elements can never receive focus, but (based on the newly-clarified definitions of rendered elements) an invisible element is rendered and may receive focus.  This allows invisible elements that are clickable because of the SVG options for `pointer-events` to also be keyboard-operable.

- An element made focusable with `tabindex` should issue a `click` event on keyboard activation.