### PR TITLE
Revisions to sentence on focusable elements

### DIFF
--- a/specs/svg-authoring/index.html
+++ b/specs/svg-authoring/index.html
@@ -329,9 +329,9 @@
 
         <p>In order to meet the needs of these users, if an element is important, navigable, or activatable, it must have an indication in the markup that it can receive focus control.</p>
 
-        <p>The <code>a</code> and <code>text</code> elements are focusable by default.</p>
+        <p>The <code>a</code> element will receive focus when it is a valid link. Generally, this is accomplished through the use of an <code>href</code> attribute.</p>
 
-        <p>All other elements, if they are to be focusable, must be have a <code>tabindex</code> attribute, with a positive value; generally, the value should be <code>0</code>. SVG also includes a <code>focusable</code> attribute and property, but this is not well supported across browsers, and <code>tabindex</code> should be preferred for now.</p>
+        <p>All other elements, if they are to be focusable, must be have a <code>tabindex</code> attribute, with a non-negative value; generally, the value should be <code>0</code>. SVG also includes a <code>focusable</code> attribute and property, but this is not well supported across browsers, and <code>tabindex</code> should be preferred for now.</p>
 
         <p>In addition to being focusable, authors should make sure interactive elements are large enough for selection and activation by small-device users and users with unsteady hands.</p>
 


### PR DESCRIPTION
The a element should require an href attribute to be focusable. 

I could be wrong, but I don't think text elements are focusable by default.

Updating non-negative, rather than positive to refer to tabindex values of 0.
