### PR TITLE
Note on pattern overflow.

### DIFF
--- a/master/pservers.html
+++ b/master/pservers.html
@@ -2592,11 +2592,21 @@ the <a>'overflow'</a> property for <a>'pattern'</a> elements to
 <span class="prop-value">hidden</span>, which causes a rectangular clipping
 path to be created at the bounds of the pattern tile.  Unless the
 <a>'overflow'</a> property is overridden, any graphics within the pattern
-which goes outside of the pattern rectangle will be clipped.  Note that if
-the <a>'overflow'</a> property is set to <span class="prop-value">visible</span>
-the rendering behavior for the pattern is undefined.
+which goes outside of the pattern rectangle will be clipped.
 <a href="pservers.html#ExamplePattern01">Example pattern01</a> below shows the
 effect of clipping to the pattern tile.</p>
+
+<p class="note">
+  Note that if the <a>'overflow'</a> property is set to
+  to <span class="prop-value">visible</span> the rendering behavior
+  for the pattern outside the bounds of the pattern is currently
+  undefined. A future version of SVG may require the overflow to be
+  shown. SVG implementers are encouraged to render the overflow as
+  this is the behavior expected by authors.
+</p>
+<p class="annotation">
+  See <a href="https://github.com/w3c/svgwg/issues/129">GitHub Issue 129</a>
+</p>
 
 <p>The contents of the <a>'pattern'</a> are relative to a new coordinate
 system. If there is a <a>'viewBox'</a> attribute, then the new coordinate


### PR DESCRIPTION
Clarifies what 'overflow:visible" means on patterns.

Adds note encouraging implementers to render overflow on patterns as this is what authors expect and is difficult for authors to simulate manually.

