### PR TITLE
Add text-transform property to the list of required CSS properties

### DIFF
--- a/master/styling.html
+++ b/master/styling.html
@@ -461,7 +461,6 @@ the presentation attribute name is the same as the property name, in lower-case 
       <a>'text-decoration'</a>,
       <a>'text-overflow'</a>,
       <a>'text-rendering'</a>,
-      <a>'text-transform'</a>,
       <a>'unicode-bidi'</a>,
       <a>'vector-effect'</a>,
       <a>'visibility'</a>,

--- a/master/styling.html
+++ b/master/styling.html
@@ -461,6 +461,7 @@ the presentation attribute name is the same as the property name, in lower-case 
       <a>'text-decoration'</a>,
       <a>'text-overflow'</a>,
       <a>'text-rendering'</a>,
+      <a>'text-transform'</a>,
       <a>'unicode-bidi'</a>,
       <a>'vector-effect'</a>,
       <a>'visibility'</a>,
@@ -549,7 +550,7 @@ animating the corresponding property.</p>
     and <a>'word-spacing'</a> properties
     [<a href='refs.html#ref-css-text-3'>css-text-3</a>]</li>
 
-  <li>the <a>'white-space'</a> shorthand property and its component
+  <li>the <a>'text-transform'</a> property, the <a>'white-space'</a> shorthand property and its component
     <a>'text-space-collapse'</a> property
     [<a href='refs.html#ref-css-text-4'>css-text-4</a>]</li>
 


### PR DESCRIPTION
Since all browsers already seem to support this property (I tested Chrome, FF and IE11), I figured we might as well add this to the list of "Required properties" in  Styling section 6.7.

https://svgwg.org/svg2-draft/styling.html#RequiredProperties
