### PR TITLE
Copy Editing: Eradicate the usage of informal `you'; clean up surrounding text

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -288,7 +288,7 @@ have been made.</p>
       <li>Define a ShadowAnimation interface to represent the cloning of Web Animations API animations</li>
       <li>Prohibit WAAPI animations from being directly applied to element instances in the use-element shadow tree.</li>
       <li>Define the propagation of SMIL-style animations through the cloning of animation elements; require that animations elements affecting the referenced graphic be cloned into the shadow tree, even if they are not descendents of the referenced element.</li>
-      <li>Define how event-based animation element triggers and animation element href attributes behave when you have multiple elements with the same id in different node trees.</li>
+      <li>Define how event-based animation element triggers and animation element href attributes behave when there are multiple elements with the same <a>'id'</a> in different node trees.</li>
       <li>Require event handling in use-element shadow trees to follow the event retargetting rules from the Shadow DOM spec.</li>
       <li>Clarify that the copying of event listeners from referenced graphics to their element instances applies to listeners added by script as well as by event attributes.</li>
       <li>Prohibit event listeners from being directly added to elements in the use-element shadow tree.</li>

--- a/master/conform.html
+++ b/master/conform.html
@@ -488,7 +488,7 @@ would likely use static mode.
     and clicking on the face tests declarative interactivity
   and script execution.
     The link should replace the image with a blue
-  square (clicking on that will return you to the original image).
+  square (clicking it will revert it to the original image).
     The declarative interactivity
     uses the <a>'set'</a> element to change the face from shades of yellow to shades of green,
     and uses CSS pseudoclasses to add a stroke to the interactive elements.
@@ -549,10 +549,10 @@ would likely use static mode.
       <tr>
         <th scope="row">Live example</th>
         <td>
-          <object class="embedcontext" type="image/svg+xml" data="images/conform/smiley.svg" aria-label="smiley face, as an object">Your browser does not support embedded SVG images.</object>
+          <object class="embedcontext" type="image/svg+xml" data="images/conform/smiley.svg" aria-label="smiley face, as an object">This browser does not support embedded SVG images.</object>
         </td>
         <td>
-          <iframe sandbox="" class="embedcontext" src="images/conform/smiley.svg" style="border: 0"  aria-label="smiley face, as an iframe">Your browser does not support embedded SVG images.</iframe>
+          <iframe sandbox="" class="embedcontext" src="images/conform/smiley.svg" style="border: 0"  aria-label="smiley face, as an iframe">This browser does not support embedded SVG images.</iframe>
         </td>
         <td>
           <img id="js-embed-img" class="embedcontext" alt="smiley face, as an image" src="images/conform/smiley.svg" />

--- a/master/coords.html
+++ b/master/coords.html
@@ -651,16 +651,13 @@ SVG viewport</a>).</p>
 
 <h2 id="EstablishingANewSVGViewport">Establishing a new SVG viewport</h2>
 
-<p>At any point in an SVG drawing, you can establish a new
-SVG viewport into which all contained graphics is drawn by
-including an <a>'svg'</a> element
-inside SVG content. By establishing a new SVG viewport, you also
-implicitly establish a new viewport coordinate system, a new
-user coordinate system.
-Additionally, there is a new meaning for percentage units
-defined to be relative to the current SVG viewport since a new
-SVG viewport has been established (see <a
-href="coords.html#Units">Units</a>).</p>
+<p>Including an <a>'svg'</a> element inside SVG content
+creates a new SVG viewport into which all contained
+graphics are drawn; this implicitly establishes both
+a new viewport coordinate system and a new user coordinate system.
+Additionally, there is a new meaning for percentage units therein,
+because a new SVG viewport has been established
+(see <a href="coords.html#Units">Units</a>).</p>
 
 <p>The bounds of the new SVG viewport are defined by the <span
 class="attr-name">'x'</span>, <span class="attr-name">'y'</span>,

--- a/master/embedded.html
+++ b/master/embedded.html
@@ -457,17 +457,19 @@ or for a <a>'canvas'</a> element if scripting is disabled.
 
 <edit:example href='images/embedded/sourceinsvg.svg' name='sourceinsvg' link='no' image='no'/>
 
-<p class="note">
-  Currently, the HTML parser does not recognize these tagnames within an SVG subtree 
-  to be HTML-namespaced elements, although this may change in the future. 
-  Therefore, in order to include these elements within your SVG, 
-  you must either use an XML serialization that recognizes namespace declarations 
-  (such as stand-alone SVG or XHTML),
-  or you must create namespaced elements via the <code>createElementNS</code> DOM API method. 
-  Alternatively, you can use the foreignObject element 
-  to wrap the HTML-namespaced elements; 
-  the HTML parser correctly parses HTML elements within a foreignObject.
-</p>
+<div class="note">
+  <p>
+    Currently, within an SVG subtree, these tagnames are not recognized by the HTML parser
+    to be HTML-namespaced elements, although this may change in the future.
+    Therefore, in order to include these elements within SVG, one of the following
+    must be used:
+  </p>
+  <ul>
+    <li>An XML serialization that recognizes namespace declarations (such as stand-alone SVG or XHTML).</li>
+    <li>Namespaced elements as created via the <code>createElementNS</code> DOM API method.</li>
+    <li>A <a>'foreignObject'</a> element to wrap the HTML-namespaced elements, which will then be correctly parsed.</li>
+  </ul>
+</div>
 
 <p>
 Other HTML elements in an SVG subtree, 

--- a/master/images/embedded/videofallback.svg
+++ b/master/images/embedded/videofallback.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <html:video src="http://example.org/dummyvideo" controls="controls">
-    <html:p>Video format not supported by your browser</html:p>
+    <html:p>The video format is not supported by this browser.</html:p>
   </html:video>
 </svg>

--- a/master/images/embedded/videofallbacksizing.svg
+++ b/master/images/embedded/videofallbacksizing.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml" viewBox="0 0 640 480">
   <html:video src="http://example.org/dummyvideo" controls="controls">
-    <html:p style="width: 50%">Video format not supported by your browser</html:p>
+    <html:p style="width: 50%">The video format is not supported by this browser.</html:p>
   </html:video>
 </svg>

--- a/master/images/embedded/videotransform.svg
+++ b/master/images/embedded/videotransform.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <html:video style="transform:translate(10px,10px)" src="http://example.org/dummyvideo" controls="controls">
-    <html:p>Video format not supported by your browser</html:p>
+    <html:p>The video format is not supported by this browser.</html:p>
   </html:video>
 </svg>

--- a/master/linking.html
+++ b/master/linking.html
@@ -183,8 +183,10 @@ by referencing the source gradient with a URL in the <a>'href'</a> attribute:
 
 <p>
 To fill a rectangle with that gradient,
-you use a URL reference to the linear gradient element as the value of the
-<a>'fill'</a> property for the rectangle, as in the following example:</p>
+the value of the rectangle's <a>'fill'</a> property may be set so as to
+include a URL reference to the relevant <a>'linearGradient'</a> element;
+here is an example:
+</p>
 
 <edit:example href="images/linking/05_08.xml" image="no" link="no"/>
 

--- a/master/paths.html
+++ b/master/paths.html
@@ -153,16 +153,23 @@ attempts to minimize the size of path data are as follows:</p>
   <li>All instructions are expressed as one character (e.g., a
   <em>moveto</em> is expressed as an <strong>M</strong>).</li>
 
-  <li>Superfluous white space and separators such as commas can
-  be eliminated (e.g., "M 100 100 L 200 200" contains
-  unnecessary spaces and could be expressed more compactly as
-  "M100 100L200 200").</li>
+  <li>
+    <div>Superfluous white space and separators (such as commas) may
+    be eliminated; for instance, the following contains unnecessary
+    spaces:</div>
+    <div style="margin-left: 2em"><code>M 100 100 L 200 200</code></div>
+    <div>It may be expressed more compactly as:</div>
+    <div style="margin-left: 2em"><code>M100 100L200 200</code></div>
+  </li>
 
-  <li>The command letter can be eliminated on subsequent
-  commands if the same command is used multiple times in a row
-  (e.g., you can drop the second "L" in "M 100 200 L 200 100 L
-  -100 -200" and use "M 100 200 L 200 100 -100 -200"
-  instead).</li>
+  <li>
+    <div>A command letter may be eliminated if an identical command
+    letter would otherwise precede it; for instance, the following
+    contains an unnecessary second "L" command:</div>
+    <div style="margin-left: 2em"><code>M 100 200 L 200 100 L -100 -200</code></div>
+    <div>It may be expressed more compactly as:</div>
+    <div style="margin-left: 2em"><code>M 100 200 L 200 100 -100 -200</code></div>
+  </li>
 
   <li>For most commands there are absolute and relative
   versions available (uppercase means absolute coordinates,

--- a/master/render.html
+++ b/master/render.html
@@ -787,11 +787,8 @@ marker symbols. The marker symbols are rendered in order along
 the outline of the shape, from the start of the shape to the
 end of the shape.</p>
 
-<p>The fill and stroke operations are entirely independent
-painting operations. Each fill and stroke operation has its own opacity settings;
-thus, you can fill and/or stroke a shape with a
-semi-transparently drawn solid color, with different opacity
-values for the fill and stroke operations.</p>
+<p>The fill and stroke operations are entirely independent;
+for instance, each fill or stroke operation has its own opacity setting.</p>
 
 <p>SVG supports numerous built-in types of paint which can
 be used in fill and stroke operations. These are described in

--- a/master/shapes.html
+++ b/master/shapes.html
@@ -268,15 +268,16 @@ with the current <a>local coordinate system</a> based on a center point and two 
 
 <p>
   An <code>auto</code> value for <em>either</em> <a>'rx'</a> or <a>'ry'</a>
-  is converted to a used value following the rules given above for rectangles,
-  except without any clamping based on <a>'width'</a> and <a>'height'</a>.
+  is converted to a used value, following the rules given above for rectangles
+  (but without any clamping based on <a>'width'</a> or <a>'height'</a>).
   Effectively, an <code>auto</code> value creates a circular shape
-  whose radius is defined by a value expressed solely in one dimension,
-  allowing you to create circles with radii defined as a percentage of the coordinate system width
-  (a percantage value for <a>'rx'</a> and an auto value for <a>'ry'</a>)
-  or height
-  (an auto value for <a>'rx'</a> and a percantage value for <a>'ry'</a>).
+  whose radius is defined by a value expressed solely in one dimension;
+  this allows for creating a circle with a radius defined in terms of one of the following:
 </p>
+<ul>
+  <li>a percentage of the coordinate system <b>width</b>; that is, a percentage value for <a><b>'rx'</b></a> and an <code>auto</code> value for <a>'ry'</a>.</li>
+  <li>a percentage of the coordinate system <b>height</b>; that is, an <code>auto</code> value for <a>'rx'</a> and a percentage value for <a><b>'ry'</b></a>.</li>
+</ul>
   
 <p class="note">
   New in SVG 2. 

--- a/master/struct.html
+++ b/master/struct.html
@@ -372,20 +372,16 @@ the <span class="element-name">'div'</span> element and its contents must not re
 
 <h3 id="Overview">Overview</h3>
 
-<p>SVG allows graphical objects to be defined for later reuse.
-To do this, it makes extensive use of <a>URL references</a>
-[<a href="refs.html#ref-rfc3987">rfc3987</a>] to these other objects.
-For example, to fill a rectangle with a linear gradient, you first
-define a <a>'linearGradient'</a> element and give it an ID, as in:</p>
+<p>SVG allows a graphical object to be defined for later reuse.
+To do this, SVG makes extensive use of the <a>URL reference</a>
+construct [<a href="refs.html#ref-rfc3987">rfc3987</a>].
+For example, to fill a rectangle with a linear gradient, a
+<a>'linearGradient'</a> element may be defined with an
+<a>'id'</a> property that may be referenced in the value for
+the rectangle's <a>'fill'</a> property, as in the following:</p>
 
 <pre class='xml'><![CDATA[
 <linearGradient id="MyGradient">...</linearGradient>
-]]></pre>
-
-<p>You then reference the linear gradient as the value of the
-<a>'fill'</a> property for the rectangle, as in:</p>
-
-<pre class='xml'><![CDATA[
 <rect style="fill:url(#MyGradient)"/>
 ]]></pre>
 
@@ -2017,11 +2013,10 @@ the following purposes:</p>
   information).</li>
 
   <li>Supplemental data for extensibility. For example, suppose
-  you have an extrusion extension which takes any 2D graphics
-  and extrudes it in three dimensions. When applying the
-  extrusion extension, you probably will need to set some
-  parameters. The parameters can be included in the SVG content
-  by inserting elements from an extrusion extension
+  there is an extension which extrudes 2D graphics
+  into three dimensions according to certain parameters;
+  these parameters may be included in the SVG content
+  by inserting elements from the extension's
   namespace.</li>
 </ul>
 

--- a/master/text.html
+++ b/master/text.html
@@ -1467,10 +1467,8 @@
       the corresponding elements within the <a>'x'</a>, <a>'y'</a>,
       <a>'dx'</a>, <a>'dy'</a>, and <a>'rotate'</a> are also
       re-ordered to maintain the correspondence. For example,
-      suppose that you have the following <a>'tspan'</a> element:
-      <pre>
-&lt;tspan dx="11 12 13 14 15 0 21 22 23 0 31 32 33 34 35 36"&gt;Latin and Hebrew&lt;/tspan&gt;
-      </pre>
+      suppose that there is the following <a>'tspan'</a> element:
+      <div style="margin-left: 2em"><code>&lt;tspan dx="11 12 13 14 15 0 21 22 23 0 31 32 33 34 35 36"&gt;Latin and Hebrew&lt;/tspan&gt;</code></div>
       and that the word "Hebrew" will be drawn right-to-left. First,
       the character data and the corresponding values in
       the <a>'dx'</a> list will be reordered, such that the text
@@ -6402,8 +6400,8 @@ is called, the following steps are run:</p>
           contributed space just after the <a>typographic character</a>, then add that space
           to <var>length</var>.</li>
         </ol>
-        <p class="note">This means that, for example, if you have a ligature
-        that is only partly included in the substring, the
+        <p class="note">This means that, for example, if there is a ligature
+        that is only partly included in the substring, then the
         advance of the <a>typographic character</a> and any subsequent <a>'letter-spacing'</a> or
         <a>'word-spacing'</a> space will be assigned to the first
         character's text length.</p>

--- a/master/xhtml1-transitional+edit.dtd
+++ b/master/xhtml1-transitional+edit.dtd
@@ -1024,8 +1024,8 @@
 
 <!--
    To avoid accessibility problems for people who aren't
-   able to see the image, you should provide a text
-   description using the alt and longdesc attributes.
+   able to see the image, there should be provided a text
+   description using the 'alt' and 'longdesc' attributes.
    In addition, avoid the use of server-side image maps.
 -->
 
@@ -1293,8 +1293,8 @@
   >
 
 <!--
-colgroup groups a set of col elements. It allows you to group
-several semantically related columns together.
+colgroup groups a set of col elements. It allows for grouping
+together several semantically related columns.
 -->
 <!ATTLIST colgroup
   %attrs;


### PR DESCRIPTION
(Ultimately, this commit should not change the meaning of the text.)

Because this is a standard, it is probably best not to employ the rather
informal second person, `you'. This commit removes that usage without
descending into overtly bureaucratic language.

Furthermore, as a matter of practicality or even necessity, some of
the nearby text has also been improved (according to this author);
this includes rewording, re-styling, the removal of typos, and the
fixing of grammar.