### PR TITLE
Correct SVGUseElementShadowRoot interface definition. Closes #290.

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -304,6 +304,11 @@ have been made.</p>
   <li>Update requirements for <a>'id'</a> values to harmonize with HTML, with extra warning about requirements for validity in an XML document.</li>
   <li>Moved the <a href="struct.html#ForeignNamespaces">Foreign namespaces and private data</a> section to this chapter and added some new cross-references and notes.</li>
 </ul>
+<div class='changed-since-cr1'>
+<ul>
+  <li>Corrected incorrect interface name for definition of <a>SVGUseElementShadowRoot</a>. <a href="https://github.com/w3c/svgwg/issues/290">Github #290</a>.</li>
+</ul>
+</div>
 
 <h3 id="styling">Styling chapter</h3>
 

--- a/master/pservers.html
+++ b/master/pservers.html
@@ -3673,7 +3673,6 @@ IDL attributes <a>reflect</a> the <a>'x'</a>, <a>'y'</a>,
 
 </edit:with>
 
-
 <h3 id="InterfaceSVGHatchElement">Interface SVGHatchElement</h3>
 
 <edit:with element="hatch">

--- a/master/struct.html
+++ b/master/struct.html
@@ -3323,10 +3323,12 @@ then getting these attributes returns null.</p>
   However, the tree rooted at this node 
   is entirely read-only from the perspective of author scripts.</p>
 
+<div class='changed-since-cr1'>
 <pre class="idl">
-interface <b>SVGElementInstance</b> : <a>ShadowRoot</a> {
+interface <b>SVGUseElementShadowRoot</b> : <a>ShadowRoot</a> {
 
 };</pre>
+</div>
 
 <h3 id="InterfaceSVGElementInstance">Interface SVGElementInstance</h3>
 


### PR DESCRIPTION
Just a little change to the spec to demonstrate how we will do PRs on the SVG 2 CR draft.