### PR TITLE
Clarify that SVGElement.className overrides Element.className

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -171,6 +171,8 @@ have been made.</p>
 <div class='changed-since-cr1'>
 <ul>
   <li><a>SVGUnitTypes</a> is no longer NoInterfaceObject. <a href="https://github.com/w3c/svgwg/issues/291">Github #291</a>.</li>
+  <li>Clarified that <a>SVGElement</a>.<a href="types.html#__svg__SVGElement__className">className</a>
+      overrides <a>Element</a>.className. Not normative, <a href="https://github.com/w3c/svgwg/issues/298">Github #298</a>.</li>
 </ul>
 </div>
 

--- a/master/types.html
+++ b/master/types.html
@@ -240,9 +240,15 @@ attribute can be accessed in the same way as on HTML elements.</p>
 <p>The <b id="__svg__SVGElement__className">className</b> IDL attribute
 <a>reflects</a> the <a>'class'</a> attribute.</p>
 
-<p class="note">This attribute is deprecated and may be removed in a
+<div class="note"><p>This attribute is deprecated and may be removed in a
 future version of this specification.  Authors are advised to use
 Element.classList intead.</p>
+<p class='changed-since-cr1'>
+The <a href="types.html#__svg__SVGElement__className">className</a>
+attribute on <a>SVGElement</a> overrides the correspond attribute on
+<a>Element</a>, following the WebIDL rules for
+<a href="https://www.w3.org/TR/WebIDL/#dfn-inherit">inheritance</a>.</p>
+</div>
 
 <div class='ready-for-wider-review'>
 <p>The <b id="__svg__SVGElement__dataset">dataset</b> IDL attribute


### PR DESCRIPTION
According to the definition of inheritance in WebIDL. Closes #298.