### PR TITLE
Remove explicit currentColor from <paint>

### DIFF
--- a/master/painting.html
+++ b/master/painting.html
@@ -144,7 +144,7 @@ and <a href="pservers.html#Hatches">hatches</a>.</p>
 | child
 | child(<a>&lt;integer&gt;</a>)
 | <a>&lt;color&gt;</a>
-| <a>&lt;url&gt;</a> [none | currentColor | <a>&lt;color&gt;</a>]?
+| <a>&lt;url&gt;</a> [none | <a>&lt;color&gt;</a>]?
 | context-fill | context-stroke
 </p>
 


### PR DESCRIPTION
According to CSS 3 Color, `currentColor` is a part of `<color>`, so we don't need to explicitly specify it


r? @nikosandronikos