### PR TITLE
Clarify patternTransform/linearTransform presentation attriute behavi…

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -350,6 +350,8 @@ have been made.</p>
     remove <a>'d'</a> as a presentation attribute for <a>'textPath'</a>;
     merge the discussion of gradientTransform and patternTransform into the main table.
   </li>
+  <li>Specify that <a>'transform'</a>, <a>'pattern/patternTransform'</a> and <a>'linearGradient/gradientTransform'</a>
+    are presentation attributes for <a>'transform'</a> that can be specified to certain sets of elements in the SVG namespace.</li>  
 </ul>
 
 <h3 id="conform">Conformance chapter (owner: BogdanBrinza)</h3>

--- a/master/styling.html
+++ b/master/styling.html
@@ -399,10 +399,28 @@ the presentation attribute name is the same as the property name, in lower-case 
       <a>'transform'</a>
     </td>
     <td>
-      Any element in the SVG namespace;
-      however, for historical reasons
-      the <a>'linearGradient'</a> and <a>'radialGradient'</a> elements use the attribute name <a>'linearGradient/gradientTransform'</a>, 
-      and the <a>'pattern'</a> element uses <a>'pattern/patternTransform'</a>.
+      Any element in the SVG namespace with the exception of the <a>'pattern'</a>,
+      <a>'linearGradient'</a> and <a>'radialGradient'</a> elements. 
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a>'pattern/patternTransform'</a>
+    </td>
+    <td>
+      <a>'pattern'</a>. <a>'pattern/patternTransform'</a> gets mapped to the
+      <a>'transform'</a> CSS property
+      [<a href='refs.html#ref-css-transforms-1'>css-transforms-1</a>].
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a>'linearGradient/gradientTransform'</a>
+    </td>
+    <td>
+      <a>'linearGradient'</a> and <a>'radialGradient'</a> elements.
+      <a>'linearGradient/gradientTransform'</a> gets mapped to the <a>'transform'</a>
+      CSS property [<a href='refs.html#ref-css-transforms-1'>css-transforms-1</a>].
     </td>
   </tr>
   <tr>

--- a/master/styling.html
+++ b/master/styling.html
@@ -399,28 +399,25 @@ the presentation attribute name is the same as the property name, in lower-case 
       <a>'transform'</a>
     </td>
     <td>
-      Any element in the SVG namespace with the exception of the <a>'pattern'</a>,
-      <a>'linearGradient'</a> and <a>'radialGradient'</a> elements. 
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a>'pattern/patternTransform'</a>
-    </td>
-    <td>
-      <a>'pattern'</a>. <a>'pattern/patternTransform'</a> gets mapped to the
-      <a>'transform'</a> CSS property
-      [<a href='refs.html#ref-css-transforms-1'>css-transforms-1</a>].
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <a>'linearGradient/gradientTransform'</a>
-    </td>
-    <td>
-      <a>'linearGradient'</a> and <a>'radialGradient'</a> elements.
-      <a>'linearGradient/gradientTransform'</a> gets mapped to the <a>'transform'</a>
-      CSS property [<a href='refs.html#ref-css-transforms-1'>css-transforms-1</a>].
+      For historical reasons, the <a>'transform'</a> property gets represented by different presentation attributes depending on the SVG element it applies to:
+      <dl>
+        <dt><a>'transform'</a></dt>
+        <dd>
+          Any element in the SVG namespace with the exception of the <a>'pattern'</a>,
+          <a>'linearGradient'</a> and <a>'radialGradient'</a> elements. 
+        </dd>
+        <dt><a>'pattern/patternTransform'</a></dt>
+        <dd>
+            <a>'pattern'</a>. <a>'pattern/patternTransform'</a> gets mapped to the
+            <a>'transform'</a> CSS property
+            [<a href='refs.html#ref-css-transforms-1'>css-transforms-1</a>].
+        </dd>
+        <dt><a>'linearGradient/gradientTransform'</a></dt>
+        <dd>
+            <a>'linearGradient'</a> and <a>'radialGradient'</a> elements.
+            <a>'linearGradient/gradientTransform'</a> gets mapped to the <a>'transform'</a>
+            CSS property [<a href='refs.html#ref-css-transforms-1'>css-transforms-1</a>].
+        </dd>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
…or, mapping and content model. Issue w3c/csswg-drafts#919

The idea is that `transform` on `<pattern>` can only be set by CSS (style attribute, inline styles, external styles) or the `patternTransform` presentation attribute (which maps to the CSS `transform` property).

Ditto for `linearGradient` and `<radialGradient>`/`<linearGradient>`.