### PR TITLE
Paths: Remove bearing commands

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -412,9 +412,6 @@ have been made.</p>
 <h3 id="paths">Paths chapter</h3>
 
 <ul>
-  <li>Added new <strong>B</strong> and
-  <strong>b</strong> "bearing" path commands.</li>
-
   <li>Allow <strong>Z</strong> or <strong>z</strong> to fill in
     missing path coordinate data in the previous command with the
     coordinate of the initial point in the subpath.</li>

--- a/master/paths.html
+++ b/master/paths.html
@@ -1210,44 +1210,8 @@ commands contribute to path length calculations.</p>
 <p>An <a>SVGPathElement</a> object represents a <a>'path'</a> in the DOM.</p>
 
 <pre class="idl">interface <b>SVGPathElement</b> : <a>SVGGeometryElement</a> {
-<!--
-  [SameObject] readonly attribute <a>SVGAnimatedNumber</a> <a href="paths.html#__svg__SVGPathElement__pathLength">pathLength</a>;
-
-  float <a href="paths.html#__svg__SVGPathElement__getTotalLength">getTotalLength</a>();
-  <a>DOMPoint</a> <a href="paths.html#__svg__SVGPathElement__getPointAtLength">getPointAtLength</a>(float distance);
--->
 };</pre>
 
-<!--
-<p>The <b id="__svg__SVGPathElement__pathLength">pathLength</b> IDL attribute
-<a>reflects</a> the <a>'pathLength'</a> content attribute.</p>
-
-<p>The <b id="__svg__SVGPathElement__getTotalLength">getTotalLength</b> method
-is used to compute the length of the path.  When getTotalLength()
-is called, the user agent's computed value for the total length of the path,
-in user units, is returned.</p>
-
-<p class="note">The user agent's computed path length does not take the
-<a>'pathLength'</a> attribute into account.</p>
-
-<p>The <b id="__svg__SVGPathElement__getPointAtLength">getPointAtLength</b> method
-is used to return the point at a given distance along the path.  When
-getPointAtLength(<var>distance</var>) is called, the following steps are run:</p>
-
-<ol class='algorithm'>
-  <li>Let <var>length</var> be the user agent's computed value for the total
-  length of the path, in user units.
-    <p class="note">As with <a href="#__svg__SVGPathElement__getTotalLength">getTotalLength</a>,
-    this does not take into account the <a>'pathLength'</a> attribute.</p>
-  </li>
-  <li>Clamp <var>distance</var> to [0, <var>length</var>].</li>
-  <li>Let (<var>x</var>, <var>y</var>) be the point on the path at distance
-  <var>distance</var>.</li>
-  <li>Return a newly created, <a href="shapes.html#PointMode">detached</a>
-  <a>DOMPoint</a> object representing the point
-  (<var>x</var>, <var>y</var>).</li>
-</ol>
--->
 </edit:with>
 </div>
 

--- a/master/paths.html
+++ b/master/paths.html
@@ -74,29 +74,6 @@ property.  See <a href="#PathData">Path data</a> below.</p>
 
 <h2 id="PathData">Path data</h2>
 
-<!--
-<div class="annotation svg2-requirement">
-  <table>
-    <tr>
-      <th>SVG 2 Requirement:</th>
-      <td>Include smooth path between points functionality.</td>
-    </tr>
-    <tr>
-      <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/07/27-svg-minutes.html#item11">We will add a Catmull Rom syntax to the path syntax with a tension parameter to control the whole curve (not per-point control).</a></td>
-    </tr>
-    <tr>
-      <th>Purpose:</th>
-      <td>Provide an easy way to graph data, etc.</td>
-    </tr>
-    <tr>
-      <th>Owner:</th>
-      <td>Doug (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3085">ACTION-3085</a>)</td>
-    </tr>
-  </table>
-</div>
--->
-
 <div class="annotation svg2-requirement">
   <table>
     <tr>

--- a/master/paths.html
+++ b/master/paths.html
@@ -41,8 +41,7 @@ curves.</p>
 
 <p>Paths represent the geometry of the outline of an object,
 defined in terms of <em>moveto</em> (set a new current point),
-<em>bearing</em> (set a new orientation), <em>lineto</em>
-(draw a straight line), <em>curveto</em> (draw
+<em>lineto</em> (draw a straight line), <em>curveto</em> (draw
 a curve using a cubic Bézier), <em>arc</em> (elliptical
 or circular arc) and <em>closepath</em> (close the current
 shape by connecting to the last <em>moveto</em>) commands.
@@ -104,7 +103,7 @@ property.  See <a href="#PathData">Path data</a> below.</p>
 <p>A path is defined by including a <a>'path'</a>
 element on which the <a>'d'</a> property specifies the
 path data.  The path data contains the
-<em>moveto</em>, <em>bearing</em>, <em>lineto</em>, <em>curveto</em> (both cubic and
+<em>moveto</em>, <em>lineto</em>, <em>curveto</em> (both cubic and
 quadratic Béziers), <em>arc</em> and <em>closepath</em>
 instructions.</p>
 
@@ -176,17 +175,6 @@ Instead, say: "13000.56".)</p>
 values are relative to the current point at the start of the
 command.</p>
 
-<div class="ready-for-wider-review">
-
-<p>Relative path commands are also influenced by the
-current bearing, which is an angle set by the <em>bearing</em>
-commands.  This allows for paths to be specified using a
-style of "turtle graphics", where straight line and curved
-<a>path segments</a> are placed with their starting point at a
-tangent (or at some other angle) to the current bearing.</p>
-
-</div>
-
 <p>In the tables below, the following notation is used to
 describe the syntax of a given path command:</p>
 
@@ -198,8 +186,7 @@ describe the syntax of a given path command:</p>
 <div class="ready-for-wider-review">
 
 <p>In the description of the path commands, <var>cpx</var> and
-<var>cpy</var> represent the coordinates of the current point,
-and <var>cb</var> represents the current bearing.</p>
+<var>cpy</var> represent the coordinates of the current point.</p>
 
 </div>
 
@@ -370,9 +357,8 @@ is not the first command) represent the start of a new
 <div class="ready-for-wider-review">
 
 <p>When a relative <strong>m</strong> command is used, the
-position moved to is (<var>cpx</var> + <var>x</var> cos <var>cb</var>
-+ <var>y</var> sin <var>cb</var>, <var>cpy</var> +
-<var>x</var> sin <var>cb</var> + <var>y</var> cos <var>cb</var>).</p>
+position moved to is (<var>cpx</var> + <var>x</var>,
+<var>cpy</var> + <var>y</var>).</p>
 
 </div>
 
@@ -459,8 +445,6 @@ rather than joined using the current value of <a>'stroke-linejoin'</a>.</p>
 next subpath. If a "closepath" is followed immediately by any
 other command, then the next subpath must start at the same <a>initial point</a>
 as the current subpath.</p>
-
-<p class='ready-for-wider-review'>The current bearing does not affect a <strong>z</strong> command.</p>
 
 <p>Examples:</p>
 <ul>
@@ -558,27 +542,18 @@ current point to a new point:</p>
 <div class="ready-for-wider-review">
 
 <p>When a relative <strong>l</strong> command is used, the
-end point of the line is (<var>cpx</var> + <var>x</var> cos <var>cb</var>
-+ <var>y</var> sin <var>cb</var>, <var>cpy</var> +
-<var>x</var> sin <var>cb</var> + <var>y</var> cos <var>cb</var>).</p>
+end point of the line is (<var>cpx</var> + <var>x</var>,
+<var>cpy</var> + <var>y</var>).</p>
 
 <p>When a relative <strong>h</strong> command is used,
-the end point of the line is (<var>cpx</var> + <var>x</var> cos <var>cb</var>,
-<var>cpy</var> + <var>x</var> sin <var>cb</var>).  This means
+the end point of the line is (<var>cpx</var> + <var>x</var>,
+<var>cpy</var>).  This means
 that an <strong>h</strong> command with a positive <var>x</var>
-value draws a line in the direction of the current bearing.  When
-the current bearing is 0, this is a horizontal line in the direction
-of the positive x-axis.</p>
-
-<div class="note">
-  <p>When there is a non-zero bearing, a mnemonic for the <strong>h</strong>
-  command could be "<u>h</u>ead this distance at the current bearing",
-  rather than "draw a <u>h</u>orizontal line".</p>
-</div>
+value draws a horizontal line in the direction of the positive x-axis.</p>
 
 <p>When a relative <strong>v</strong> command is used,
-the end point of the line is (<var>cpx</var> + <var>y</var> sin <var>cb</var>,
-<var>cpy</var> + <var>y</var> cos <var>cb</var>).</p>
+the end point of the line is (<var>cpx</var>,
+<var>cpy</var> + <var>y</var>).</p>
 
 </div>
 
@@ -638,9 +613,8 @@ the end point of the line is (<var>cpx</var> + <var>y</var> sin <var>cb</var>,
 command is used, each of the relative coordinate pairs
 is computed as for those in an <strong>m</strong> command.
 For example, the final control point of the curve of
-both commands is (<var>cpx</var> + <var>x</var> cos <var>cb</var>
-+ <var>y</var> sin <var>cb</var>, <var>cpy</var> +
-<var>x</var> sin <var>cb</var> + <var>y</var> cos <var>cb</var>).</p>
+both commands is (<var>cpx</var> + <var>x</var>,
+<var>cpy</var> + <var>y</var>).</p>
 
 </div>
 
@@ -718,9 +692,8 @@ this example as SVG (SVG-enabled browsers only)</a><br />
 command is used, each of the relative coordinate pairs
 is computed as for those in an <strong>m</strong> command.
 For example, the final control point of the curve of
-both commands is (<var>cpx</var> + <var>x</var> cos <var>cb</var>
-+ <var>y</var> sin <var>cb</var>, <var>cpy</var> +
-<var>x</var> sin <var>cb</var> + <var>y</var> cos <var>cb</var>).</p>
+both commands is (<var>cpx</var> + <var>x</var>,
+<var>cpy</var> + <var>y</var>).</p>
 
 </div>
 
@@ -789,12 +762,8 @@ command.</p>
 <div class="ready-for-wider-review">
 
 <p>When a relative <strong>a</strong> command is used, the end point
-of the arc is (<var>cpx</var> + <var>x</var> cos <var>cb</var>
-+ <var>y</var> sin <var>cb</var>, <var>cpy</var> +
-<var>x</var> sin <var>cb</var> + <var>y</var> cos <var>cb</var>).
-The effective value of the x-axis-rotation parameter is
-also affected by the current bearing: it is computed as
-<var>x-axis-rotation</var> + <var>cb</var>.</p>
+of the arc is (<var>cpx</var> + <var>x</var>,
+<var>cpy</var> + <var>y</var>).</p>
 
 </div>
 
@@ -869,79 +838,6 @@ href="implnote.html#ArcImplementationNotes">Elliptical arc
 implementation notes</a> for detailed implementation notes for
 the path data elliptical arc commands.</p>
 
-<div class="ready-for-wider-review">
-
-<h3 id="PathDataBearingCommands">The bearing commands</h3>
-
-<p class="issue" data-issue="15">The bearing commands are at risk, with no known implementations.</p>
-
-<p>The bearing commands (<strong>B</strong> or <strong>b</strong>)
-set the current bearing, which influences the orientation of
-subsequent relative path commands:</p>
-
-<table class="PathDataTable">
-  <tr>
-    <th>Command</th>
-    <th>Name</th>
-    <th>Parameters</th>
-    <th>Description</th>
-  </tr>
-  <tr>
-    <td><strong>B</strong> (absolute)<br/>
-      <strong>b</strong> (relative)</td>
-    <td>bearing</td>
-    <td>angle+</td>
-    <td>Sets the current bearing.  The parameter is an angle
-    in degrees, where 0 indicates the direction of the positive
-    x-axis.  <strong>B</strong> (uppercase) sets
-    the current bearing to the specified angle; <strong>b</strong>
-    (lowercase) sets the current bearing to be the angle of the
-    tangent at the end of the preceding path command plus the
-    specified angle.  The current point is unaffected.
-    Although multiple parameters may be specified, this usually
-    will not be useful, as they could be combined into a single
-    angle value.</td>
-  </tr>
-</table>
-
-<p>At the beginning of a path, the current bearing is 0, which
-points in the direction of the positive x-axis.  The current
-bearing remains unchanged until a <strong>B</strong> or
-<strong>b</strong> command is encountered.  Since the relative
-<strong>b</strong> command sets the current bearing relative
-to the tangent at the end of the preceding path command,
-it is possible to set the bearing to that tangent by using
-"b 0".</p>
-
-<div class="example">
-  <p>The example below shows how bearing commands can be used
-  to draw a regular pentagon.</p>
-
-  <pre class="xml"><![CDATA[<svg xmlns="http://www.w3.org/2000/svg"
-     width="300" height="100" viewBox="0 0 300 100">
-
-  <path fill="#eee"
-        stroke="deeppink" stroke-width="8px" stroke-linejoin="round"
-        d="M 150,10
-           B 36 h 47
-           b 72 h 47
-           b 72 h 47
-           b 72 h 47 z"/>
-
-</svg>]]></pre>
-
-  <div class="figure">
-    <img class="bordered" src="images/paths/bearing01.svg"
-         alt="Image showing the use of the bearing command."/>
-    <p class="caption">Bearing commands can be used to position
-    the end points of the sides of a regular polygon without
-    having to use trigonometry to calculate them based on the
-    polygon's interior angles.</p>
-  </div>
-</div>
-
-</div>
-
 
 <h3 id="PathDataBNF">The grammar for path data</h3>
 
@@ -960,7 +856,6 @@ drawto_command::=
     | quadratic_bezier_curveto
     | smooth_quadratic_bezier_curveto
     | elliptical_arc
-    | bearing
 
 moveto::=
     ( "M" | "m" ) wsp* coordinate_pair_sequence wsp* closepath?
@@ -1019,12 +914,6 @@ elliptical_arc_argument::=
 elliptical_arc_closing_argument::=
     number comma_wsp? number comma_wsp? number comma_wsp
     flag comma_wsp? flag comma_wsp? closepath
-
-bearing::=
-    ( "B" | "b" ) wsp* bearing_argument_sequence
-
-bearing_argument_sequence::=
-    number | (number comma_wsp? bearing_argument_sequence)
 
 coordinate_pair_double::=
     coordinate_pair comma_wsp? coordinate_pair
@@ -1265,7 +1154,7 @@ path so that the user agent can scale distance-along-a-path
 computations by the ratio of <a>'pathLength'</a> to the user agent's own
 computed value for total path length.</p>
 
-<p>A "moveto" or "bearing" operation within a <a>'path'</a> element is defined to have
+<p>A "moveto" operation within a <a>'path'</a> element is defined to have
 zero length. Only the various "lineto", "curveto" and "arcto"
 commands contribute to path length calculations.</p>
 


### PR DESCRIPTION
Paths: Remove bearing commands
    
Bearing commands 'B' and 'b' remain in the SVG Paths spec
https://www.w3.org/TR/svg-paths/#PathDataBearingCommands
but are being removed from svg2-draft.
    
Resolution:
https://github.com/w3c/svgwg/issues/385#issuecomment-363207475
