### PR TITLE
Fixes #345 Add [Exposed] to SVG interfaces

### DIFF
--- a/master/coords.html
+++ b/master/coords.html
@@ -3224,7 +3224,8 @@ IDL attribute.  An <a>SVGTransform</a> object's
 <a href="#TransformMatrixObject">matrix object</a>
 is always kept synchronized with its <a href="#TransformValue">value</a>.</p>
 
-<pre class="idl">interface <b>SVGTransform</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGTransform</b> {
 
   // Transform Types
   const unsigned short <a href="coords.html#__svg__SVGTransform__SVG_TRANSFORM_UNKNOWN">SVG_TRANSFORM_UNKNOWN</a> = 0;
@@ -3443,7 +3444,8 @@ represents a value that the <a>'transform'</a> property can take, namely
 either a <a href="https://drafts.csswg.org/css-transforms-1/#typedef-transform-list">&lt;transform-list&gt;</a>
 or the keyword <span class='prop-value'>none</span>.</p>
 
-<pre class="idl">interface <b>SVGTransformList</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGTransformList</b> {
 
   readonly attribute unsigned long <a href="types.html#__svg__SVGNameList__length">length</a>;
   readonly attribute unsigned long <a href="types.html#__svg__SVGNameList__numberOfItems">numberOfItems</a>;
@@ -3523,7 +3525,8 @@ defined in <a href="types.html#ListInterfaces">List interfaces</a>.</p>
 <a>'linearGradient/gradientTransform'</a> or
 <a>'pattern/patternTransform'</a>).</p>
 
-<pre class="idl">interface <b>SVGAnimatedTransformList</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGAnimatedTransformList</b> {
   [SameObject] readonly attribute <a>SVGTransformList</a> <a href="coords.html#__svg__SVGAnimatedTransformList__baseVal">baseVal</a>;
   [SameObject] readonly attribute <a>SVGTransformList</a> <a href="coords.html#__svg__SVGAnimatedTransformList__animVal">animVal</a>;
 };</pre>
@@ -3552,7 +3555,8 @@ attribute (being exposed through the methods on the
 <a href="#__svg__SVGAnimatedPreserveAspectRatio__animVal">animVal</a> member of
 an <a>SVGAnimatedPreserveAspectRatio</a>).</p>
 
-<pre class="idl">interface <b>SVGPreserveAspectRatio</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGPreserveAspectRatio</b> {
 
   // Alignment Types
   const unsigned short <a href="coords.html#__svg__SVGPreserveAspectRatio__SVG_PRESERVEASPECTRATIO_UNKNOWN">SVG_PRESERVEASPECTRATIO_UNKNOWN</a> = 0;
@@ -3690,7 +3694,8 @@ following steps are run:</p>
 <p>An <a>SVGAnimatedPreserveAspectRatio</a> object is used to <a>reflect</a>
 the <a>'preserveAspectRatio'</a> attribute.</p>
 
-<pre class="idl">interface <b>SVGAnimatedPreserveAspectRatio</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGAnimatedPreserveAspectRatio</b> {
   [SameObject] readonly attribute <a>SVGPreserveAspectRatio</a> <a href="coords.html#__svg__SVGAnimatedPreserveAspectRatio__baseVal">baseVal</a>;
   [SameObject] readonly attribute <a>SVGPreserveAspectRatio</a> <a href="coords.html#__svg__SVGAnimatedPreserveAspectRatio__animVal">animVal</a>;
 };</pre>

--- a/master/embedded.html
+++ b/master/embedded.html
@@ -587,7 +587,8 @@ At this time, such a capability is not a requirement.</p>
 
 <p>An <a>SVGImageElement</a> object represents an <a>'image'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGImageElement</b> : <a>SVGGraphicsElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGImageElement</b> : <a>SVGGraphicsElement</a> {
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="embedded.html#__svg__SVGImageElement__x">x</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="embedded.html#__svg__SVGImageElement__y">y</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="embedded.html#__svg__SVGImageElement__width">width</a>;
@@ -622,7 +623,8 @@ IDL attribute <a>reflects</a> the <a>'preserveAspectRatio'</a> content attribute
 <p>An <a>SVGForeignObjectElement</a> object represents a <a>'foreignObject'</a>
 in the DOM.</p>
 
-<pre class="idl">interface <b>SVGForeignObjectElement</b> : <a>SVGGraphicsElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGForeignObjectElement</b> : <a>SVGGraphicsElement</a> {
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="embedded.html#__svg__SVGForeignObjectElement__x">x</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="embedded.html#__svg__SVGForeignObjectElement__y">y</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="embedded.html#__svg__SVGForeignObjectElement__width">width</a>;

--- a/master/interact.html
+++ b/master/interact.html
@@ -1300,7 +1300,8 @@ attribute.</p>
 <p>An <a>SVGCursorElement</a> object represents a <a>'cursor element'</a>
 element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGCursorElement</b> : <a>SVGElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGCursorElement</b> : <a>SVGElement</a> {
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="interact.html#__svg__SVGCursorElement__x">x</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="interact.html#__svg__SVGCursorElement__y">y</a>;
 };
@@ -1319,7 +1320,8 @@ IDL attributes <a>reflect</a> the <a>'x'</a> and <a>'y'</a> content attributes.<
 
 <p>An <a>SVGScriptElement</a> object represents a <a>'script'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGScriptElement</b> : <a>SVGElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGScriptElement</b> : <a>SVGElement</a> {
   attribute DOMString <a href="interact.html#__svg__SVGScriptElement__type">type</a>;
   attribute DOMString? <a href="interact.html#__svg__SVGScriptElement__crossOrigin">crossOrigin</a>;
 };

--- a/master/linking.html
+++ b/master/linking.html
@@ -1131,7 +1131,8 @@ as follows:</p>
 
 <p>An <a>SVGElement</a> object represents an <a>'a'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGAElement</b> : <a>SVGGraphicsElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGAElement</b> : <a>SVGGraphicsElement</a> {
   [SameObject] readonly attribute <a>SVGAnimatedString</a> <a href="linking.html#__svg__SVGAElement__target">target</a>;
   [SameObject] readonly attribute <a>SVGAnimatedString</a> <a href="linking.html#__svg__SVGAElement__download">download</a>;
   [SameObject] readonly attribute <a>SVGAnimatedString</a> <a href="linking.html#__svg__SVGAElement__rel">rel</a>;
@@ -1163,7 +1164,8 @@ as follows:</p>
 
 <p>An <a>SVGViewElement</a> object represents a <a>'view'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGViewElement</b> : <a>SVGElement</a> {};
+<pre class="idl">[Exposed=Window]
+interface <b>SVGViewElement</b> : <a>SVGElement</a> {};
 
 <a>SVGViewElement</a> implements <a>SVGFitToViewBox</a>;
 <a>SVGViewElement</a> implements <a>SVGZoomAndPan</a>;</pre>

--- a/master/painting.html
+++ b/master/painting.html
@@ -3532,7 +3532,8 @@ SVG Tiny 1.2.</p>
 <p>An <a>SVGMarkerElement</a> object represents a <a>'marker element'</a>
 element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGMarkerElement</b> : <a>SVGElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGMarkerElement</b> : <a>SVGElement</a> {
 
   // Marker Unit Types
   const unsigned short <a href="painting.html#__svg__SVGMarkerElement__SVG_MARKERUNITS_UNKNOWN">SVG_MARKERUNITS_UNKNOWN</a> = 0;

--- a/master/paths.html
+++ b/master/paths.html
@@ -1209,7 +1209,8 @@ commands contribute to path length calculations.</p>
 <edit:with element="path">
 <p>An <a>SVGPathElement</a> object represents a <a>'path'</a> in the DOM.</p>
 
-<pre class="idl">interface <b>SVGPathElement</b> : <a>SVGGeometryElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGPathElement</b> : <a>SVGGeometryElement</a> {
 };</pre>
 
 </edit:with>

--- a/master/pservers.html
+++ b/master/pservers.html
@@ -3440,7 +3440,8 @@ solid color paint servers are allowed for the <a>'stroke'</a> property.</p>
 <p>An <a>SVGSolidcolorElement</a> object represents an <a>'solidcolor'</a>
 element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGSolidcolorElement</b> : <a>SVGElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGSolidcolorElement</b> : <a>SVGElement</a> {
 };</pre>
 
 </edit:with>
@@ -3451,7 +3452,8 @@ element in the DOM.</p>
 <p>The <a>SVGGradientElement</a> interface is used as a base interface
 for gradient paint server element interfaces.</p>
 
-<pre class="idl">interface <b>SVGGradientElement</b> : <a>SVGElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGGradientElement</b> : <a>SVGElement</a> {
 
   // Spread Method Types
   const unsigned short <a href="pservers.html#__svg__SVGGradientElement__SVG_SPREADMETHOD_UNKNOWN">SVG_SPREADMETHOD_UNKNOWN</a> = 0;
@@ -3517,7 +3519,8 @@ numeric spread type constant table.</p>
 <p>An <a>SVGLinearGradientElement</a> object represents an <a>'linearGradient'</a>
 in the DOM.</p>
 
-<pre class="idl">interface <b>SVGLinearGradientElement</b> : <a>SVGGradientElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGLinearGradientElement</b> : <a>SVGGradientElement</a> {
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="pservers.html#__svg__SVGLinearGradientElement__x1">x1</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="pservers.html#__svg__SVGLinearGradientElement__y1">y1</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="pservers.html#__svg__SVGLinearGradientElement__x2">x2</a>;
@@ -3542,7 +3545,8 @@ content attributes, respectively</p>
 <p>An <a>SVGRadialGradientElement</a> object represents an <a>'radialGradient'</a>
 in the DOM.</p>
 
-<pre class="idl">interface <b>SVGRadialGradientElement</b> : <a>SVGGradientElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGRadialGradientElement</b> : <a>SVGGradientElement</a> {
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="pservers.html#__svg__SVGRadialGradientElement__cx">cx</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="pservers.html#__svg__SVGRadialGradientElement__cy">cy</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="pservers.html#__svg__SVGRadialGradientElement__r">r</a>;
@@ -3571,7 +3575,8 @@ in the DOM.</p>
 The <a>SVGMeshGradientElement</a> interface corresponds to the
 <a>'mesh'</a> element.
 
-<pre class="idl">interface <b>SVGMeshGradientElement</b> : <a>SVGGradientElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGMeshGradientElement</b> : <a>SVGGradientElement</a> {
 };</pre>
 
 <p class="note">Note that the <a>SVGMeshGradientElement</a> does not have any
@@ -3587,7 +3592,8 @@ attributes.</p>
 <p>An <a>SVGMeshrowElement</a> object represents a <a>'meshrow'</a> element
 in the DOM.</p>
 
-<pre class="idl">interface <b>SVGMeshrowElement</b> : <a>SVGElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGMeshrowElement</b> : <a>SVGElement</a> {
 };</pre>
 
 
@@ -3596,7 +3602,8 @@ in the DOM.</p>
 <p>An <a>SVGMeshpatchElement</a> object represents a <a>'meshpatch'</a> element
 in the DOM.</p>
 
-<pre class="idl">interface <b>SVGMeshpatchElement</b> : <a>SVGElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGMeshpatchElement</b> : <a>SVGElement</a> {
 };</pre>
 
 
@@ -3607,7 +3614,8 @@ in the DOM.</p>
 <p>An <a>SVGStopElement</a> object represents a <a>'stop'</a> element
 in the DOM.</p>
 
-<pre class="idl">interface <b>SVGStopElement</b> : <a>SVGElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGStopElement</b> : <a>SVGElement</a> {
   [SameObject] readonly attribute <a>SVGAnimatedNumber</a> <a href="pservers.html#__svg__SVGStopElement__offset">offset</a>;
 };</pre>
 
@@ -3626,7 +3634,8 @@ in the DOM.</p>
 <p>An <a>SVGPatternElement</a> object represents a <a>'pattern'</a> element
 in the DOM.</p>
 
-<pre class="idl">interface <b>SVGPatternElement</b> : <a>SVGElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGPatternElement</b> : <a>SVGElement</a> {
   [SameObject] readonly attribute <a>SVGAnimatedEnumeration</a> <a href="pservers.html#__svg__SVGPatternElement__patternUnits">patternUnits</a>;
   [SameObject] readonly attribute <a>SVGAnimatedEnumeration</a> <a href="pservers.html#__svg__SVGPatternElement__patternContentUnits">patternContentUnits</a>;
   [SameObject] readonly attribute <a>SVGAnimatedTransformList</a> <a href="pservers.html#__svg__SVGPatternElement__patternTransform">patternTransform</a>;
@@ -3677,7 +3686,8 @@ IDL attributes <a>reflect</a> the <a>'x'</a>, <a>'y'</a>,
 
 <edit:with element="hatch">
 
-<pre class="idl">interface <b>SVGHatchElement</b> : <a>SVGElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGHatchElement</b> : <a>SVGElement</a> {
 };</pre>
 
 <p class="note">Note that <a>SVGHatchElement</a> does not have any
@@ -3692,7 +3702,8 @@ IDL attributes <a>reflect</a> the <a>'x'</a>, <a>'y'</a>,
 
 <edit:with element="hatchpath">
 
-<pre class="idl">interface <b>SVGHatchpathElement</b> : <a>SVGElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGHatchpathElement</b> : <a>SVGElement</a> {
 };</pre>
 
 <p class="note">Note that <a>SVGHatchpathElement</a> does not have any

--- a/master/shapes.html
+++ b/master/shapes.html
@@ -675,7 +675,8 @@ on the <a>'svg'</a> element.</p>
 
 <p>An <a>SVGRectElement</a> object represents a <a>'rect'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGRectElement</b> : <a>SVGGeometryElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGRectElement</b> : <a>SVGGeometryElement</a> {
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="shapes.html#__svg__SVGRectElement__x">x</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="shapes.html#__svg__SVGRectElement__y">y</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="shapes.html#__svg__SVGRectElement__width">width</a>;
@@ -705,7 +706,8 @@ respectively.</p>
 
 <p>An <a>SVGCircleElement</a> object represents a <a>'circle'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGCircleElement</b> : <a>SVGGeometryElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGCircleElement</b> : <a>SVGGeometryElement</a> {
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="shapes.html#__svg__SVGCircleElement__cx">cx</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="shapes.html#__svg__SVGCircleElement__cy">cy</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="shapes.html#__svg__SVGCircleElement__r">r</a>;
@@ -728,7 +730,8 @@ respectively.</p>
 
 <p>An <a>SVGEllipseElement</a> object represents a <a>'ellipse'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGEllipseElement</b> : <a>SVGGeometryElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGEllipseElement</b> : <a>SVGGeometryElement</a> {
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="shapes.html#__svg__SVGEllipseElement__cx">cx</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="shapes.html#__svg__SVGEllipseElement__cy">cy</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="shapes.html#__svg__SVGEllipseElement__rx">rx</a>;
@@ -754,7 +757,8 @@ respectively.</p>
 The <a>SVGLineElement</a> interface corresponds to the <a>'line'</a>
 element.
 
-<pre class="idl">interface <b>SVGLineElement</b> : <a>SVGGeometryElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGLineElement</b> : <a>SVGGeometryElement</a> {
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="shapes.html#__svg__SVGLineElement__x1">x1</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="shapes.html#__svg__SVGLineElement__y1">y1</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="shapes.html#__svg__SVGLineElement__x2">x2</a>;
@@ -778,7 +782,8 @@ content attributes, respectively</p>
 
 <p>An <a>SVGMeshElement</a> object represents a <a>'mesh'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGMeshElement</b> : <a>SVGGeometryElement</a> {};
+<pre class="idl">[Exposed=Window]
+interface <b>SVGMeshElement</b> : <a>SVGGeometryElement</a> {};
 
 <a>SVGMeshElement</a> implements <a>SVGURIReference</a>;</pre>
 
@@ -816,7 +821,8 @@ value of the reflected attribute.</p>
 elements are <a>DOMPoint</a> objects.  An <a>SVGPointList</a>
 object represents a list of points.</p>
 
-<pre class="idl">interface <b>SVGPointList</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGPointList</b> {
 
   readonly attribute unsigned long <a href="types.html#__svg__SVGNameList__length">length</a>;
   readonly attribute unsigned long <a href="types.html#__svg__SVGNameList__numberOfItems">numberOfItems</a>;
@@ -915,7 +921,8 @@ the internal coordinate value:</p>
 
 <p>An <a>SVGPolylineElement</a> object represents a <a>'polyline'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGPolylineElement</b> : <a>SVGGeometryElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGPolylineElement</b> : <a>SVGGeometryElement</a> {
 };
 
 <a>SVGPolylineElement</a> implements <a>SVGAnimatedPoints</a>;</pre>
@@ -929,7 +936,8 @@ the internal coordinate value:</p>
 
 <p>An <a>SVGPolygonElement</a> object represents a <a>'polygon'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGPolygonElement</b> : <a>SVGGeometryElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGPolygonElement</b> : <a>SVGGeometryElement</a> {
 };
 
 <a>SVGPolygonElement</a> implements <a>SVGAnimatedPoints</a>;</pre>

--- a/master/struct.html
+++ b/master/struct.html
@@ -2839,7 +2839,8 @@ miscellaneous utility methods, such as data type object factory methods.</p>
 which is the object returned from the <a href="#__svg__SVGSVGElement__currentTranslate">currentTranslate</a>
 IDL attribute.</p>
 
-<pre class="idl">interface <b>SVGSVGElement</b> : <a>SVGGraphicsElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGSVGElement</b> : <a>SVGGraphicsElement</a> {
 
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="struct.html#__svg__SVGSVGElement__x">x</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="struct.html#__svg__SVGSVGElement__y">y</a>;
@@ -3186,7 +3187,8 @@ null if there is no such element.</p>
 
 <p>An <a>SVGGElement</a> object represents a <a>'g'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGGElement</b> : <a>SVGGraphicsElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGGElement</b> : <a>SVGGraphicsElement</a> {
 };</pre>
 
 </edit:with>
@@ -3198,7 +3200,8 @@ null if there is no such element.</p>
 
 <p>An <a>SVGUnknownElement</a> object represents an unknown element in the SVG namespace.</p>
 
-<pre class="idl">interface <b>SVGUnknownElement</b> : <a>SVGGraphicsElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGUnknownElement</b> : <a>SVGGraphicsElement</a> {
 };</pre>
 
 </edit:with>
@@ -3210,7 +3213,8 @@ null if there is no such element.</p>
 
 <p>An <a>SVGDefsElement</a> object represents a <a>'defs'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGDefsElement</b> : <a>SVGGraphicsElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGDefsElement</b> : <a>SVGGraphicsElement</a> {
 };</pre>
 
 </edit:with>
@@ -3222,7 +3226,8 @@ null if there is no such element.</p>
 
 <p>An <a>SVGDescElement</a> object represents a <a>'desc'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGDescElement</b> : <a>SVGElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGDescElement</b> : <a>SVGElement</a> {
 };</pre>
 
 </edit:with>
@@ -3234,7 +3239,8 @@ null if there is no such element.</p>
 
 <p>An <a>SVGMetadataElement</a> object represents a <a>'metadata'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGMetadataElement</b> : <a>SVGElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGMetadataElement</b> : <a>SVGElement</a> {
 };</pre>
 
 </edit:with>
@@ -3246,7 +3252,8 @@ null if there is no such element.</p>
 
 <p>An <a>SVGTitleElement</a> object represents a <a>'title'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGTitleElement</b> : <a>SVGElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGTitleElement</b> : <a>SVGElement</a> {
 };</pre>
 
 </edit:with>
@@ -3258,7 +3265,8 @@ null if there is no such element.</p>
 
 <p>An <a>SVGSymbolElement</a> object represents a <a>'symbol'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGSymbolElement</b> : <a>SVGGraphicsElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGSymbolElement</b> : <a>SVGGraphicsElement</a> {
 };
 
 <a>SVGSymbolElement</a> implements <a>SVGFitToViewBox</a>;</pre>
@@ -3278,7 +3286,8 @@ null if there is no such element.</p>
 
 <p>An <a>SVGUseElement</a> object represents a <a>'use'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGUseElement</b> : <a>SVGGraphicsElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGUseElement</b> : <a>SVGGraphicsElement</a> {
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="struct.html#__svg__SVGUseElement__x">x</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="struct.html#__svg__SVGUseElement__y">y</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLength</a> <a href="struct.html#__svg__SVGUseElement__width">width</a>;
@@ -3324,9 +3333,8 @@ then getting these attributes returns null.</p>
   is entirely read-only from the perspective of author scripts.</p>
 
 <div class='changed-since-cr1'>
-<pre class="idl">
+<pre class="idl">[Exposed=Window]
 interface <b>SVGUseElementShadowRoot</b> : <a>ShadowRoot</a> {
-
 };</pre>
 </div>
 
@@ -3385,8 +3393,7 @@ or is null otherwise.</p>
 </p>
   
 
-<pre class="idl">
-[<i>Constructor</i> (<a>Animation</a> source, <a>Animatable</a> newTarget) ]
+<pre class="idl">[<i>Constructor</i>(<a>Animation</a> source, <a>Animatable</a> newTarget), Exposed=Window]
 interface <b>ShadowAnimation</b> : <a>Animation</a> {
   [SameObject] readonly attribute <a>Animation</a> <a href="#__svg__ShadowAnimation__sourceAnimation">sourceAnimation</a>;
 };</pre>
@@ -3423,7 +3430,8 @@ interface <b>ShadowAnimation</b> : <a>Animation</a> {
 
 <p>An <a>SVGSwitchElement</a> object represents a <a>'switch'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGSwitchElement</b> : <a>SVGGraphicsElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGSwitchElement</b> : <a>SVGGraphicsElement</a> {
 };</pre>
 
 </edit:with>

--- a/master/styling.html
+++ b/master/styling.html
@@ -712,7 +712,8 @@ also supported in SVG user agents:</p>
 <p>An <a>SVGStyleElement</a> object represents a <a>'style element'</a> element
 in the DOM.</p>
 
-<pre class="idl">interface <b>SVGStyleElement</b> : <a>SVGElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGStyleElement</b> : <a>SVGElement</a> {
   attribute DOMString <a href="styling.html#__svg__SVGStyleElement__type">type</a>;
   attribute DOMString <a href="styling.html#__svg__SVGStyleElement__media">media</a>;
   attribute DOMString <a href="styling.html#__svg__SVGStyleElement__title">title</a>;

--- a/master/text.html
+++ b/master/text.html
@@ -6293,7 +6293,8 @@ invoking <a>SVGTextContentElement::getNumberOfChars</a> on that
 element will return 2 since there are two UTF-16 code units (the
 surrogate pair) used to represent that one character.</p>
 
-<pre class="idl">interface <b>SVGTextContentElement</b> : <a>SVGGraphicsElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGTextContentElement</b> : <a>SVGGraphicsElement</a> {
 
   // lengthAdjust Types
   const unsigned short <a href="text.html#__svg__SVGTextContentElement__LENGTHADJUST_UNKNOWN">LENGTHADJUST_UNKNOWN</a> = 0;
@@ -6619,7 +6620,8 @@ selection.addRange(range);</pre>
 that support attributes that position individual text glyphs.  It is inherited by
 <a>SVGTextElement</a> and <a>SVGTSpanElement</a>.</p>
 
-<pre class="idl">interface <b>SVGTextPositioningElement</b> : <a>SVGTextContentElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGTextPositioningElement</b> : <a>SVGTextContentElement</a> {
   [SameObject] readonly attribute <a>SVGAnimatedLengthList</a> <a href="text.html#__svg__SVGTextPositioningElement__x">x</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLengthList</a> <a href="text.html#__svg__SVGTextPositioningElement__y">y</a>;
   [SameObject] readonly attribute <a>SVGAnimatedLengthList</a> <a href="text.html#__svg__SVGTextPositioningElement__dx">dx</a>;
@@ -6644,7 +6646,8 @@ content attributes, respectively.</p>
 
 <p>An <a>SVGTextElement</a> object represents a <a>'text'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGTextElement</b> : <a>SVGTextPositioningElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGTextElement</b> : <a>SVGTextPositioningElement</a> {
 };</pre>
 
 </edit:with>
@@ -6655,7 +6658,8 @@ content attributes, respectively.</p>
 
 <p>An <a>SVGTSpanElement</a> object represents a <a>'tspan'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGTSpanElement</b> : <a>SVGTextPositioningElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGTSpanElement</b> : <a>SVGTextPositioningElement</a> {
 };</pre>
 
 </edit:with>
@@ -6666,7 +6670,8 @@ content attributes, respectively.</p>
 
 <p>An <a>SVGTextPathElement</a> object represents a <a>'textPath'</a> element in the DOM.</p>
 
-<pre class="idl">interface <b>SVGTextPathElement</b> : <a>SVGTextContentElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGTextPathElement</b> : <a>SVGTextContentElement</a> {
 
   // textPath Method Types
   const unsigned short <a href="text.html#__svg__SVGTextPathElement__TEXTPATH_METHODTYPE_UNKNOWN">TEXTPATH_METHODTYPE_UNKNOWN</a> = 0;

--- a/master/types.html
+++ b/master/types.html
@@ -220,7 +220,8 @@ SVG language (such as the <a>SVGPathElement</a> interface for the
 SVGElement with a style IDL attribute</a>, so that the <a>'style attribute'</a>
 attribute can be accessed in the same way as on HTML elements.</p>
 
-<pre class="idl">interface <b>SVGElement</b> : <a>Element</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGElement</b> : <a>Element</a> {
 
   [SameObject] readonly attribute <a>SVGAnimatedString</a> <a href="types.html#__svg__SVGElement__className">className</a>;
 
@@ -416,7 +417,8 @@ is defined by geometry with an <a>equivalent path</a>,
 and which can be filled and stroked.  
 This includes paths and the basic shapes.</p>
 
-<pre class="idl">interface <b>SVGGeometryElement</b> : <a>SVGGraphicsElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGGeometryElement</b> : <a>SVGGraphicsElement</a> {
   [SameObject] readonly attribute <a>SVGAnimatedNumber</a> <a href="types.html#__svg__SVGGeometryElement__pathLength">pathLength</a>;
 
   boolean isPointInFill(<a>DOMPoint</a> point);
@@ -503,7 +505,8 @@ modes.  It can:</p>
 <p>An <a>SVGNumber</a> object maintains an internal number value,
 which is called its <dfn id="NumberValue">value</dfn>.</p>
 
-<pre class="idl">interface <b>SVGNumber</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGNumber</b> {
   attribute float <a href="types.html#__svg__SVGNumber__value">value</a>;
 };</pre>
 
@@ -571,7 +574,8 @@ four modes.  It can:</p>
 <a>&lt;percentage&gt;</a> or <a>&lt;number&gt;</a> value, which is called its
 <dfn id="LengthValue">value</dfn>.</p>
 
-<pre class="idl">interface <b>SVGLength</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGLength</b> {
 
   // Length Unit Types
   const unsigned short <a href="types.html#__svg__SVGLength__SVG_LENGTHTYPE_UNKNOWN">SVG_LENGTHTYPE_UNKNOWN</a> = 0;
@@ -934,7 +938,8 @@ two modes.  It can:</p>
 <p>An <a>SVGAngle</a> object maintains an internal <a>&lt;angle&gt;</a> or
 <a>&lt;number&gt;</a> value, which is called its <dfn id="AngleValue">value</dfn>.</p>
 
-<pre class="idl">interface <b>SVGAngle</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGAngle</b> {
 
   // Angle Unit Types
   const unsigned short <a href="types.html#__svg__SVGAngle__SVG_ANGLETYPE_UNKNOWN">SVG_ANGLETYPE_UNKNOWN</a> = 0;
@@ -1544,7 +1549,8 @@ method.</p>
 elements are <a>SVGNumber</a> objects.  An <a>SVGNumberList</a> object
 represents a list of numbers.</p>
 
-<pre class="idl">interface <b>SVGNumberList</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGNumberList</b> {
 
   readonly attribute unsigned long <a href="types.html#__svg__SVGNameList__length">length</a>;
   readonly attribute unsigned long <a href="types.html#__svg__SVGNameList__numberOfItems">numberOfItems</a>;
@@ -1569,7 +1575,8 @@ defined in the <a href="#ListInterfaces">List interfaces</a> section above.</p>
 elements are <a>SVGLength</a> objects.  An <a>SVGLengthList</a> object
 represents a list of lengths.</p>
 
-<pre class="idl">interface <b>SVGLengthList</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGLengthList</b> {
 
   readonly attribute unsigned long <a href="types.html#__svg__SVGNameList__length">length</a>;
   readonly attribute unsigned long <a href="types.html#__svg__SVGNameList__numberOfItems">numberOfItems</a>;
@@ -1797,7 +1804,8 @@ specific value, the following steps must be performed:</p>
 <p>An <a>SVGAnimatedBoolean</a> object is used to <a>reflect</a> an
 animatable attribute that takes a boolean value.</p>
 
-<pre class="idl">interface <b>SVGAnimatedBoolean</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGAnimatedBoolean</b> {
            attribute boolean <a href="types.html#__svg__SVGAnimatedBoolean__baseVal">baseVal</a>;
   readonly attribute boolean <a href="types.html#__svg__SVGAnimatedBoolean__animVal">animVal</a>;
 };</pre>
@@ -1831,7 +1839,8 @@ only by the <a href='painting.html#__svg__SVGMarkerElement__orientType'>orientTy
 IDL attribute for the <a>'marker element'</a> element's
 <a>'marker/orient'</a> attribute).</p>
 
-<pre class="idl">interface <b>SVGAnimatedEnumeration</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGAnimatedEnumeration</b> {
            attribute unsigned short <a href="types.html#__svg__SVGAnimatedEnumeration__baseVal">baseVal</a>;
   readonly attribute unsigned short <a href="types.html#__svg__SVGAnimatedEnumeration__animVal">animVal</a>;
 };</pre>
@@ -1889,7 +1898,8 @@ is not used in this specification, however the
 <a href="https://www.w3.org/TR/filter-effects/">Filter Effects</a>
 specification has a number of uses of it.</p>
 
-<pre class="idl">interface <b>SVGAnimatedInteger</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGAnimatedInteger</b> {
            attribute long <a href="types.html#__svg__SVGAnimatedInteger__baseVal">baseVal</a>;
   readonly attribute long <a href="types.html#__svg__SVGAnimatedInteger__animVal">animVal</a>;
 };</pre>
@@ -1969,7 +1979,8 @@ used to reflect one part of an animatable attribute that takes
 an number followed by an optional second number (such as
 <a>'feDiffuseLighting/kernelUnitLength'</a> on <a>'feDiffuseLighting'</a>).</p>
 
-<pre class="idl">interface <b>SVGAnimatedNumber</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGAnimatedNumber</b> {
            attribute float <a href="types.html#__svg__SVGAnimatedNumber__baseVal">baseVal</a>;
   readonly attribute float <a href="types.html#__svg__SVGAnimatedNumber__animVal">animVal</a>;
 };</pre>
@@ -2064,7 +2075,8 @@ the following steps are run:</p>
 CSS property that takes one of these values and its corresponding
 presentation attribute.</p>
 
-<pre class="idl">interface <b>SVGAnimatedLength</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGAnimatedLength</b> {
   [SameObject] readonly attribute <a>SVGLength</a> <a href="types.html#__svg__SVGAnimatedLength__baseVal">baseVal</a>;
   [SameObject] readonly attribute <a>SVGLength</a> <a href="types.html#__svg__SVGAnimatedLength__animVal">animVal</a>;
 };</pre>
@@ -2095,7 +2107,8 @@ attribute on <a>'marker element'</a>, through the
 <a href='painting.html#__svg__SVGMarkerElement__orientAngle'>orientAngle</a>
 IDL attribute.</p>
 
-<pre class="idl">interface <b>SVGAnimatedAngle</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGAnimatedAngle</b> {
   [SameObject] readonly attribute <a>SVGAngle</a> <a href="types.html#__svg__SVGAnimatedAngle__baseVal">baseVal</a>;
   [SameObject] readonly attribute <a>SVGAngle</a> <a href="types.html#__svg__SVGAnimatedAngle__animVal">animVal</a>;
 };</pre>
@@ -2122,7 +2135,8 @@ reflected <a>'marker/orient'</a> attribute.  On getting
 animatable attribute that takes a string value.  It can optionally
 be defined to additionally reflect a second, deprecated attribute.</p>
 
-<pre class="idl">interface <b>SVGAnimatedString</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGAnimatedString</b> {
            attribute DOMString <a href="types.html#__svg__SVGAnimatedString__baseVal">baseVal</a>;
   readonly attribute DOMString <a href="types.html#__svg__SVGAnimatedString__animVal">animVal</a>;
 };</pre>
@@ -2182,7 +2196,8 @@ by an <var>x</var>, <var>y</var>, <var>width</var> and <var>height</var>.</p>
 <p class="note">In this specification the only attribute to be
 reflected as an <a>SVGAnimatedRect</a> is <a>'viewBox'</a>.</p>
 
-<pre class="idl">interface <b>SVGAnimatedRect</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGAnimatedRect</b> {
   [SameObject] readonly attribute <a>DOMRect</a> <a href="types.html#__svg__SVGAnimatedRect__baseVal">baseVal</a>;
   [SameObject] readonly attribute <a>DOMRectReadOnly</a> <a href="types.html#__svg__SVGAnimatedRect__animVal">animVal</a>;
 };</pre>
@@ -2230,7 +2245,8 @@ content attribute must be <a>reserialized</a>.</p>
 <p>An <a>SVGAnimatedNumberList</a> object is used to <a>reflect</a> an animatable
 attribute that takes a list of <a>&lt;number&gt;</a> values.</p>
 
-<pre class="idl">interface <b>SVGAnimatedNumberList</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGAnimatedNumberList</b> {
   [SameObject] readonly attribute <a>SVGNumberList</a> <a href="types.html#__svg__SVGAnimatedNumberList__baseVal">baseVal</a>;
   [SameObject] readonly attribute <a>SVGNumberList</a> <a href="types.html#__svg__SVGAnimatedNumberList__animVal">animVal</a>;
 };</pre>
@@ -2249,7 +2265,8 @@ of the reflected attribute.</p>
 attribute that takes a list of <a>&lt;length&gt;</a>, <a>&lt;percentage&gt;</a>
 or <a>&lt;number&gt;</a> values.</p>
 
-<pre class="idl">interface <b>SVGAnimatedLengthList</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGAnimatedLengthList</b> {
   [SameObject] readonly attribute <a>SVGLengthList</a> <a href="types.html#__svg__SVGAnimatedLengthList__baseVal">baseVal</a>;
   [SameObject] readonly attribute <a>SVGLengthList</a> <a href="types.html#__svg__SVGAnimatedLengthList__animVal">animVal</a>;
 };</pre>
@@ -2268,7 +2285,8 @@ of the reflected attribute.</p>
 elements are <b>DOMString</b> values.  An <a>SVGStringList</a> object
 represents a list of strings.</p>
 
-<pre class="idl">interface <b>SVGStringList</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGStringList</b> {
 
   readonly attribute unsigned long <a href="types.html#__svg__SVGNameList__length">length</a>;
   readonly attribute unsigned long <a href="types.html#__svg__SVGNameList__numberOfItems">numberOfItems</a>;
@@ -2296,7 +2314,8 @@ defined in the <a href="#ListInterfaces">List interfaces</a> section above.</p>
 used for reflecting <a>'linearGradient/gradientUnits'</a>, <a>'pattern/patternContentUnits'</a> and
 other similar attributes.</p>
 
-<pre class="idl">interface <b>SVGUnitTypes</b> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGUnitTypes</b> {
   // Unit Types
   const unsigned short <a href="types.html#__svg__SVGUnitTypes__SVG_UNIT_TYPE_UNKNOWN">SVG_UNIT_TYPE_UNKNOWN</a> = 0;
   const unsigned short <a href="types.html#__svg__SVGUnitTypes__SVG_UNIT_TYPE_USERSPACEONUSE">SVG_UNIT_TYPE_USERSPACEONUSE</a> = 1;


### PR DESCRIPTION
WebIDL now requires interfaces to explicitly define that they are exposed to Window.