### PR TITLE
Add DocumentAndElementEventHandlers

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -130,7 +130,7 @@ have been made.</p>
 
   <li>Added <a href="struct.html#__svg__SVGDocument__activeElement">activeElement</a> attribute to <a>Document</a>.</li>
 
-  <li>Made <a>SVGElement</a> implement the <a>GlobalEventHandlers</a> interface from HTML.</li>
+  <li>Made <a>SVGElement</a> include the <a>GlobalEventHandlers</a> interface from HTML.</li>
 
   <li>Removed getStrokeBBox from <a>SVGGraphicsElement</a> and extended <a href="types.html#__svg__SVGGraphicsElement__getBBox">getBBox</a> with a dictionary argument that controls which parts of the element are included in the returned bounding box.</li>
 
@@ -178,6 +178,7 @@ have been made.</p>
   <li><a>SVGUnitTypes</a> is no longer NoInterfaceObject. <a href="https://github.com/w3c/svgwg/issues/291">Github #291</a>.</li>
   <li>Clarified that <a>SVGElement</a>.<a href="types.html#__svg__SVGElement__className">className</a>
       overrides <a>Element</a>.className. Not normative, <a href="https://github.com/w3c/svgwg/issues/298">Github #298</a>.</li>
+  <li>Made <a>SVGElement</a> include the <a>DocumentAndElementEventHandlers</a> interface from HTML.</li>
 </ul>
 </div>
 

--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -1293,6 +1293,7 @@
   <interface name='CSSPrimitiveValue' href='https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-CSSPrimitiveValue'/>
   <interface name='CSSRule' href='https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-CSSRule'/>
   <interface name='Document' href='https://www.w3.org/TR/2015/REC-dom-20151119/#interface-document'/>
+  <interface name='DocumentAndElementEventHandlers' href='https://www.w3.org/TR/html5/webappapis.html#documentandelementeventhandlers'/>
   <interface name='DocumentFragment' href='https://www.w3.org/TR/2015/REC-dom-20151119/#interface-documentfragment'/>
   <interface name='ShadowRoot' href="https://www.w3.org/TR/shadow-dom/#the-shadowroot-interface" />
   <interface name='DocumentCSS' href='https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-DocumentCSS'/>

--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -12,7 +12,7 @@
   <element
       name='a'
       href='linking.html#AElement'
-      attributecategories='aria, conditional processing, core, global event, graphical event, presentation, style, deprecated xlink'
+      attributecategories='aria, conditional processing, core, global event, document element event, graphical event, presentation, style, deprecated xlink'
       interfaces='SVGAElement'>
     <x:contentmodel xmlns='http://www.w3.org/1999/xhtml'>Descriptive content, plus any element or text allowed by its parent's content model, except for another a element.  If the parent is a switch element, use the content model of the nearest ancestor that isn't a switch.</x:contentmodel>
     <attribute name='href' href='linking.html#AElementHrefAttribute' animatable='yes'/>
@@ -29,7 +29,7 @@
       contentmodel='anyof'
       elementcategories='animation, descriptive, paint server, structurally external'
       elements='clipPath, marker, mask, script, style'
-      attributecategories='aria, core, conditional processing, global event, graphical event, style, presentation'
+      attributecategories='aria, core, conditional processing, global event, document element event, graphical event, style, presentation'
       attributes=''
       interfaces='HTMLAudioElement'>
   </element>
@@ -40,7 +40,7 @@
       contentmodel='anyof'
       elementcategories='animation, descriptive, paint server'
       elements='clipPath, marker, mask, script, style'
-      attributecategories='aria, core, conditional processing, global event, graphical event, style, presentation'
+      attributecategories='aria, core, conditional processing, global event, document element event, graphical event, style, presentation'
       attributes='preserveAspectRatio'
       interfaces='HTMLCanvasElement'>
   </element>
@@ -51,7 +51,7 @@
       contentmodel='anyof'
       elementcategories='animation, descriptive, paint server'
       elements='clipPath, marker, mask, script, style'
-      attributecategories='aria, conditional processing, core, global event, graphical event, presentation, style'
+      attributecategories='aria, conditional processing, core, global event, document element event, graphical event, presentation, style'
       geometryproperties='cx, cy, r'
       attributes='pathLength'
       interfaces='SVGCircleElement'>
@@ -63,7 +63,7 @@
       contentmodel='anyof'
       elementcategories='descriptive'
       elements='script, style'
-      attributecategories='aria, core, global event, deprecated xlink'
+      attributecategories='aria, core, global event, document element event, deprecated xlink'
       interfaces='SVGCursorElement'>
     <attribute name='x' href='interact.html#CursorElementXAttribute' animatable='yes'/>
     <attribute name='y' href='interact.html#CursorElementYAttribute' animatable='yes'/>
@@ -76,14 +76,14 @@
     contentmodel='anyof'
     elementcategories='animation, descriptive, shape, structural, paint server'
     elements='a, clipPath, cursor, filter, foreignObject, image, audio, video, canvas, iframe, marker, mask, script, style, switch, view, text'
-    attributecategories='core, graphical event, global event, presentation, style'
+    attributecategories='core, graphical event, global event, document element event, presentation, style'
     interfaces='SVGDefsElement'/>
   
   <element
     name='desc'
     href='struct.html#DescElement'
     contentmodel='any'
-    attributecategories='core, global event, style'
+    attributecategories='core, global event, document element event, style'
     interfaces='SVGDescElement'/>
 
   <element
@@ -92,7 +92,7 @@
       contentmodel='anyof'
       elementcategories='animation, descriptive, paint server'
       elements='clipPath, marker, mask, script, style'
-      attributecategories='aria, conditional processing, core, global event, graphical event, presentation, style'
+      attributecategories='aria, conditional processing, core, global event, document element event, graphical event, presentation, style'
       geometryproperties='cx, cy, rx, ry'
       attributes='pathLength'
       interfaces='SVGEllipseElement'>
@@ -102,7 +102,7 @@
       name='foreignObject'
       href='embedded.html#ForeignObjectElement'
       contentmodel='any'
-      attributecategories='aria, core, conditional processing, global event, graphical event, presentation, style'
+      attributecategories='aria, core, conditional processing, global event, document element event, graphical event, presentation, style'
       geometryproperties='x, y, width, height'
       interfaces='SVGForeignObjectElement'>
   </element>
@@ -113,14 +113,14 @@
     contentmodel='anyof'
     elementcategories='animation, descriptive, shape, structural, paint server'
     elements='a, clipPath, cursor, filter, foreignObject, image, audio, video, canvas, iframe, marker, mask, script, style, switch, text, view'
-    attributecategories='aria, conditional processing, core, global event, graphical event, presentation, style'
+    attributecategories='aria, conditional processing, core, global event, document element event, graphical event, presentation, style'
     interfaces='SVGGElement'/>
 
   <element
     name='unknown'
     href='struct.html#UnknownElement'
     contentmodel='any'
-    attributecategories='aria, core, conditional processing, global event, graphical event, presentation, style'
+    attributecategories='aria, core, conditional processing, global event, document element event, graphical event, presentation, style'
     interfaces='SVGUnknownElement'/>
 
   <element
@@ -129,7 +129,7 @@
       contentmodel='anyof'
       elementcategories='animation, descriptive'
       elements='hatchpath, script, style'
-      attributecategories='core, global event, presentation, style'
+      attributecategories='core, global event, document element event, presentation, style'
       interfaces='SVGHatchElement'>
     <attribute name='x' href='pservers.html#HatchElementXAttribute' animatable='yes'/>
     <attribute name='y' href='pservers.html#HatchElementYAttribute' animatable='yes'/>
@@ -147,7 +147,7 @@
       contentmodel='anyof'
       elementcategories='animation, descriptive'
       elements='script, style'
-      attributecategories='core, global event, presentation, style'
+      attributecategories='core, global event, document element event, presentation, style'
       interfaces='SVGHatchpathElement'>
     <attribute name='d' href='pservers.html#HatchpathElementDAttribute' animatable='yes'/>
     <attribute name='offset' href='pservers.html#HatchpathElementOffsetAttribute' animatable='yes'/>
@@ -159,7 +159,7 @@
       contentmodel='anyof'
       elementcategories='animation, descriptive, paint server, structurally external'
       elements='clipPath, marker, mask, script, style'
-      attributecategories='aria, core, conditional processing, global event, graphical event, style, presentation'
+      attributecategories='aria, core, conditional processing, global event, document element event, graphical event, style, presentation'
       attributes=''
       interfaces='HTMLIFrameElement'>
   </element>
@@ -170,7 +170,7 @@
       contentmodel='anyof'
       elementcategories='animation, descriptive'
       elements='clipPath, mask, script, style'
-      attributecategories='aria, core, conditional processing, global event, graphical event, style, deprecated xlink, presentation'
+      attributecategories='aria, core, conditional processing, global event, document element event, graphical event, style, deprecated xlink, presentation'
       geometryproperties='x, y, width, height'
       attributes='preserveAspectRatio'
       interfaces='SVGImageElement'>
@@ -184,7 +184,7 @@
       contentmodel='anyof'
       elementcategories='animation, descriptive, paint server'
       elements='clipPath, marker, mask, script, style'
-      attributecategories='aria, conditional processing, core, global event, graphical event, presentation, style'
+      attributecategories='aria, conditional processing, core, global event, document element event, graphical event, presentation, style'
       attributes='pathLength'
       interfaces='SVGLineElement'>
     <attribute name='x1' href='shapes.html#LineElementX1Attribute' animatable='yes'/>
@@ -199,7 +199,7 @@
       contentmodel='anyof'
       elementcategories='descriptive'
       elements='animate, animateTransform, script, style, set, stop'
-      attributecategories='core, global event, presentation, style, deprecated xlink'
+      attributecategories='core, global event, document element event, presentation, style, deprecated xlink'
       interfaces='SVGLinearGradientElement'>
     <attribute name='x1' href='pservers.html#LinearGradientElementX1Attribute' animatable='yes'/>
     <attribute name='y1' href='pservers.html#LinearGradientElementY1Attribute' animatable='yes'/>
@@ -217,7 +217,7 @@
       contentmodel='anyof'
       elementcategories='animation, descriptive, shape, structural, paint server'
       elements='a, clipPath, cursor, filter, foreignObject, image, audio, video, canvas, iframe, marker, mask, script, style, switch, view, text'
-      attributecategories='core, global event, presentation, style'
+      attributecategories='core, global event, document element event, presentation, style'
       attributes='viewBox, preserveAspectRatio'
       interfaces='SVGMarkerElement'>
     <attribute name='refX' href='painting.html#MarkerElementRefXAttribute' animatable='yes'/>
@@ -246,7 +246,7 @@
       contentmodel='anyof'
       elementcategories='descriptive'
       elements='animate, animateTransform, script, set, meshrow'
-      attributecategories='core, global event, presentation, style'
+      attributecategories='core, global event, document element event, presentation, style'
       interfaces='SVGMeshGradientElement'>
     <attribute name='x' href='pservers.html#MeshGradientElementXAttribute' animatable='yes'/>
     <attribute name='y' href='pservers.html#MeshGradientElementYAttribute' animatable='yes'/>
@@ -261,7 +261,7 @@
       href='pservers.html#MeshpatchElement'
       elementcategories='descriptive'
       elements='script, style, stop'
-      attributecategories='core, global event, presentation, style'
+      attributecategories='core, global event, document element event, presentation, style'
       interfaces='SVGMeshpatchElement'>
     <x:contentmodel xmlns='http://www.w3.org/1999/xhtml'>Any number of <a>descriptive elements</a>, <a>'script'</a> and from two to four <a>'stop'</a> elements.</x:contentmodel>
   </element>
@@ -272,7 +272,7 @@
       contentmodel='anyof'
       elementcategories='descriptive'
       elements='meshpatch, script, style'
-      attributecategories='core, global event, presentation, style'
+      attributecategories='core, global event, document element event, presentation, style'
       interfaces='SVGMeshrowElement'>
   </element>
 
@@ -280,7 +280,7 @@
     name='metadata'
     href='struct.html#MetadataElement'
     contentmodel='any'
-    attributecategories='core, global event'
+    attributecategories='core, global event, document element event'
     interfaces='SVGMetadataElement'/>
 
   <element
@@ -289,7 +289,7 @@
       contentmodel='anyof'
       elementcategories='animation, descriptive, paint server'
       elements='clipPath, marker, mask, script, style'
-      attributecategories='aria, conditional processing, core, global event, graphical event, presentation, style'
+      attributecategories='aria, conditional processing, core, global event, document element event, graphical event, presentation, style'
       geometryproperties='d'
       attributes='pathLength'
       interfaces='SVGPathElement'>
@@ -320,7 +320,7 @@
       contentmodel='anyof'
       elementcategories='animation, descriptive, paint server'
       elements='clipPath, marker, mask, script, style'
-      attributecategories='aria, conditional processing, core, global event, graphical event, presentation, style'
+      attributecategories='aria, conditional processing, core, global event, document element event, graphical event, presentation, style'
       attributes='pathLength'
       interfaces='SVGPolygonElement'>
     <attribute name='points' href='shapes.html#PolygonElementPointsAttribute' animatable='yes'/>
@@ -332,7 +332,7 @@
       contentmodel='anyof'
       elementcategories='animation, descriptive, paint server'
       elements='clipPath, marker, mask, script, style'
-      attributecategories='aria, conditional processing, core, global event, graphical event, presentation, style'
+      attributecategories='aria, conditional processing, core, global event, document element event, graphical event, presentation, style'
       attributes='pathLength'
       interfaces='SVGPolylineElement'>
     <attribute name='points' href='shapes.html#PolylineElementPointsAttribute' animatable='yes'/>
@@ -344,7 +344,7 @@
       contentmodel='anyof'
       elementcategories='descriptive'
       elements='animate, animateTransform, set, stop, script, style'
-      attributecategories='core, global event, presentation, style, deprecated xlink'
+      attributecategories='core, global event, document element event, presentation, style, deprecated xlink'
       interfaces='SVGRadialGradientElement'>
     <attribute name='cx' href='pservers.html#RadialGradientElementCXAttribute' animatable='yes'/>
     <attribute name='cy' href='pservers.html#RadialGradientElementCYAttribute' animatable='yes'/>
@@ -364,7 +364,7 @@
       contentmodel='anyof'
       elementcategories='animation, descriptive, paint server'
       elements='mask, clipPath, marker, script, style'
-      attributecategories='aria, conditional processing, core, global event, graphical event, presentation, style'
+      attributecategories='aria, conditional processing, core, global event, document element event, graphical event, presentation, style'
       geometryproperties='x, y, width, height, rx, ry'
       attributes='pathLength'
       interfaces='SVGRectElement'>
@@ -375,7 +375,7 @@
       href='interact.html#ScriptElement'
       contentmodel='text'
       elementcategories='structurally external'
-      attributecategories='core, global event, deprecated xlink'
+      attributecategories='core, global event, document element event, deprecated xlink'
       interfaces='SVGScriptElement'>
     <attribute name='type' href='interact.html#ScriptElementTypeAttribute'/>
     <attribute name='href' href='interact.html#ScriptElementHrefAttribute'/>
@@ -388,7 +388,7 @@
       contentmodel='anyof'
       elementcategories='descriptive'
       elements='animate, set, script, style'
-      attributecategories='core, global event, presentation, style'
+      attributecategories='core, global event, document element event, presentation, style'
       interfaces='SVGSolidcolorElement'>
   </element>
 
@@ -397,7 +397,7 @@
       href='pservers.html#StopElement'
       contentmodel='anyof'
       elements='animate, set, script, style'
-      attributecategories='core, global event, presentation, style'
+      attributecategories='core, global event, document element event, presentation, style'
       interfaces='SVGStopElement'>
     <attribute name='offset' href='pservers.html#StopElementOffsetAttribute' animatable='yes'/>
     <attribute name='path'   href='pservers.html#StopElementPathAttribute' animatable='yes'/>
@@ -407,7 +407,7 @@
       name='style'
       href='styling.html#StyleElement'
       contentmodel='text'
-      attributecategories='core, global event'
+      attributecategories='core, global event, document element event'
       interfaces='SVGStyleElement'>
     <attribute name='type' href='styling.html#StyleElementTypeAttribute'/>
     <attribute name='media' href='styling.html#StyleElementMediaAttribute'/>
@@ -420,7 +420,7 @@
       contentmodel='anyof'
       elementcategories='animation, descriptive, shape, structural, paint server'
       elements='a, clipPath, cursor, filter, foreignObject, image, audio, video, canvas, iframe, marker, mask, script, style, switch, text, view'
-      attributecategories='aria, conditional processing, core, document event, global event, graphical event, presentation, style'
+      attributecategories='aria, conditional processing, core, document event, global event, document element event, graphical event, presentation, style'
       attributes='viewBox, preserveAspectRatio, zoomAndPan'
       geometryproperties='x, y, width, height'
       interfaces='SVGSVGElement'>
@@ -433,7 +433,7 @@
     contentmodel='anyof'
     elementcategories='animation, shape'
     elements='a, foreignObject, g, image, audio, video, canvas, iframe, svg, switch, text, use'
-    attributecategories='aria, conditional processing, core, global event, graphical event, presentation, style'
+    attributecategories='aria, conditional processing, core, global event, document element event, graphical event, presentation, style'
     interfaces='SVGSwitchElement'>
   </element>
 
@@ -443,7 +443,7 @@
     contentmodel='anyof'
     elementcategories='animation, descriptive, shape, structural, paint server'
     elements='a, clipPath, cursor, filter, foreignObject, image, audio, video, canvas, iframe, marker, mask, script, style, switch, text, view'
-    attributecategories='aria, core, global event, graphical event, presentation, style'
+    attributecategories='aria, core, global event, document element event, graphical event, presentation, style'
     attributes='preserveAspectRatio, viewBox'
     geometryproperties='x, y, width, height'
     interfaces='SVGSymbolElement'>
@@ -457,7 +457,7 @@
       contentmodel='textoranyof'
       elementcategories='animation, descriptive, text content child, paint server'
       elements='a, clipPath, marker, mask, script, style'
-      attributecategories='aria, conditional processing, core, global event, graphical event, presentation, style'
+      attributecategories='aria, conditional processing, core, global event, document element event, graphical event, presentation, style'
       attributes='lengthAdjust'
       interfaces='SVGTextElement'>
     <attribute name='x' href='text.html#TextElementXAttribute' animatable='yes'/>
@@ -474,7 +474,7 @@
       contentmodel='textoranyof'
       elementcategories='descriptive, paint server'
       elements='a, animate, clipPath, marker, mask, script, set, style, tspan'
-      attributecategories='aria, conditional processing, core, global event, graphical event, presentation, style, deprecated xlink'
+      attributecategories='aria, conditional processing, core, global event, document element event, graphical event, presentation, style, deprecated xlink'
       attributes='lengthAdjust, textLength'
       interfaces='SVGTextPathElement'>
     <attribute name='path' href='text.html#TextPathElementPathAttribute' animatable='yes'/>
@@ -489,7 +489,7 @@
     name='title'
     href='struct.html#TitleElement'
     contentmodel='any'
-    attributecategories='core, global event, style'
+    attributecategories='core, global event, document element event, style'
     interfaces='SVGTitleElement'/>
 
   <element
@@ -498,7 +498,7 @@
     contentmodel='textoranyof'
     elementcategories='descriptive, paint server'
     elements='a, animate, script, set, style, tspan'
-    attributecategories='aria, conditional processing, core, global event, graphical event, presentation, style'
+    attributecategories='aria, conditional processing, core, global event, document element event, graphical event, presentation, style'
     attributes='x, y, dx, dy, rotate, textLength, lengthAdjust'
     interfaces='SVGTSpanElement'>
   </element>
@@ -509,7 +509,7 @@
       contentmodel='anyof'
       elementcategories='animation, descriptive'
       elements='clipPath, mask, script, style'
-      attributecategories='aria, core, conditional processing, global event, graphical event, presentation, style, deprecated xlink'
+      attributecategories='aria, core, conditional processing, global event, document element event, graphical event, presentation, style, deprecated xlink'
       geometryproperties='x, y, width, height'
       interfaces='SVGUseElement'>
     <attribute name='href' href='struct.html#UseElementHrefAttribute' animatable='yes'/>
@@ -521,7 +521,7 @@
       contentmodel='anyof'
       elementcategories='animation, descriptive, paint server, structurally external'
       elements='clipPath, marker, mask, script, style'
-      attributecategories='aria, core, conditional processing, global event, graphical event, style, presentation'
+      attributecategories='aria, core, conditional processing, global event, document element event, graphical event, style, presentation'
       attributes=''
       interfaces='HTMLVideoElement'>
   </element>
@@ -532,7 +532,7 @@
       contentmodel='anyof'
       elementcategories='animation, descriptive'
       elements='script, style'
-      attributecategories='aria, core, global event'
+      attributecategories='aria, core, global event, document element event'
       attributes='viewBox, preserveAspectRatio, zoomAndPan'
       interfaces='SVGViewElement'>
   </element>
@@ -673,7 +673,7 @@
 
   <attributecategory
       name='window event'
-      href='https://www.w3.org/TR/2014/CR-html5-20140204/webappapis.html#windoweventhandlers'>
+      href='https://html.spec.whatwg.org/multipage/webappapis.html#windoweventhandlers'>
     <attribute name='onafterprint' href='interact.html#EventAttributes'/>
     <attribute name='onbeforeprint' href='interact.html#EventAttributes'/>
     <attribute name='onhashchange' href='interact.html#EventAttributes'/>
@@ -689,7 +689,7 @@
 
   <attributecategory
       name='global event'
-      href='https://www.w3.org/TR/2014/CR-html5-20140204/webappapis.html#globaleventhandlers'>
+      href='https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers'>
     <attribute name='oncancel' href='interact.html#EventAttributes'/>
     <attribute name='oncanplay' href='interact.html#EventAttributes'/>
     <attribute name='oncanplaythrough' href='interact.html#EventAttributes'/>
@@ -747,6 +747,14 @@
     <attribute name='ontoggle' href='interact.html#EventAttributes'/>
     <attribute name='onvolumechange' href='interact.html#EventAttributes'/>
     <attribute name='onwaiting' href='interact.html#EventAttributes'/>
+  </attributecategory>
+
+  <attributecategory
+      name='document element event'
+      href='https://html.spec.whatwg.org/multipage/webappapis.html#documentandelementeventhandlers'>
+    <attribute name='oncopy' href='interact.html#EventAttributes'/>
+    <attribute name='oncut' href='interact.html#EventAttributes'/>
+    <attribute name='onpaste' href='interact.html#EventAttributes'/>
   </attributecategory>
 
   <attributecategory

--- a/master/types.html
+++ b/master/types.html
@@ -236,6 +236,7 @@ interface <b>SVGElement</b> : <a>Element</a> {
 };
 
 <a>SVGElement</a> includes <a>GlobalEventHandlers</a>;
+<a>SVGElement</a> includes <a>DocumentAndElementEventHandlers</a>;
 <a>SVGElement</a> includes <a>SVGElementInstance</a>;</pre>
 
 <p>The <b id="__svg__SVGElement__className">className</b> IDL attribute

--- a/specs/animations/master/definitions.xml
+++ b/specs/animations/master/definitions.xml
@@ -10,13 +10,13 @@
     contentmodel='anyof'
     elementcategories='descriptive'
     elements='script'
-    attributecategories='animation addition, animation event, animation attribute target, animation timing, animation value, conditional processing, core, global event, presentation, xlink'
+    attributecategories='animation addition, animation event, animation attribute target, animation timing, animation value, conditional processing, core, global event, document element event, presentation, xlink'
     interfaces='SVGAnimateElement'/>
 
   <element
       name='animateMotion'
       href='#AnimateMotionElement'
-      attributecategories='animation addition, animation event, animation timing, animation value, conditional processing, core, global event, xlink'
+      attributecategories='animation addition, animation event, animation timing, animation value, conditional processing, core, global event, document element event, xlink'
       interfaces='SVGAnimateMotionElement'>
     <x:contentmodel xmlns='http://www.w3.org/1999/xhtml'>Any number of <a>descriptive elements</a>, <a>'script'</a> and at most one <a>'mpath'</a> element, in any order.</x:contentmodel>
     <!--
@@ -34,7 +34,7 @@
       contentmodel='anyof'
       elementcategories='descriptive'
       elements='script'
-      attributecategories='animation addition, animation event, animation attribute target, animation timing, animation value, conditional processing, core, global event, xlink'
+      attributecategories='animation addition, animation event, animation attribute target, animation timing, animation value, conditional processing, core, global event, document element event, xlink'
       interfaces='SVGAnimateTransformElement'>
     <attribute name='type' href='#AnimateTransformElementTypeAttribute'/>
   </element>
@@ -56,7 +56,7 @@
       contentmodel='anyof'
       elementcategories='descriptive'
       elements='script'
-      attributecategories='core, global event, xlink'
+      attributecategories='core, global event, document element event, xlink'
       interfaces='SVGMPathElement'>
     <attribute name='href' href='#MPathElementHrefAttribute'/>
   </element>
@@ -67,7 +67,7 @@
       contentmodel='anyof'
       elementcategories='descriptive'
       elements='script'
-      attributecategories='animation event, animation attribute target, animation timing, conditional processing, core, global event, xlink'
+      attributecategories='animation event, animation attribute target, animation timing, conditional processing, core, global event, document element event, xlink'
       interfaces='SVGSetElement'>
     <attribute name='to' href='#SetElementToAttribute'/>
   </element>

--- a/specs/markers/master/definitions.xml
+++ b/specs/markers/master/definitions.xml
@@ -10,7 +10,7 @@
       contentmodel='anyof'
       elementcategories='animation, descriptive, shape, structural, paint server'
       elements='a, clipPath, cursor, filter, foreignObject, image, marker, mask, script, style, switch, view, text'
-      attributecategories='core, global event, presentation, style'
+      attributecategories='core, global event, document element event, presentation, style'
       attributes='viewBox, preserveAspectRatio'
       interfaces='SVGMarkerElement'>
     <attribute name='refX' href='#MarkerElementRefXAttribute' animatable='yes'/>


### PR DESCRIPTION
Fixes #395  (any additional members should have their own issue)

Supported by Firefox and Edge (upcoming version) as specified. Supported by Chrome and Safari on Element (HTML defines them on HTMLElement so Safari/Chrome have them one level too high)

Tests: https://github.com/w3c/web-platform-tests/pull/10249