### PR TITLE
Add HTMLOrSVGElement mixn

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -178,6 +178,7 @@ have been made.</p>
   <li><a>SVGUnitTypes</a> is no longer NoInterfaceObject. <a href="https://github.com/w3c/svgwg/issues/291">Github #291</a>.</li>
   <li>Clarified that <a>SVGElement</a>.<a href="types.html#__svg__SVGElement__className">className</a>
       overrides <a>Element</a>.className. Not normative, <a href="https://github.com/w3c/svgwg/issues/298">Github #298</a>.</li>
+  <li>Moved dataset, tabIndex, focus(), and blur() to a shared <a>HTMLOrSVGElement</a> mixin defined in the HTML specification.</li>
 </ul>
 </div>
 

--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -1298,31 +1298,32 @@
   <interface name='DocumentCSS' href='https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-DocumentCSS'/>
   <interface name='DOMImplementation' href='https://www.w3.org/TR/2014/WD-dom-20140204/#domimplementation'/>
   <interface name='DOMException' href='https://www.w3.org/TR/2014/WD-dom-20140204/#exception-domexception'/>
-  <interface name='DOMStringMap' href='https://www.w3.org/TR/2014/CR-html5-20140204/infrastructure.html#domstringmap'/>
+  <interface name='DOMStringMap' href='https://html.spec.whatwg.org/multipage/dom.html#domstringmap'/>
   <interface name='DOMTokenList' href='https://www.w3.org/TR/dom/#domtokenlist'/>
   <interface name='Element' href='https://www.w3.org/TR/2014/WD-dom-20140204/#element'/>
-  <interface name='EventHandler' href='https://www.w3.org/TR/html5/webappapis.html#event-handler'/>
+  <interface name='EventHandler' href='https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler'/>
   <interface name='EventListener' href='https://www.w3.org/TR/2014/WD-dom-20140204/#eventlistener'/>
   <interface name='EventTarget' href='https://www.w3.org/TR/2014/WD-dom-20140204/#eventtarget'/>
   <interface name='Event' href='https://www.w3.org/TR/2014/WD-dom-20140204/#event'/>
-  <interface name='event handler content attributes' href='https://www.w3.org/TR/html5/webappapis.html#event-handler-content-event-handler-content-attribute'/>
-  <interface name='event handler IDL attributes' href='https://www.w3.org/TR/html5/webappapis.html#event-handler-idl-event-handler-idl-attribute'/>
-  <interface name='event handlers' href='https://www.w3.org/TR/html5/webappapis.html#event-handler'/>
-  <interface name='GlobalEventHandlers' href='https://www.w3.org/TR/html5/webappapis.html#globaleventhandlers'/>
-  <interface name='HTMLAudioElement' href='https://www.w3.org/TR/html5/semantics-embedded-content.html#htmlaudioelement'/>
-  <interface name='HTMLCanvasElement' href='https://www.w3.org/TR/html5/semantics-scripting.html#htmlcanvaselement'/>
-  <interface name='HTMLEmbedElement' href='https://www.w3.org/TR/html5/semantics-embedded-content.html#htmlembedelement'/>
-  <interface name='HTMLIFrameElement' href='https://www.w3.org/TR/html5/semantics-embedded-content.html#htmliframeelement'/>
-  <interface name='HTMLObjectElement' href='https://www.w3.org/TR/html5/semantics-embedded-content.html#htmlobjectelement'/>
-  <interface name='HTMLVideoElement' href='https://www.w3.org/TR/html5/semantics-embedded-content.html#the-video-element'/>
-  <interface name='HTMLElement' href='https://www.w3.org/TR/html5/dom.html#htmlelement'/>
+  <interface name='event handler content attributes' href='https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes'/>
+  <interface name='event handler IDL attributes' href='https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes'/>
+  <interface name='event handlers' href='https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers'/>
+  <interface name='GlobalEventHandlers' href='https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers'/>
+  <interface name='HTMLAudioElement' href='https://html.spec.whatwg.org/multipage/media.html#htmlaudioelement'/>
+  <interface name='HTMLCanvasElement' href='https://html.spec.whatwg.org/multipage/canvas.html#htmlcanvaselement'/>
+  <interface name='HTMLEmbedElement' href='https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlembedelement'/>
+  <interface name='HTMLIFrameElement' href='https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmliframeelement'/>
+  <interface name='HTMLObjectElement' href='https://html.spec.whatwg.org/multipage/iframe-embed-object.html#htmlobjectelement'/>
+  <interface name='HTMLOrSVGElement' href='https://html.spec.whatwg.org/multipage/dom.html#htmlorsvgelement'/>
+  <interface name='HTMLVideoElement' href='https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement'/>
+  <interface name='HTMLElement' href='https://html.spec.whatwg.org/multipage/dom.html#htmlelement'/>
   <interface name='LinkStyle' href='https://www.w3.org/TR/cssom-1/#the-linkstyle-interface'/>
   <interface name='Node' href='https://www.w3.org/TR/2014/WD-dom-20140204/#node'/>
   <interface name='NodeList' href='https://www.w3.org/TR/2014/WD-dom-20140204/#nodelist'/>
   <interface name='RGBColor' href='https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-RGBColor'/>
   <interface name='ViewCSS' href='https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-ViewCSS'/>
-  <interface name='Window' href='https://www.w3.org/TR/html5/browsers.html#the-window-object'/>
-  <interface name='WindowEventHandlers' href='https://www.w3.org/TR/html5/webappapis.html#windoweventhandlers'/>
+  <interface name='Window' href='https://html.spec.whatwg.org/multipage/window-object.html#window'/>
+  <interface name='WindowEventHandlers' href='https://html.spec.whatwg.org/multipage/webappapis.html#windoweventhandlers'/>
   <interface name='Animation' href='https://www.w3.org/TR/web-animations-1/#the-animation-interface' />
 
   <!-- ... terms .......................................................... -->

--- a/master/refs.html
+++ b/master/refs.html
@@ -109,6 +109,9 @@
   <dt id="ref-filter-effects-1" class="normref">[<a href="https://www.w3.org/TR/filter-effects-1/">filter-effects-1</a>]</dt>
   <dd><div>Dean Jackson; Erik Dahlström; Dirk Schulze. <a href="https://www.w3.org/TR/filter-effects-1/"><cite>Filter Effects Module Level 1</cite></a>. 25 November 2014. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/filter-effects-1/">https://www.w3.org/TR/filter-effects-1/</a> ED:&nbsp;<a href="http://dev.w3.org/fxtf/filters/">http://dev.w3.org/fxtf/filters/</a></div></dd>
 
+  <dt id="ref-html" class="normref">[<a href="https://html.spec.whatwg.org/multipage/">HTML</a>]</dt>
+  <dd><div>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Living Standard. URL:&nbsp;<a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a></div></dd>
+ 
   <dt id="ref-html51" class="normref">[<a href="https://www.w3.org/TR/html51/">html51</a>]</dt>
   <dd><div>Steve Faulkner; Arron Eicholz; Travis Leithead; Alex Danilo. <a href="https://www.w3.org/TR/html51/"><cite>HTML 5.1</cite></a>. 21 June 2016. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/html51/">https://www.w3.org/TR/html51/</a> ED:&nbsp;<a href="https://w3c.github.io/html/">https://w3c.github.io/html/</a></div></dd>
 

--- a/master/types.html
+++ b/master/types.html
@@ -1584,8 +1584,8 @@ or a property.  The way this reflection is done depends on the type of the IDL a
 <ul>
   <li>If the type of the reflecting IDL attribute is a
   <a href="http://heycam.github.io/webidl/#dfn-primitive-type">primitive type</a> (such as
-  <b>long</b>, as used by tabIndex 
-  on <a>SVGElement</a>) or <b>DOMString</b> (as used by
+  <b>long</b>, as used by <a href="https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex">tabIndex</a> 
+   on <a>SVGElement</a>) or <b>DOMString</b> (as used by
   <a href="styling.html#__svg__SVGStyleElement__title">title</a> on <a>SVGStyleElement</a>),
   then the rules for
   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#reflect">reflecting

--- a/master/types.html
+++ b/master/types.html
@@ -225,18 +225,13 @@ interface <b>SVGElement</b> : <a>Element</a> {
 
   [SameObject] readonly attribute <a>SVGAnimatedString</a> <a href="types.html#__svg__SVGElement__className">className</a>;
 
-  [SameObject] readonly attribute <a>DOMStringMap</a> <a href="types.html#__svg__SVGElement__dataset">dataset</a>;
-
   readonly attribute <a>SVGSVGElement</a>? <a href="types.html#__svg__SVGElement__ownerSVGElement">ownerSVGElement</a>;
   readonly attribute <a>SVGElement</a>? <a href="types.html#__svg__SVGElement__viewportElement">viewportElement</a>;
-
-  attribute long <a href="types.html#__svg__SVGElement__tabIndex">tabIndex</a>;
-  void <a href="types.html#__svg__SVGElement__focus">focus</a>();
-  void <a href="types.html#__svg__SVGElement__blur">blur</a>();
 };
 
 <a>SVGElement</a> includes <a>GlobalEventHandlers</a>;
-<a>SVGElement</a> includes <a>SVGElementInstance</a>;</pre>
+<a>SVGElement</a> includes <a>SVGElementInstance</a>;
+<a>SVGElement</a> includes <a>HTMLOrSVGElement</a></pre>
 
 <p>The <b id="__svg__SVGElement__className">className</b> IDL attribute
 <a>reflects</a> the <a>'class'</a> attribute.</p>
@@ -251,13 +246,6 @@ attribute on <a>SVGElement</a> overrides the correspond attribute on
 <a href="https://www.w3.org/TR/WebIDL/#dfn-inherit">inheritance</a>.</p>
 </div>
 
-<div class='ready-for-wider-review'>
-<p>The <b id="__svg__SVGElement__dataset">dataset</b> IDL attribute
-provides access to <a href="struct.html#DataAttributes">custom data attributes</a>
-on the element.  Its behavior is the same as the corresponding IDL
-member on the <a>HTMLElement</a> interface.</p>
-</div>
-
 <p>The <b id="__svg__SVGElement__ownerSVGElement">ownerSVGElement</b> IDL attribute
 represents the nearest ancestor <a>'svg'</a> element.  On getting
 <a href="#__svg__SVGElement__ownerSVGElement">ownerSVGElement</a>,
@@ -269,24 +257,6 @@ represents the element that provides the SVG viewport for the current element.  
 <a href="#__svg__SVGElement__viewportElement">viewport</a>,
 the nearest ancestor element that establishes an SVG viewport is returned; if the current
 element is the <a>outermost svg element</a>, then null is returned.</p>
-
-<p>The <b id="__svg__SVGElement__tabIndex">tabIndex</b> IDL attribute and
-the <b id="__svg__SVGElement__focus">focus</b> and
-<b id="__svg__SVGElement__blur">blur</b> methods are used to control
-focus on SVG elements in the document.  Their behavior is the same as the
-corresponding IDL members on the <a>HTMLElement</a> interface.</p>
-
-<p class="note">As in HTML documents, the use of the
-<a href="#__svg__SVGElement__blur">blur</a> method is discouraged.  Authors
-are recommended to focus another element instead.</p>
-
-<p class="note">Authors are strongly suggested not to use the
-<a href="#__svg__SVGElement__blur">blur</a> method or any
-other technique to hide the focus ring from keyboard users, such as
-using a CSS rule to override the <a>'outline'</a> property.
-Removal of the focus ring leads to serious accessibility issues for users who
-navigate and interact with interactive content using the keyboard.</p>
-
 
 <h3 id="InterfaceSVGGraphicsElement">Interface SVGGraphicsElement</h3>
 
@@ -1614,8 +1584,8 @@ or a property.  The way this reflection is done depends on the type of the IDL a
 <ul>
   <li>If the type of the reflecting IDL attribute is a
   <a href="http://heycam.github.io/webidl/#dfn-primitive-type">primitive type</a> (such as
-  <b>long</b>, as used by <a href="types.html#__svg__SVGElement__tabIndex">tabIndex</a>
-  on <a>SVGElement</a>) or <b>DOMString</b> (as used by
+  <b>long</b>, as used by <a href="types.html#__svg__SVGNameList__numberOfItems">numberOfItems</a>
+  on <a>SVGNumberList</a>) or <b>DOMString</b> (as used by
   <a href="styling.html#__svg__SVGStyleElement__title">title</a> on <a>SVGStyleElement</a>),
   then the rules for
   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#reflect">reflecting

--- a/master/types.html
+++ b/master/types.html
@@ -1584,7 +1584,8 @@ or a property.  The way this reflection is done depends on the type of the IDL a
 <ul>
   <li>If the type of the reflecting IDL attribute is a
   <a href="http://heycam.github.io/webidl/#dfn-primitive-type">primitive type</a> (such as
-  <b>DOMString</b> (as used by
+  <b>long</b>, as used by tabIndex 
+  on <a>SVGElement</a>) or <b>DOMString</b> (as used by
   <a href="styling.html#__svg__SVGStyleElement__title">title</a> on <a>SVGStyleElement</a>),
   then the rules for
   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#reflect">reflecting

--- a/master/types.html
+++ b/master/types.html
@@ -231,7 +231,7 @@ interface <b>SVGElement</b> : <a>Element</a> {
 
 <a>SVGElement</a> includes <a>GlobalEventHandlers</a>;
 <a>SVGElement</a> includes <a>SVGElementInstance</a>;
-<a>SVGElement</a> includes <a>HTMLOrSVGElement</a></pre>
+<a>SVGElement</a> includes <a>HTMLOrSVGElement</a>;</pre>
 
 <p>The <b id="__svg__SVGElement__className">className</b> IDL attribute
 <a>reflects</a> the <a>'class'</a> attribute.</p>
@@ -1584,8 +1584,7 @@ or a property.  The way this reflection is done depends on the type of the IDL a
 <ul>
   <li>If the type of the reflecting IDL attribute is a
   <a href="http://heycam.github.io/webidl/#dfn-primitive-type">primitive type</a> (such as
-  <b>long</b>, as used by <a href="types.html#__svg__SVGNameList__numberOfItems">numberOfItems</a>
-  on <a>SVGNumberList</a>) or <b>DOMString</b> (as used by
+  <b>DOMString</b> (as used by
   <a href="styling.html#__svg__SVGStyleElement__title">title</a> on <a>SVGStyleElement</a>),
   then the rules for
   <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#reflect">reflecting


### PR DESCRIPTION
Fixes #60 
Remove definiion of dataset/focus/blur/tabIndex and include mixin from HTML instead.

I've kept the content attribute definition of tabindex until we figure out what to do with the reflecting content attributes that pair with IDL attributes in mixins.