### PR TITLE
Keep the linting minions happy

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -736,8 +736,8 @@ have been made.</p>
   <li>Removed the <span class='attr-name'>'xlink:type'</span>, <span class='attr-name'>'xlink:role'</span>, <span class='attr-name'>'xlink:arcrole'</span>, <span class='attr-name'>'xlink:show'</span> and <span class='attr-name'>'xlink:actuate'</span> attributes.</li>
   <li>Deprecated the <a>'xlink:href'</a> attribute in favor of using <span
    class="attr-name">'href'</span> without a namespace.
+    <h4>Tests:</h4>
     <ul>
-      Tests:
       <li><a href="https://github.com/w3c/web-platform-tests/blob/master/svg/linking/reftests/href-feImage-element.html">feImage</a></li>
       <li><a href="https://github.com/w3c/web-platform-tests/blob/master/svg/linking/reftests/href-filter-element.html">filter</a></li>
       <li><a href="https://github.com/w3c/web-platform-tests/blob/master/svg/linking/reftests/href-gradient-element.html">gradient</a></li>
@@ -745,7 +745,9 @@ have been made.</p>
       <li><a href="https://github.com/w3c/web-platform-tests/blob/master/svg/linking/reftests/href-pattern-element.html">pattern</a></li>
       <li><a href="https://github.com/w3c/web-platform-tests/blob/master/svg/linking/reftests/href-textPath-element.html">textPath</a></li>
       <li><a href="https://github.com/w3c/web-platform-tests/blob/master/svg/linking/reftests/href-use-element.html">use</a></li>
-      Actions:
+    </ul>
+    <h4>Actions:</h4>
+    <ul>
       <li><a href="https://github.com/w3c/svgwg/issues/362">Convert SVG linking reftests to .svg files</a></li>
     </ul>
   </li>

--- a/master/styling.html
+++ b/master/styling.html
@@ -418,6 +418,7 @@ the presentation attribute name is the same as the property name, in lower-case 
             <a>'linearGradient/gradientTransform'</a> gets mapped to the <a>'transform'</a>
             CSS property [<a href='refs.html#ref-css-transforms-1'>css-transforms-1</a>].
         </dd>
+      </dl>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
Fixes all the linting issues except text content in an iframe. It looks like according to the HTML spec, fallback content is never allowed. I didn't want to just strip the text out as it is part of the example.