### PR TITLE
Add or update dfns for definitions

### DIFF
--- a/master/coords.html
+++ b/master/coords.html
@@ -21,16 +21,16 @@
 <div class="ready-for-wider-review">
 
 <p>All SVG content is drawn inside
-<dfn data-dfn-type="dfn" id="TermSVGViewport">SVG viewports</dfn>.
+<dfn id="TermSVGViewport" data-dfn-type="dfn" data-dfn-export>SVG viewports</dfn>.
 Every SVG viewport defines a drawing region characterized by a size 
 (width, height), and an origin, measured in abstract 
-<dfn data-dfn-type="dfn" id="TermUserUnits">user units</dfn>.</p>
+<dfn id="TermUserUnits" data-dfn-type="dfn" data-dfn-export>user units</dfn>.</p>
 
 <p class="note">Note that the term SVG viewport is distinct from the 
 <a href="https://www.w3.org/TR/2011/REC-CSS2-20110607/visuren.html#viewport">"viewport"</a>
 term used in CSS.</p> 
 
-<p>The <dfn data-dfn-type="dfn">initial viewport</dfn> is a top-level
+<p>The <dfn id="TermInitialViewport" data-dfn-type="dfn" data-dfn-export>initial viewport</dfn> is a top-level
 SVG viewport that establishes a mapping between the coordinate system used
 by the containing environment (for example, CSS pixels in web browsers)
 and <a>user units</a>. Establishing an initial viewport is described in more
@@ -41,8 +41,8 @@ detail in <a href="#ViewportSpace">The initial viewport</a>.</p>
 on which elements generate viewports.</p>
 
 <p>Each SVG viewport generates a 
-<dfn data-dfn-type="dfn" id="TermViewportCoordinateSystem">viewport coordinate system</dfn>
-and a <dfn data-dfn-type="dfn">local coordinate system</dfn>, initially identical.
+<dfn id="TermViewportCoordinateSystem" data-dfn-type="dfn" data-dfn-export>viewport coordinate system</dfn>
+and a <dfn id="TermLocalCoordinateSystem" data-dfn-type="dfn" data-dfn-export>local coordinate system</dfn>, initially identical.
 Providing a <a>'viewBox'</a> on a viewport's element transforms the local coordinate system 
 relative to the viewport coordinate system as described in
 The <a>'viewBox'</a> attribute. Child elements of a viewport can
@@ -67,7 +67,7 @@ element. However, a <a>'transform'</a> property on an SVG viewport's element wil
 the <a>viewport coordinate system</a> relative to the parent element's local coordinate system.</p>
 
 <p>Abstractly, all SVG viewports are embedded in the
-<dfn data-dfn-type="dfn" id="TermCanvas">canvas</dfn>,
+<dfn id="TermCanvas" data-dfn-type="dfn" data-dfn-export>canvas</dfn>,
 a drawing region that is infinitely large in all relevant dimensions.</p>
 
 <h2 id="ComputingAViewportsTransform">Computing the equivalent transform of an SVG viewport</h2>
@@ -243,7 +243,7 @@ as defined in [<a href="refs.html#ref-css-transforms-1">css-transforms-1</a>].</
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn data-dfn-type="element-attr" data-dfn-for="svg">viewBox</dfn></td>
+        <td><dfn id="TermViewBox" data-dfn-type="element-attr" data-dfn-for="svg" data-dfn-export>viewBox</dfn></td>
         <td>[<span class="attr-value">&lt;min-x&gt;</span>,?
             <span class="attr-value">&lt;min-y&gt;</span>,?
             <span class="attr-value">&lt;width&gt;</span>,?
@@ -440,7 +440,7 @@ attribute</h2>
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn data-dfn-type="element-attr" data-dfn-for="svg">preserveAspectRatio</dfn></td>
+        <td><dfn id="TermPreserveAspectRatio" data-dfn-type="element-attr" data-dfn-for="svg" data-dfn-export>preserveAspectRatio</dfn></td>
         <td><span class="attr-value">&lt;align&gt;</span> <span class="attr-value">&lt;meetOrSlice&gt;</span>?</td>
         <td>xMidYMid meet</td>
         <td>yes</td>
@@ -821,9 +821,9 @@ values specified in percentage units are scaled.</p>
 
 <h2 id="BoundingBoxes">Bounding boxes</h2>
 
-<dl class='definitions'  data-dfn-type="dfn" data-export="">
+<dl class='definitions' data-dfn-type="dfn" data-dfn-export="">
 
-  <dt id="TermBoundingBox"><dfn id="bounding-box">bounding box</dfn></dt>
+  <dt id="TermBoundingBox"><dfn id="bounding-box" data-dfn-type="dfn" data-dfn-export>bounding box</dfn></dt>
   <dd>
       <p>The bounding box (or "bbox") of an element is the tightest fitting rectangle
       aligned with the axes of that element's user coordinate system that entirely
@@ -834,15 +834,15 @@ values specified in percentage units are scaled.</p>
 <p>Three kinds of bounding boxes can be computed for an element:</p>
 
 <ol>
-  <li>The <dfn id="TermObjectBoundingBox" data-dfn-type="dfn" data-export="">object bounding box</dfn> is the bounding box that contains only
+  <li>The <dfn id="TermObjectBoundingBox" data-dfn-type="dfn" data-dfn-export>object bounding box</dfn> is the bounding box that contains only
   an element's geometric shape.  For <a>basic shapes</a>, this is the area
   that is filled.  Unless otherwise specified, this is what is meant by the
   unqualified term "bounding box".</li>
 
-  <li>The <dfn id="TermStrokeBoundingBox" data-dfn-type="dfn" data-export="">stroke bounding box</dfn> is the bounding box that contains
+  <li>The <dfn id="TermStrokeBoundingBox" data-dfn-type="dfn" data-dfn-export>stroke bounding box</dfn> is the bounding box that contains
   an element's geometric shape and its <a>stroke shape</a>.</li>
 
-  <li>The <dfn id="TermDecoratedBoundingBox" data-dfn-type="dfn" data-export="">decorated bounding box</dfn> is the bounding box that contains
+  <li>The <dfn id="TermDecoratedBoundingBox" data-dfn-type="dfn" data-dfn-export>decorated bounding box</dfn> is the bounding box that contains
   an element's geometric shape, its <a>stroke shape</a> and its <a>markers</a>.</li>
 </ol>
 
@@ -926,7 +926,7 @@ does not contribute to the bounding box of any ancestor element.</p>
 calculation, each glyph must be treated as a separate graphics element.
 The calculations must assume that all glyphs occupy the <a>full glyph cell</a>.
 <span class='ready-for-wider-review'>
-The <dfn id="TermFullGlyphCell">full glyph cell</dfn> must have width
+The <dfn id="TermFullGlyphCell" data-dfn-type="dfn" data-dfn-export>full glyph cell</dfn> must have width
 equal to the horizontal advance and height equal to the EM box for horizontal
 text. For vertical text that is typeset sideways, the <a>full glyph cell</a> must 
 have width equal to the EM box and height equal to the horizontal advance.
@@ -1452,7 +1452,7 @@ through this property.</p>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="VectorEffectProperty">vector-effect</dfn></td>
+    <td><dfn id="VectorEffectProperty" data-dfn-type="property" data-dfn-export>vector-effect</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -3216,9 +3216,9 @@ two modes.  It can:</p>
 
 <p>An <a>SVGTransform</a> object maintains an internal
 <a href='https://drafts.csswg.org/css-transforms-1/#typedef-transform-function'>&lt;transform-function&gt;</a>
-value, which is called its <dfn id="TransformValue">value</dfn>.
+value, which is called its <dfn id="TransformValue" data-dfn-type="dfn">value</dfn>.
 It also maintains a <a>DOMMatrix</a> object,
-which is called its <dfn id="TransformMatrixObject">matrix object</dfn>,
+which is called its <dfn id="TransformMatrixObject" data-dfn-type="dfn" data-dfn-export>matrix object</dfn>,
 which is the object returned from the <a href="#__svg__SVGTransform__matrix">matrix</a>
 IDL attribute.  An <a>SVGTransform</a> object's
 <a href="#TransformMatrixObject">matrix object</a>

--- a/master/embedded.html
+++ b/master/embedded.html
@@ -57,7 +57,7 @@ This is the same definition as <a href="https://www.w3.org/TR/html51/">HTML's</a
 
   <p>
     The <a>'x'</a>, <a>'y'</a>, <a>'width'</a>, and <a>'height'</a> geometry properties specify the rectangular region into which the embedded content is positioned
-    (the <dfn id="TermPositioningRectangle">positioning rectangle</dfn>).
+    (the <dfn id="TermPositioningRectangle"  data-dfn-type="dfn" data-dfn-export>positioning rectangle</dfn>).
     The <a>positioning rectangle</a> is used as the bounding box of the element;
     note, however, that graphics may overflow the positioning rectangle,
     depending on the value of the <a>'overflow'</a> property.
@@ -169,7 +169,7 @@ and the alpha channel is uniformly set to 1.</p>
 determines how the referenced image is scaled and positioned to fit
 into the <a>concrete object size</a> determined from the
 <a>positioning rectangle</a> and the <a>'object-fit'</a> and <a>'object-position'</a> properties.
-The result of applying this attribute defines an <dfn id="TermImageRenderingRectangle">image-rendering rectangle</dfn>
+The result of applying this attribute defines an <dfn id="TermImageRenderingRectangle"  data-dfn-type="dfn" data-dfn-export>image-rendering rectangle</dfn>
 used for actual image rendering.
 When the referenced image is an SVG,
 the <a>image-rendering rectangle</a> defines
@@ -364,7 +364,7 @@ elements within an SVG file.</p>
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn data-dfn-type="element-attr" data-dfn-for="image" id="ImageElementCrossoriginAttribute">crossorigin</dfn></td>
+        <td><dfn id="ImageElementCrossoriginAttribute" data-dfn-type="element-attr" data-dfn-for="image" data-dfn-export>crossorigin</dfn></td>
         <td>[ anonymous | use-credentials ]?</td>
         <td>(see HTML definition of attribute)</td>
         <td>yes</td>
@@ -383,7 +383,7 @@ elements within an SVG file.</p>
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn data-dfn-type="element-attr" data-dfn-for="image" id="ImageElementHrefAttribute">href</dfn></td>
+        <td><dfn id="ImageElementHrefAttribute" data-dfn-type="element-attr" data-dfn-for="image" data-dfn-export>href</dfn></td>
         <td>URL <a href="types.html#attribute-url" class="syntax">[URL]</a></td>
         <td>(none)</td>
         <td>yes</td>

--- a/master/geometry.html
+++ b/master/geometry.html
@@ -18,7 +18,7 @@
 <h1>Geometry Properties</h1>
 
 <p>Beside SVG's styling properties, SVG also defines
-<dfn id='geometry-properties'>geometry properties</dfn>. Geometry properties
+<dfn id='geometry-properties' data-dfn-type="dfn" data-dfn-export>geometry properties</dfn>. Geometry properties
 describe the position and dimension of the <a>graphics element</a>s <a>'circle'</a>,
 <a>'ellipse'</a>, <a>'rect'</a>, <a>'image'</a>, <a>'foreignObject'</a> and the
 <a>'svg'</a> element.</p>
@@ -28,7 +28,7 @@ describe the position and dimension of the <a>graphics element</a>s <a>'circle'<
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="CxProperty">cx</dfn></td>
+    <td><dfn id="CxProperty" data-dfn-type="property" data-dfn-export>cx</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -74,7 +74,7 @@ property</h2>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="CyProperty">cy</dfn></td>
+    <td><dfn id="CyProperty" data-dfn-type="property" data-dfn-export>cy</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -119,7 +119,7 @@ of the position of the element. </p>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="RProperty">r</dfn></td>
+    <td><dfn id="RProperty" data-dfn-type="property" data-dfn-export>r</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -166,7 +166,7 @@ property</h2>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="RxProperty">rx</dfn></td>
+    <td><dfn id="RxProperty" data-dfn-type="property" data-dfn-export>rx</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -224,7 +224,7 @@ property</h2>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="RyProperty">ry</dfn></td>
+    <td><dfn id="RyProperty" data-dfn-type="property" data-dfn-export>ry</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -281,7 +281,7 @@ property</h2>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="XProperty">x</dfn></td>
+    <td><dfn id="XProperty" data-dfn-type="property" data-dfn-export>x</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -327,7 +327,7 @@ property</h2>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="YProperty">y</dfn></td>
+    <td><dfn id="YProperty" data-dfn-type="property" data-dfn-export>y</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>

--- a/master/interact.html
+++ b/master/interact.html
@@ -358,9 +358,9 @@ then the event is ignored.</p>
 
 <h2 id="pointer-processing">Hit-testing and processing order for user interface events</h2>
 
-<dl class='definitions'  data-dfn-type="dfn" data-export="">
+<dl class="definitions">
 
-  <dt id="TermHitTesting">hit-testing</dt>
+  <dt><dfn id="TermHitTesting" data-dfn-type="dfn" data-dfn-export>hit-testing</dfn></dt>
   <dd>The process of determining whether a pointer intersects a given
   <a>graphics element</a>.  Hit-testing is used in determining which element
   to dispatch a mouse event to, which might be done in response to the user
@@ -515,7 +515,7 @@ the circumstances under which the following are processed:</p>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="PointerEventsProperty">pointer-events</dfn></td>
+    <td><dfn id="PointerEventsProperty" data-dfn-type="property" data-dfn-export>pointer-events</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -755,7 +755,7 @@ and is unlikely to be implemented. See
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn data-dfn-type="element-attr" data-dfn-for="cursor" id="ZoomAndPanAttribute">zoomAndPan</dfn></td>
+        <td><dfn id="ZoomAndPanAttribute" data-dfn-type="element-attr" data-dfn-for="cursor">zoomAndPan</dfn></td>
         <td>[ disable | magnify ]</td>
         <td>disable</td>
         <td>no</td>
@@ -857,7 +857,7 @@ and the offset from the image dimensions to the active cursor point.</p>
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn data-dfn-type="element-attr" data-dfn-for="cursor" id="CursorElementXAttribute">x</dfn>, <dfn data-dfn-type="element-attr" data-dfn-for="cursor" id="CursorElementYAttribute">y</dfn></td>
+        <td><dfn id="CursorElementXAttribute" data-dfn-type="element-attr" data-dfn-for="cursor" data-dfn-export>x</dfn>, <dfn id="CursorElementYAttribute" data-dfn-type="element-attr" data-dfn-for="cursor" data-dfn-export>y</dfn></td>
         <td><a>&lt;length&gt;</a></td>
         <td>0</td>
         <td>yes</td>
@@ -879,7 +879,7 @@ and the offset from the image dimensions to the active cursor point.</p>
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn id="CursorElementHrefAttribute">href</dfn></td>
+        <td><dfn id="CursorElementHrefAttribute" data-dfn-type="element-attr" data-dfn-for="cursor" data-dfn-export>href</dfn></td>
         <td>URL <a href="types.html#attribute-url" class="syntax">[URL]</a></td>
         <td>(none)</td>
         <td>yes</td>
@@ -927,7 +927,7 @@ and the offset from the image dimensions to the active cursor point.</p>
     but should not use it to remove visual indications of focus completely.
 </p>
 <p>
-    The following SVG elements are <dfn id="TermFocusable">focusable</dfn>
+    The following SVG elements are <dfn id="TermFocusable" data-dfn-type="dfn" data-dfn-export>focusable</dfn>
     in an interactive document.
     Any <a>instance</a> of such an element in a <a>use-element shadow tree</a>
     is also focusable.
@@ -1038,8 +1038,8 @@ attribute.</p>
 
 <h2 id="EventAttributes">Event attributes</h2>
 
-  <dl class='definitions'  data-dfn-type="dfn" data-export="">
-    <dt id="TermEventAttribute">event attribute</dt>
+  <dl class='definitions'>
+    <dt><dfn id="TermEventAttribute" data-dfn-type="dfn" data-dfn-export>event attribute</dfn></dt>
     <dd>An event attribute always has a name that starts with "on" followed by the name of the event for which it is intended.
     It specifies some script to run when the event of the given type is dispatched to the element on which the attribute
     is specified.</dd>
@@ -1074,9 +1074,9 @@ attribute.</p>
         </tr>
         <tr>
           <td>
-            <dfn id="OnBeginEventAttribute">onbegin</dfn>,
-            <dfn id="OnEndEventAttribute">onend</dfn>,
-            <dfn id="OnRepeatEventAttribute">onrepeat</dfn>
+            <dfn id="OnBeginEventAttribute" data-dfn-type="element-attr" data-dfn-for="animate, animateMotion, animateTransform, discard, set" data-dfn-export>onbegin</dfn>,
+            <dfn id="OnEndEventAttribute" data-dfn-type="element-attr" data-dfn-for="animate, animateMotion, animateTransform, discard, set" data-dfn-export>onend</dfn>,
+            <dfn id="OnRepeatEventAttribute" data-dfn-type="element-attr" data-dfn-for="animate, animateMotion, animateTransform, discard, set" data-dfn-export>onrepeat</dfn>
           </td>
           <td>(see below)</td>
           <td>(none)</td>
@@ -1226,7 +1226,7 @@ attribute.</p>
           <th>Animatable</th>
         </tr>
         <tr>
-          <td><dfn data-dfn-type="element-attr" data-dfn-for="script" id="ScriptElementCrossoriginAttribute">crossorigin</dfn></td>
+          <td><dfn id="ScriptElementCrossoriginAttribute" data-dfn-type="element-attr" data-dfn-for="script" data-dfn-export>crossorigin</dfn></td>
           <td>[ anonymous | use-credentials ]?</td>
           <td>(see HTML definition of attribute)</td>
           <td>yes</td>
@@ -1245,7 +1245,7 @@ attribute.</p>
           <th>Animatable</th>
         </tr>
         <tr>
-          <td><dfn id="ScriptElementTypeAttribute">type</dfn></td>
+          <td><dfn id="ScriptElementTypeAttribute" data-dfn-type="element-attr" data-dfn-for="script" data-dfn-export>type</dfn></td>
           <td>(see below)</td>
           <td>application/ecmascript</td>
           <td>no</td>
@@ -1270,7 +1270,7 @@ attribute.</p>
           <th>Animatable</th>
         </tr>
         <tr>
-          <td><dfn id="ScriptElementHrefAttribute">href</dfn></td>
+          <td><dfn id="ScriptElementHrefAttribute" data-dfn-type="element-attr" data-dfn-for="script" data-dfn-export>href</dfn></td>
           <td>URL <a href="types.html#attribute-url" class="syntax">[URL]</a></td>
           <td>(none)</td>
           <td>no</td>

--- a/master/linking.html
+++ b/master/linking.html
@@ -57,9 +57,9 @@ on the scripting context when a <a>'script'</a> element's
 -->
 
 <h3 id="definitions">Definitions</h3>
-<dl class='definitions'  data-dfn-type="dfn" data-export="">
+<dl class='definitions'>
 
-  <dt id="TermURLReference">URL reference</dt>
+  <dt><dfn id="TermURLReference" data-dfn-type="dfn" data-dfn-export>URL reference</dfn></dt>
   <dd>An URL reference is an Internationalized Resource Identifier, as defined in
   <a href="http://www.ietf.org/rfc/rfc3987.txt"><cite>Internationalized Resource Identifiers</cite></a>
   [<a href='refs.html#ref-rfc3987'>rfc3987</a>]. See
@@ -67,23 +67,23 @@ on the scripting context when a <a>'script'</a> element's
   <a href="struct.html#Head">References and the
   <span class="element-name">'defs'</span> element</a>.</dd>
 
-  <dt id="TermURLReferenceWithFragmentIdentifier">URL reference with fragment identifier</dt>
+  <dt><dfn id="TermURLReferenceWithFragmentIdentifier" data-dfn-type="dfn" data-dfn-export>URL reference with fragment identifier</dfn></dt>
   <dd>An Internationalized Resource Identifier [<a href="refs.html#ref-rfc3987">rfc3987</a>] that
   can include an &lt;absoluteURL&gt; or
   &lt;relativeURL&gt; and a identifier of the fragment in that resource. See <a href="struct.html#Head">References and the
   <span class="element-name">'defs'</span> element</a>. URL reference with fragment identifiers are commonly used to reference <a href="pservers.html">paint servers</a>.</dd>
   
-  <dt id="TermExternalReference">external file reference</dt>
+  <dt><dfn id="TermExternalReference" data-dfn-type="dfn" data-dfn-export>external file reference</dfn></dt>
   <dd>A <a>URL reference</a> or <a>URL reference with fragment identifier</a>
     which refers to a resource that is not part of the current document.
   </dd>
   
-  <dt id="TermSameDocumentURL">same-document URL reference</dt>
+  <dt><dfn id="TermSameDocumentURL" data-dfn-type="dfn" data-dfn-export>same-document URL reference</dfn></dt>
   <dd>A <a>URL reference with fragment identifier</a>
     where the non-fragment part of the URL refers to the current document.
   </dd>
   
-  <dt id="TermDataURL">data URL</dt>
+  <dt><dfn id="TermDataURL" data-dfn-type="dfn" data-dfn-export>data URL</dfn></dt>
   <dd>A <a>URL reference</a> to an embedded document
     specified using the <a href="http://www.ietf.org/rfc/rfc2397.txt">"data" URL scheme</a>
   [<a href="refs.html#ref-rfc2397">rfc2397</a>].
@@ -91,19 +91,19 @@ on the scripting context when a <a>'script'</a> element's
     <a>external file references</a> nor <a>same-document URL references</a>.
   </dd>
 
-  <dt id="TermCircularReference">circular reference</dt>
+  <dt><dfn id="TermCircularReference" data-dfn-type="dfn" data-dfn-export>circular reference</dfn></dt>
   <dd><a href="#TermURLReference">URL references</a> that directly or indirectly reference
   themselves are treated as invalid circular references.
     What constitutes a circular reference will depend on how the referenced resource is used,
     and may include a reference to an ancestor of the current element.
   </dd> 
   
-  <dt id="TermUnresolvedReference">unresolved reference</dt>
+  <dt><dfn id="TermUnresolvedReference" data-dfn-type="dfn" data-dfn-export>unresolved reference</dfn></dt>
   <dd>A reference that is still being processed,
     and has not yet resulted in either an error or an identified resource.
   </dd>
 
-  <dt id="TermInvalidReference">invalid reference</dt>
+  <dt><dfn id="TermInvalidReference" data-dfn-type="dfn" data-dfn-export>invalid reference</dfn></dt>
   <dd>
     <p>Any of the following are invalid references:</p>
     <ul>
@@ -259,7 +259,7 @@ been deprecated.</p>
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn id="XLinkHrefAttribute">xlink:href</dfn></td>
+        <td><dfn id="XLinkHrefAttribute" data-dfn-type="element-attr" data-dfn-for="a, cursor, hatch, image, linearGradient, meshGradient, mesh, pattern, radialGradient, script, textPath, use" data-dfn-export>xlink:href</dfn></td>
         <td>URL <a href="types.html#attribute-url" class="syntax">[URL]</a></td>
         <td>(none)</td>
         <td>(see below)</td>
@@ -295,7 +295,7 @@ been deprecated.</p>
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn id="XLinkTitleAttribute">xlink:title</dfn></td>
+        <td><dfn id="XLinkTitleAttribute" data-dfn-type="element-attr" data-dfn-for="a, cursor, hatch, image, linearGradient, meshGradient, mesh, pattern, radialGradient, script, textPath, use" data-dfn-export>xlink:title</dfn></td>
         <td>&lt;anything&gt;</td>
         <td>(none)</td>
         <td>no</td>
@@ -772,7 +772,7 @@ or frame to be replaced by the W3C home page.</p>
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn id="AElementHrefAttribute">href</dfn></td>
+        <td><dfn id="AElementHrefAttribute" data-dfn-type="element-attr" data-dfn-for="a" data-dfn-export>href</dfn></td>
         <td>URL <a href="types.html#attribute-url" class="syntax">[URL]</a></td>
         <td>(none)</td>
         <td>yes</td>
@@ -793,7 +793,7 @@ or frame to be replaced by the W3C home page.</p>
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn id="AElementTargetAttribute">target</dfn></td>
+        <td><dfn id="AElementTargetAttribute" data-dfn-type="element-attr" data-dfn-for="a" data-dfn-export>target</dfn></td>
         <td> _self | _parent | _top | _blank | &lt;XML-Name&gt;</td>
         <td>_self</td>
         <td>yes</td>
@@ -873,25 +873,25 @@ or frame to be replaced by the W3C home page.</p>
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn id="AElementDownloadAttribute">download</dfn></td>
+        <td><dfn id="AElementDownloadAttribute" data-dfn-type="element-attr" data-dfn-for="a" data-dfn-export>download</dfn></td>
         <td>any value (meaning is conveyed by presence or absence of attribute)</td>
         <td>(none)</td>
         <td>no</td>
       </tr>
       <tr>
-        <td><dfn id="AElementRelAttribute">rel</dfn></td>
+        <td><dfn id="AElementRelAttribute" data-dfn-type="element-attr" data-dfn-for="a" data-dfn-export>rel</dfn></td>
         <td>space-separated keyword tokens <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#set-of-space-separated-tokens" class="syntax">[HTML]</a></td>
         <td>(none)</td>
         <td>yes</td>
       </tr>
       <tr>
-        <td><dfn id="AElementHreflangAttribute">hreflang</dfn></td>
+        <td><dfn id="AElementHreflangAttribute" data-dfn-type="element-attr" data-dfn-for="a" data-dfn-export>hreflang</dfn></td>
         <td>A BCP 47 language tag string <a href="https://html.spec.whatwg.org/multipage/semantics.html#attr-hyperlink-hreflang" class="syntax">[HTML]</a></td>
         <td>(none)</td>
         <td>yes</td>
       </tr>
       <tr>
-        <td><dfn id="AElementTypeAttribute">type</dfn></td>
+        <td><dfn id="AElementTypeAttribute" data-dfn-type="element-attr" data-dfn-for="a" data-dfn-export>type</dfn></td>
         <td>A MIME type string <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#mime-type" class="syntax">[HTML]</a></td>
         <td>(none)</td>
         <td>yes</td>
@@ -940,7 +940,7 @@ section of the document.</p>
 </div>
 
 <p>To link into a particular view of an SVG document, the <a href="#TermURLReferenceWithFragmentIdentifier">URL reference with fragment
-identifier</a> needs to be a correctly formed <dfn id='svg-fragment-identifier'>SVG
+identifier</a> needs to be a correctly formed <dfn id='svg-fragment-identifier' data-dfn-type="dfn" data-dfn-export>SVG
 fragment identifier</dfn>. An SVG fragment identifier defines the
 meaning of the "selector" or "fragment identifier" portion of URLs that
 locate resources of MIME media type "image/svg+xml".</p>
@@ -953,7 +953,7 @@ locate resources of MIME media type "image/svg+xml".</p>
   addressing, which allows addressing an SVG element by its ID, is compatible
   with the fragment addressing mechanism for older versions of HTML.</li>
 
-  <li id="SVGViewSpecification">An <dfn>SVG view specification</dfn>
+  <li>An <dfn id="SVGViewSpecification" data-dfn-type="dfn" data-dfn-export>SVG view specification</dfn>
   (e.g., <span class="attr-value">MyDrawing.svg#svgView(viewBox(0,200,1000,1000))</span>).
   This form of addressing specifies the desired view of the
   document (e.g., the region of the document to view, the

--- a/master/painting.html
+++ b/master/painting.html
@@ -22,14 +22,14 @@
 <h2 id="Introduction">Introduction</h2>
 
 <h3 id="Definitions">Definitions</h3>
-<dl class='definitions'  data-dfn-type="dfn" data-export="">
+<dl class="definitions">
 
-  <dt id="TermFill">fill</dt>
+  <dt><dfn id="TermFill" data-dfn-type="dfn" data-dfn-export>fill</dfn></dt>
   <dd>The operation of <a>painting</a> the interior of a
   <a>shape</a> or the interior of the
   character glyphs in a text string.</dd>
 
-  <dt id="TermStroke">stroke</dt>
+  <dt><dfn id="TermStroke" data-dfn-type="dfn" data-dfn-export>stroke</dfn></dt>
   <dd>The operation of <a>painting</a> the outline
   of a <a>shape</a> or the outline of
   character glyphs in a text string.</dd>
@@ -128,8 +128,8 @@ paint servers.</p>
 </div>
 
 <p>The <a>'fill'</a> and <a>'stroke'</a> properties, defined below, are used to
-specify the <dfn id="TermPaint">paint</dfn> used to render the interior of and the
-stroke around shapes and text.  A paint specification describes a way of putting
+specify the <dfn id="TermPaint" data-dfn-type="dfn" data-dfn-export>paint</dfn> used to render the interior of and the
+stroke around shapes and text. A paint specification describes a way of putting
 color values on to the canvas and is composed of one or more paint layers.
 Four types of paints within these paint layers are supported:
 <a href="https://www.w3.org/TR/css3-values/#colors">solid colors</a>,
@@ -139,7 +139,7 @@ and <a href="pservers.html#Hatches">hatches</a>.</p>
 
 <p>A <a>&lt;paint&gt;</a> value is defined as follows:</p>
 <p class="definition">
-<dfn id="DataTypePaint">&lt;paint&gt;</dfn>
+<dfn id="DataTypePaint" data-dfn-type="type" data-dfn-export>&lt;paint&gt;</dfn>
 = none
 | child
 | child(<a>&lt;integer&gt;</a>)
@@ -162,7 +162,7 @@ and <a href="pservers.html#Hatches">hatches</a>.</p>
   element being painted.</dd>
 
   <dt><a>&lt;url&gt;</a> [none | <a>&lt;color&gt;</a>]?</dt>
-  <dd>A URL reference to a <dfn id="TermPaintServerElement">paint server element</dfn>,
+  <dd>A URL reference to a <dfn id="TermPaintServerElement" data-dfn-type="dfn" data-dfn-export>paint server element</dfn>,
   which is an element that defines a <a href="pservers.html">paint server</a>:
   <edit:elementcategory name='paint server'/>, optionally followed by a fall-back
   value that is used if the paint server reference cannot be resolved.</dd>
@@ -239,7 +239,7 @@ the <span class='prop-value'>currentColor</span> value.</p>
 
 <p id="context-paint">The <span class='prop-value'>context-fill</span> and <span class='prop-value'>context-stroke</span>
 values are a reference to the paint layers generated for the <a>'fill'</a> or <a>'stroke'</a>
-property, respectively, of the <dfn id="TermContextElement">context element</dfn>
+property, respectively, of the <dfn id="TermContextElement" data-dfn-type="dfn" data-dfn-export>context element</dfn>
 of the element being painted.  The context element of an element is defined as follows:</p>
 
 <ul>
@@ -340,7 +340,7 @@ svg { border: 1px solid #888; background-color: #eee }
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="FillProperty">fill</dfn></td>
+    <td><dfn id="FillProperty" data-dfn-type="property" data-dfn-export>fill</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -398,7 +398,7 @@ property</h3>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="FillRuleProperty">fill-rule</dfn></td>
+    <td><dfn id="FillRuleProperty" data-dfn-type="property" data-dfn-export>fill-rule</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -496,7 +496,7 @@ property</h3>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="FillOpacityProperty">fill-opacity</dfn></td>
+    <td><dfn id="FillOpacityProperty" data-dfn-type="property" data-dfn-export>fill-opacity</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -612,7 +612,7 @@ property</h3>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="StrokeProperty">stroke</dfn></td>
+    <td><dfn id="StrokeProperty" data-dfn-type="property" data-dfn-export>stroke</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -694,7 +694,7 @@ property</h3>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="StrokeOpacityProperty">stroke-opacity</dfn></td>
+    <td><dfn id="StrokeOpacityProperty" data-dfn-type="property" data-dfn-export>stroke-opacity</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -758,7 +758,7 @@ property</h3>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="StrokeWidthProperty">stroke-width</dfn></td>
+    <td><dfn id="StrokeWidthProperty" data-dfn-type="property" data-dfn-export>stroke-width</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -804,7 +804,7 @@ property</h3>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="StrokeLinecapProperty">stroke-linecap</dfn></td>
+    <td><dfn id="StrokeLinecapProperty" data-dfn-type="property" data-dfn-export>stroke-linecap</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -891,7 +891,7 @@ and <span class="property">'stroke-miterlimit'</span> properties</h3>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="StrokeLinejoinProperty">stroke-linejoin</dfn></td>
+    <td><dfn id="StrokeLinejoinProperty" data-dfn-type="property" data-dfn-export>stroke-linejoin</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -992,7 +992,7 @@ the <a href="paths.html#PathElementImplementationNotes">path implementation note
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="StrokeMiterlimitProperty">stroke-miterlimit</dfn></td>
+    <td><dfn id="StrokeMiterlimitProperty" data-dfn-type="property" data-dfn-export>stroke-miterlimit</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -1170,7 +1170,7 @@ the <a href="paths.html#PathElementImplementationNotes">path implementation note
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="StrokeDasharrayProperty">stroke-dasharray</dfn></td>
+    <td><dfn id="StrokeDasharrayProperty" data-dfn-type="property" data-dfn-export>stroke-dasharray</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -1208,7 +1208,7 @@ the <a href="paths.html#PathElementImplementationNotes">path implementation note
 
 <p>where:</p>
 
-<p class="definition"><dfn id="DataTypeDasharray">&lt;dasharray&gt;</dfn> =
+<p class="definition"><dfn id="DataTypeDasharray" data-dfn-type="type" data-dfn-export>&lt;dasharray&gt;</dfn> =
 [ <a>&lt;length&gt;</a> | <a>&lt;percentage&gt;</a> | <a>&lt;number&gt;</a> ]#*</p>
 
 <p>The <a>'stroke-dasharray'</a> property controls
@@ -1254,7 +1254,7 @@ to the author's path length as specified by <a>'path/pathLength'</a>.</p>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="StrokeDashoffsetProperty">stroke-dashoffset</dfn></td>
+    <td><dfn id="StrokeDashoffsetProperty" data-dfn-type="property" data-dfn-export>stroke-dashoffset</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -1374,7 +1374,7 @@ description of positions along a path that dashes will be placed.</p>
 </div>
 
 <div class="ready-for-wider-review">
-<p>The <dfn id="TermStrokeShape">stroke shape</dfn> of an element is the
+<p>The <dfn id="TermStrokeShape" data-dfn-type="dfn" data-dfn-export>stroke shape</dfn> of an element is the
 shape that is filled by the <a>'stroke'</a> property.  Since <a>'text'</a>
 elements can be rendered in multiple chunks, each chunk has its own
 <a>stroke shape</a>.  The following algorithm describes the ideal stroke shape
@@ -1472,7 +1472,7 @@ The ideal stroke shape is determined as follows:
   <li>Return <var>shape</var>.</li>
 </ol>
 
-<p>The <dfn id="TermDashPositions">dash positions</dfn> for a given subpath of
+<p>The <dfn id="TermDashPositions" data-dfn-type="dfn" data-dfn-export>dash positions</dfn> for a given subpath of
 the <a>equivalent path</a> of a <a>'path'</a> or <a>basic shape</a> is a
 sequence of pairs of values, which represent the starting and ending distance
 along the subpath for each of the dashes that form the subpath's stroke.  It is
@@ -1530,7 +1530,7 @@ determined as follows:</p>
   <li>Return <var>positions</var>.</li>
 </ol>
 
-<p>The starting and ending <dfn id="TermCapShape">cap shapes</dfn> at a given
+<p>The starting and ending <dfn id="TermCapShape" data-dfn-type="dfn" data-dfn-export>cap shapes</dfn> at a given
 <var>position</var> along a subpath are determined as follows:</p>
 
 <ol class="algorithm">
@@ -1592,7 +1592,7 @@ determined as follows:</p>
   and cap highlighting.</p>
 </div>
 
-<p>The <dfn id="TermLineJoinShape">line join shape</dfn> for a given segment of
+<p>The <dfn id="TermLineJoinShape"  data-dfn-type="dfn" data-dfn-export>line join shape</dfn> for a given segment of
 a subpath is determined as follows:</p>
 
 <ol class="algorithm">
@@ -2265,14 +2265,14 @@ can be used to place markers at the first and last vertex of a
 to place markers at all other vertices (aside from the first and last).
 The <a>'marker-start'</a> and <a>'marker-end'</a> can be used for example to
 add arrowheads to paths.  Markers placed using these properties are known as
-<dfn id="TermVertexMarker">vertex markers</dfn>.</p>
+<dfn id="TermVertexMarker" data-dfn-type="dfn" data-dfn-export>vertex markers</dfn>.</p>
 
 <p class='note'>In SVG 2, vertex markers are the only kind of markers
 available.  Other specifications will add new types of markers.</p>
 
 <p>The graphics for a marker are defined by a <a>'marker element'</a> element.
 The <a>'marker-start'</a>, <a>'marker-end'</a> and <a>'marker-mid'</a> properties,
-together known as the <dfn id="TermMarkerProperties">marker properties</dfn>, reference
+together known as the <dfn id="TermMarkerProperties" data-dfn-type="dfn" data-dfn-export>marker properties</dfn>, reference
 <a>'marker element'</a> elements.</p>
 
 <p>Markers can be animated, and as with <a>'use'</a> elements, the animated
@@ -2310,7 +2310,7 @@ be used for drawing markers on a <a>shape</a>.</p>
     <th>Animatable</th>
   </tr>
   <tr>
-    <td><dfn id="MarkerUnitsAttribute">markerUnits</dfn></td>
+    <td><dfn id="MarkerUnitsAttribute" data-dfn-type="element-attr" data-dfn-for="marker" data-dfn-export>markerUnits</dfn></td>
     <td>strokeWidth | userSpaceOnUse</td>
     <td>strokeWidth</td>
     <td>yes</td>
@@ -2359,8 +2359,8 @@ also being non scaling.</p>
     <th>Animatable</th>
   </tr>
   <tr>
-    <td><dfn id="MarkerWidthAttribute">markerWidth</dfn>,
-    <dfn id="MarkerHeightAttribute">markerHeight</dfn></td>
+    <td><dfn id="MarkerWidthAttribute" data-dfn-type="element-attr" data-dfn-for="marker" data-dfn-export>markerWidth</dfn>,
+    <dfn id="MarkerHeightAttribute" data-dfn-type="element-attr" data-dfn-for="marker" data-dfn-export>markerHeight</dfn></td>
     <td><a>&lt;length&gt;</a> | <a>&lt;percentage&gt;</a> | <a>&lt;number&gt;</a></td>
     <td>3</td>
     <td>yes</td>
@@ -2389,13 +2389,13 @@ for either attribute is an error (see
     <th>Animatable</th>
   </tr>
   <tr>
-    <td><dfn id="MarkerElementRefXAttribute">refX</dfn></td>
+    <td><dfn id="MarkerElementRefXAttribute" data-dfn-type="element-attr" data-dfn-for="marker" data-dfn-export>refX</dfn></td>
     <td><a>&lt;length&gt;</a> | <a>&lt;percentage&gt;</a> | <a>&lt;number&gt;</a> | left | center | right</td>
     <td>0</td>
     <td>yes</td>
   </tr>
   <tr>
-    <td><dfn id="MarkerElementRefYAttribute">refY</dfn></td>
+    <td><dfn id="MarkerElementRefYAttribute" data-dfn-type="element-attr" data-dfn-for="marker" data-dfn-export>refY</dfn></td>
     <td><a>&lt;length&gt;</a> | <a>&lt;percentage&gt;</a> | <a>&lt;number&gt;</a> | top | center | bottom</td>
     <td>0</td>
     <td>yes</td>
@@ -2450,7 +2450,7 @@ width for <a>'refX'</a> or a percentage of the <a>'viewBox'</a> height for
     <th>Animatable</th>
   </tr>
   <tr>
-    <td><dfn id="OrientAttribute">orient</dfn></td>
+    <td><dfn id="OrientAttribute" data-dfn-type="element-attr" data-dfn-for="marker" data-dfn-export>orient</dfn></td>
     <td>auto | auto-start-reverse | <a>&lt;angle&gt;</a> | <a>&lt;number&gt;</a></td>
     <td>0</td>
     <td>yes&#160;(non-additive)</td>
@@ -2516,9 +2516,9 @@ properties</h3>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="MarkerStartProperty">marker-start</dfn>,
-        <dfn id="MarkerMidProperty">marker-mid</dfn>,
-        <dfn id="MarkerEndProperty">marker-end</dfn></td>
+    <td><dfn id="MarkerStartProperty" data-dfn-type="property" data-dfn-export>marker-start</dfn>,
+        <dfn id="MarkerMidProperty" data-dfn-type="property" data-dfn-export>marker-mid</dfn>,
+        <dfn id="MarkerEndProperty" data-dfn-type="property" data-dfn-export>marker-end</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -2557,7 +2557,7 @@ properties</h3>
 
 <p>where:</p>
 
-<p class="definition"><dfn id="DataTypeMarkerRef">&lt;marker-ref&gt;</dfn> = <a>&lt;url&gt;</a></p>
+<p class="definition"><dfn id="DataTypeMarkerRef"  data-dfn-type="type" data-dfn-export>&lt;marker-ref&gt;</dfn> = <a>&lt;url&gt;</a></p>
 
 <p>The <a>'marker-start'</a> and <a>'marker-end'</a> properties are used
 to specify the marker that will be drawn at the first and last vertices
@@ -2640,7 +2640,7 @@ property</h3>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="MarkerProperty">marker</dfn></td>
+    <td><dfn id="MarkerProperty" data-dfn-type="property" data-dfn-export>marker</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -2911,7 +2911,7 @@ the following:</p>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="PaintOrderProperty">paint-order</dfn></td>
+    <td><dfn id="PaintOrderProperty" data-dfn-type="property" data-dfn-export>paint-order</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -3003,7 +3003,7 @@ has the same rendering behavior as
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="ColorInterpolationProperty">color-interpolation</dfn></td>
+    <td><dfn id="ColorInterpolationProperty" data-dfn-type="property" data-dfn-export>color-interpolation</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -3185,7 +3185,7 @@ on the element being animated.</p>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="ColorRenderingProperty">color-rendering</dfn></td>
+    <td><dfn id="ColorRenderingProperty" data-dfn-type="property" data-dfn-export>color-rendering</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -3256,7 +3256,7 @@ precision as specified by <span class="prop-value">color-interpolation-filters:Â
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="ShapeRenderingProperty">shape-rendering</dfn></td>
+    <td><dfn id="ShapeRenderingProperty" data-dfn-type="property" data-dfn-export>shape-rendering</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -3330,7 +3330,7 @@ such as circles and rectangles.  Values have the following meanings:</p>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="TextRenderingProperty">text-rendering</dfn></td>
+    <td><dfn id="TextRenderingProperty" data-dfn-type="property" data-dfn-export>text-rendering</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>
@@ -3403,7 +3403,7 @@ following meanings:</p>
 <table class="propdef def">
   <tr>
     <th>Name:</th>
-    <td><dfn id="ImageRenderingProperty">image-rendering</dfn></td>
+    <td><dfn id="ImageRenderingProperty" data-dfn-type="property" data-dfn-export>image-rendering</dfn></td>
   </tr>
   <tr>
     <th>Value:</th>

--- a/master/pservers.html
+++ b/master/pservers.html
@@ -433,8 +433,8 @@ in the stops. This is discussed in detail in the
 
 <h3 id="Definitions">Definitions</h3>
 
-<dl class='definitions'  data-dfn-type="dfn" data-export="">
-  <dt id="TermGradientElement">gradient element</dt>
+<dl class="definitions">
+  <dt><dfn id="TermGradientElement" data-dfn-type="dfn" data-dfn-export>gradient element</dfn></dt>
   <dd>A gradient element is one that defines a gradient paint server.
     This specification defines the following gradient elements:
     <edit:elementcategory name='gradient'/>.

--- a/master/render.html
+++ b/master/render.html
@@ -107,8 +107,8 @@ match the conformance requirements).</p>
     
 <h3 id="Definitions">Definitions</h3>
     
-<dl class='definitions'  data-dfn-type="dfn" data-export="">
-    <dt>rendering tree</dt>
+<dl class="definitions">
+    <dt><dfn id="TermRenderingTree" data-dfn-type="dfn" data-dfn-export>rendering tree</dfn></dt>
     <dd>
     <p>
         The rendering tree is the set of elements being rendered
@@ -122,7 +122,7 @@ match the conformance requirements).</p>
         Note that elements that have no visual paint may still be in the rendering tree.
     </p>
   </dd>
-  <dt id="TermRenderedElement">rendered element</dt>
+  <dt><dfn id="TermRenderedElement" data-dfn-type="dfn" data-dfn-export>rendered element</dfn></dt>
   <dd>
     <p>
         An element that has a direct representation in the
@@ -134,7 +134,7 @@ match the conformance requirements).</p>
         See <a href="#Rendered-vs-NonRendered">Rendered versus non-rendered elements</a>
     </p>
   </dd>
-  <dt id="TermNonRenderedElement">non-rendered element</dt>
+  <dt><dfn id="TermNonRenderedElement" data-dfn-type="dfn" data-dfn-export>non-rendered element</dfn></dt>
   <dd>
     <p>
         An element that does not have a direct representation in the
@@ -144,7 +144,7 @@ match the conformance requirements).</p>
         See <a href="#Rendered-vs-NonRendered">Rendered versus non-rendered elements</a>.
     </p>
   </dd>
-  <dt id="TermReusedGraphics">re-used graphics</dt>
+  <dt><dfn id="TermReusedGraphics" data-dfn-type="dfn" data-dfn-export>re-used graphics</dfn></dt>
   <dd>
     <p>
         Graphical components that are included in the rendering tree
@@ -157,7 +157,7 @@ match the conformance requirements).</p>
     </p>
   </dd>
 
-  <dt id="TermNeverRenderedElement">never-rendered element</dt>
+  <dt><dfn id="TermNeverRenderedElement" data-dfn-type="dfn" data-dfn-export>never-rendered element</dfn></dt>
   <dd>
       <p>
           Any element type that is <em>never directly rendered</em>,
@@ -168,7 +168,7 @@ match the conformance requirements).</p>
           the <a>instance root</a> of a <a>use-element shadow tree</a>.
       </p>
   </dd>
-  <dt id="TermRenderableElement">renderable element</dt>
+  <dt><dfn id="TermRenderableElement" data-dfn-type="dfn" data-dfn-export>renderable element</dfn></dt>
   <dd>
     <p>
         Any element type that <em>can</em> have a direct representation
@@ -398,7 +398,7 @@ position on the x and y axis of the <a>SVG viewport</a>, SVG elements are also
 positioned on the z axis. The position on the z-axis defines the order that 
 they are painted.</p>
 
-<p>Along the z axis, elements are grouped into <dfn id="TermStackingContext">stacking contexts</dfn>, each stacking
+<p>Along the z axis, elements are grouped into <dfn id="TermStackingContext" data-dfn-type="dfn" data-dfn-export>stacking contexts</dfn>, each stacking
 context has an associated stack level.
 A stack level may contain one or more child nodes - either child
 stack levels, <a>graphics elements</a>, or <a>'g'</a> elements.

--- a/master/shapes.html
+++ b/master/shapes.html
@@ -19,11 +19,10 @@
 
 <h2 id="Introduction">Introduction and definitions</h2>
 
-<dl class='definitions'  data-dfn-type="dfn" data-export="">
-
-  <dt id="TermBasicShapeElement"><dfn id="basic-shape">basic shape</dfn></dt>
-  <dt id="TermShapeElement">shape</dt>
-  <dt><dfn>shape elements</dfn></dt><!--keep that for Bikeshed! -->
+<dl class="definitions">
+  <dt id="TermBasicShapeElement"><dfn id="basic-shape" data-dfn-type="dfn" data-dfn-export>basic shape</dfn></dt>
+  <dt>shape</dt>
+  <dt><dfn id="TermShapeElement" data-dfn-type="dfn" data-dfn-export>shape elements</dfn></dt><!--keep that for Bikeshed! -->
   <dd>A graphics element that is defined by some combination of
   straight lines and curves. Specifically:
   <edit:elementcategory name='shape'/>.</dd>
@@ -351,7 +350,7 @@ and ends at another.</p>
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn id="LineElementX1Attribute">x1</dfn>, <dfn id="LineElementY1Attribute">y1</dfn></td>
+        <td><dfn id="LineElementX1Attribute" data-dfn-type="element-attr" data-dfn-for="line" data-dfn-export>x1</dfn>, <dfn id="LineElementY1Attribute" data-dfn-type="element-attr" data-dfn-for="line" data-dfn-export>y1</dfn></td>
         <td><a>&lt;length&gt;</a> | <a>&lt;percentage&gt;</a> | <a>&lt;number&gt;</a></td>
         <td>0</td>
         <td>yes</td>
@@ -370,7 +369,7 @@ and ends at another.</p>
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn id="LineElementX2Attribute">x2</dfn>, <dfn id="LineElementY2Attribute">y2</dfn></td>
+        <td><dfn id="LineElementX2Attribute" data-dfn-type="element-attr" data-dfn-for="line" data-dfn-export>x2</dfn>, <dfn id="LineElementY2Attribute" data-dfn-type="element-attr" data-dfn-for="line" data-dfn-export>y2</dfn></td>
         <td><a>&lt;length&gt;</a> | <a>&lt;percentage&gt;</a> | <a>&lt;number&gt;</a></td>
         <td>0</td>
         <td>yes</td>
@@ -436,7 +435,7 @@ shapes.</p>
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn id="PolylineElementPointsAttribute">points</dfn></td>
+        <td><dfn id="PolylineElementPointsAttribute" data-dfn-type="element-attr" data-dfn-for="polyline" data-dfn-export>points</dfn></td>
 	<td><a>&lt;points&gt;</a></td>
         <td>(none)</td>
         <td>yes</td>
@@ -446,7 +445,7 @@ shapes.</p>
   <dd>
     <p>where:</p>
     <div class="definition">
-      <dfn id="DataTypePoints">&lt;points&gt;</dfn> =
+      <dfn id="DataTypePoints" data-dfn-type="type" data-dfn-export>&lt;points&gt;</dfn> =
       <div style="margin-left: 4em">[ <a>&lt;number&gt;</a>+ ]#</div>
     </div>
     <p>The points that make up the polyline. All coordinate
@@ -506,7 +505,7 @@ set of connected straight line segments.</p>
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn id="PolygonElementPointsAttribute">points</dfn></td>
+        <td><dfn id="PolygonElementPointsAttribute" data-dfn-type="element-attr" data-dfn-for="polygon" data-dfn-export>points</dfn></td>
 	<td><a>&lt;points&gt;</a></td>
         <td>(none)</td>
         <td>yes</td>
@@ -586,7 +585,7 @@ on the <a>'svg'</a> element.</p>
           <th>Animatable</th>
 	</tr>
 	<tr>
-          <td><dfn id="MeshElementHrefAttribute">href</dfn></td>
+          <td><dfn id="MeshElementHrefAttribute" data-dfn-type="element-attr" data-dfn-for="mesh" data-dfn-export>href</dfn></td>
           <td>URL <a href="types.html#attribute-url" class="syntax">[URL]</a></td>
           <td>(none)</td>
           <td>yes</td>

--- a/master/struct.html
+++ b/master/struct.html
@@ -129,32 +129,31 @@ information, refer to the <a href="https://www.w3.org/TR/2006/REC-xml-names-2006
 
 <h3 id="Definitions">Definitions</h3>
 
-<dl class='definitions'  data-dfn-type="dfn" data-export="">
-
-  <dt id="TermStructuralElement"><dfn>structural element</dfn></dt>
+<dl class="definitions">
+  <dt><dfn id="TermStructuralElement" data-dfn-type="dfn" data-dfn-export>structural element</dfn></dt>
   <dd>The structural elements are those which define the primary
   structure of an SVG document.  Specifically, the following
   elements are structural elements:
   <edit:elementcategory name='structural'/>.</dd>
 
-  <dt id="TermStructurallyExternalElement">structurally external element</dt>
+  <dt><dfn id="TermStructurallyExternalElement" data-dfn-type="dfn" data-dfn-export>structurally external element</dt>
   <dd>Elements that define its structure by reference to an external resource.
   Specifically, the following elements are structurally external elements when
   they have an <span class="attr-name">'href'</span> attribute:
   <edit:elementcategory name='structurally external'/>.</dd>
 
-  <dt id="TermCurrentSVGDocumentFragment">current SVG document fragment</dt>
+  <dt><dfn id="TermCurrentSVGDocumentFragment" data-dfn-type="dfn" data-dfn-export>current SVG document fragment</dfn></dt>
   <dd>The document sub-tree which starts with the outermost
   ancestor <a>'svg'</a> element of a given SVG
   element, with the requirement that all container elements
   between the outermost <a>'svg'</a> and the given element are
   all elements in the SVG namespace.</dd>
 
-  <dt id="TermOutermostSVGElement">outermost svg element</dt>
+  <dt><dfn id="TermOutermostSVGElement" data-dfn-type="dfn" data-dfn-export>outermost svg element</dfn></dt>
   <dd>The furthest <a>'svg'</a> ancestor element that remains in the
   <a>current SVG document fragment</a>.</dd>
 
-  <dt id="TermSVGDocumentFragment">SVG document fragment</dt>
+  <dt><dfn id="TermSVGDocumentFragment" data-dfn-type="dfn" data-dfn-export>SVG document fragment</dfn></dt>
   <dd>A document sub-tree which starts with an <a>'svg'</a>
   element which is either the root element of the document or whose parent
   element is not in the SVG namespace.
@@ -165,15 +164,15 @@ information, refer to the <a href="https://www.w3.org/TR/2006/REC-xml-names-2006
   is not the root of an SVG document fragment.
   </dd>
 
-  <dt id="TermSVGElements"> SVG elements</dt>
+  <dt><dfn id="TermSVGElements" data-dfn-type="dfn" data-dfn-export>SVG elements</dfn></dt>
   <dd>Any element in the <a>SVG namespace</a>.</dd>
 
-  <dt id="TermGraphicsElement"><dfn id="graphics-element">graphics element</dfn></dt>
+  <dt id="TermGraphicsElement"><dfn id="graphics-element" data-dfn-type="dfn" data-dfn-export>graphics element</dfn></dt>
   <dd>One of the element types that can cause graphics to be
   drawn onto the target canvas. Specifically:
   <edit:elementcategory name='graphics'/>.</dd>
 
-  <dt id="TermGraphicsReferencingElement"><dfn id="graphics-referencing-element">graphics referencing element</dfn></dt>
+  <dt id="TermGraphicsReferencingElement"><dfn id="graphics-referencing-element" data-dfn-type="dfn" data-dfn-export>graphics referencing element</dfn></dt>
   <dd>A graphics element which uses a reference to a different
   document or element as the source of its graphical content.
   Specifically: <edit:elementcategory name='graphics referencing'/>.</dd>
@@ -238,7 +237,7 @@ information, refer to the <a href="https://www.w3.org/TR/2006/REC-xml-names-2006
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn id="SVGElementZoomAndPanAttribute">zoomAndPan</dfn></td>
+        <td><dfn id="SVGElementZoomAndPanAttribute" data-dfn-type="element-attr" data-dfn-for="svg" data-dfn-export>zoomAndPan</dfn></td>
         <td>disable | magnify</td>
         <td>magnify</td>
         <td>no</td>
@@ -269,8 +268,8 @@ replace the generic <a>event handlers</a> with the same names normally supported
 
 <h3 id="GroupsOverview">Overview</h3>
 
-<dl class='definitions'  data-dfn-type="dfn" data-export="">
-  <dt id="TermContainerElement"><dfn id="container-element">container element</dfn></dt>
+<dl class="definitions">
+  <dt id="TermContainerElement"><dfn id="container-element" data-dfn-type="dfn" data-dfn-export>container element</dfn></dt>
   <dd>An element which can have <a>graphics elements</a> and other
   container elements as child elements. Specifically:
   <edit:elementcategory name='container'/>.</dd>
@@ -1521,8 +1520,8 @@ other elements (such as via a <a>'use'</a>).</p>
 </div>
 
 <h3 id="ConditionalProcessingDefinitions">Definitions</h3>
-<dl class='definitions'  data-dfn-type="dfn" data-export="">
-  <dt id="TermConditionalProcessingAttribute">conditional processing attribute</dt>
+<dl class="definitions">
+  <dt><dfn id="TermConditionalProcessingAttribute" data-dfn-type="dfn" data-dfn-export>conditional processing attribute</dfn></dt>
   <dd>A conditional processing attribute is one that controls whether
   or not the element on which it appears is processed.  Most elements,
   but not all, may have conditional processing attributes specified
@@ -1712,9 +1711,9 @@ element whether to render the element or not.</p>
 <h2 id="DescriptionAndTitleElements">The <span class='element-name'>'desc'</span>
 and <span class='element-name'>'title'</span> elements</h2>
 
-<h3 id='DescriptionDefinitions'>Definition</h3>
-<dl class='definitions'  data-dfn-type="dfn" data-export="">
-  <dt id="TermDescriptiveElement"><dfn>descriptive element</dfn></dt>
+<h3 id="DescriptionDefinitions">Definition</h3>
+<dl class="definitions">
+  <dt><dfn id="TermDescriptiveElement" data-dfn-type="dfn" data-dfn-export>descriptive element</dfn></dt>
   <dd>An element which provides supplementary descriptive information about
   its parent.  Specifically, the following elements are descriptive elements:
   <edit:elementcategory name='descriptive'/>.</dd>
@@ -2054,9 +2053,9 @@ this case) upon reading it back in:
 
 <h3 id="CommonAttributeDefinitions">Definitions</h3>
 
-<dl class='definitions'  data-dfn-type="dfn" data-export="">
+<dl class="definitions">
 
-  <dt id="TermCoreAttribute"><dfn>core attributes</dfn></dt>
+  <dt><dfn id="TermCoreAttribute" data-dfn-type="dfn" data-dfn-export>core attributes</dfn></dt>
   <dd>The core attributes are those attributes that can be specified
   on any SVG element.  This includes <a href="struct.html#CommonAttributes">common attributes</a>,
   and <a href="styling.html">styling attributes</a>.
@@ -2262,8 +2261,8 @@ for custom data attributes</a> in the HTML specification.</p>
 
 <h3 id="WAIARIA-definitions">Definitions</h3>
 
-<dl class='definitions'  data-dfn-type="dfn" data-export="">
-  <dt id="TermARIAAttribute"><dfn>ARIA attributes</dfn></dt>
+<dl class="definitions">
+  <dt><dfn id="TermARIAAttribute" data-dfn-type="dfn" data-dfn-export>ARIA attributes</dfn></dt>
   <dd>These are the attributes defined in WAI-ARIA,
     consisting of WAI-ARIA states and properties
     as well as the role attribute. 
@@ -2302,7 +2301,7 @@ A valid role is a recognized, non-abstract role that is <a href="#implicit-aria-
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn id="RoleAttribute">role</dfn></td>
+        <td><dfn id="RoleAttribute" data-dfn-type="element-attr" data-dfn-export>role</dfn></td>
         <td><a>set of space-separated tokens</a> <span class="syntax">[HTML]</span></td>
         <td>(see below)</td>
         <td>no</td>
@@ -2364,7 +2363,7 @@ specifications. [<a href="refs.html#ref-wai-aria">wai-aria</a>] [<a href="refs.h
   given in the cell in the second column of the same row. The third column defines restrictions as to what WAI-ARIA semantic (role, state, or property) may or may not apply.</p>
 <p>For many graphics elements, an implicit role is only assigned 
   if the author provides information that indicates semantic importance.  
-  The complete <dfn id="TermInclusionCriteria">inclusion criteria</dfn> for the accessibility tree
+  The complete <dfn id="TermInclusionCriteria" data-dfn-type="dfn" data-dfn-export>inclusion criteria</dfn> for the accessibility tree
   are defined by the <a href="https://www.w3.org/TR/svg-aam-1.0/"><cite>SVG Accessibility API Mappings</cite></a> specification for user agents [<a href="refs.html#ref-svg-aam-1.0">svg-aam-1.0</a>].
   For authors, the preferred means of indicating semantic importance is to provide an accessible name for the element.
   This can be done through a direct child <a>'title'</a> element,
@@ -2835,7 +2834,7 @@ miscellaneous utility methods, such as data type object factory methods.</p>
 
 <p>An <a>SVGSVGElement</a> object maintains an internal
 <a>DOMPoint</a> object, called its
-<dfn id="CurrentTranslatePointObject">current translate point object</dfn>,
+<dfn id="CurrentTranslatePointObject" data-dfn-type="dfn" data-dfn-export>current translate point object</dfn>,
 which is the object returned from the <a href="#__svg__SVGSVGElement__currentTranslate">currentTranslate</a>
 IDL attribute.</p>
 
@@ -2988,7 +2987,7 @@ used to perform geometry operations on <a>graphics elements</a> to find
 those whose (or check whether their) graphical content lies partially or
 completely within a given rectangle.</p>
 
-<p>To <dfn id="TermFindIntersectingOrEnclosedDescendants">find the intersecting
+<p>To <dfn id="TermFindIntersectingOrEnclosedDescendants" data-dfn-type="dfn" data-dfn-export>find the intersecting
 or enclosed descendants</dfn> of a given element <var>element</var>
 with a given rectangle <var>rectangle</var> using <var>ancestor</var>
 as the element in whose coordinate space <var>rectangle</var> is
@@ -3045,7 +3044,7 @@ to be interpreted, the following steps are run:</p>
   <li>Return <var>result</var>.</li>
 </ol>
 
-<p>To <dfn id="TermFindNonContainerGraphicsElements">find the non-container
+<p>To <dfn id="TermFindNonContainerGraphicsElements" data-dfn-type="dfn" data-dfn-export>find the non-container
 graphics elements</dfn> within a given element <var>element</var>, the following
 steps are run:</p>
 

--- a/master/styling.html
+++ b/master/styling.html
@@ -21,7 +21,7 @@
 
 <p>Elements in an SVG document can be styled using CSS.
 Most visual characteristics and some aspects of element
-geometry are controlled using CSS <dfn id="TermProperty">properties</dfn>.
+geometry are controlled using CSS <dfn id="TermProperty" data-dfn-type="dfn">properties</dfn>.
 For example, the <a>'fill'</a> property controls the paint used to
 fill the inside of a shape, and the <a>'width'</a> and
 <a>'height'</a> properties are used to control the size
@@ -80,7 +80,7 @@ element in HTML</a>.</p>
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn id="StyleElementTypeAttribute">type</dfn></td>
+        <td><dfn id="StyleElementTypeAttribute" data-dfn-type="element-attr" data-dfn-for="style" data-dfn-export>type</dfn></td>
         <td>(see below)</td>
         <td>text/css</td>
         <td>no</td>
@@ -103,7 +103,7 @@ element in HTML</a>.</p>
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn id="StyleElementMediaAttribute">media</dfn></td>
+        <td><dfn id="StyleElementMediaAttribute" data-dfn-type="element-attr" data-dfn-for="style" data-dfn-export>media</dfn></td>
         <td>(see below)</td>
         <td>all</td>
         <td>no</td>
@@ -125,7 +125,7 @@ element in HTML</a>.</p>
         <th>Animatable</th>
       </tr>
       <tr>
-        <td><dfn id="StyleElementTitleAttribute">title</dfn></td>
+        <td><dfn id="StyleElementTitleAttribute" data-dfn-type="element-attr" data-dfn-for="style" data-dfn-export>title</dfn></td>
         <td>(see below)</td>
         <td>(none)</td>
         <td>no</td>
@@ -304,7 +304,7 @@ text.error   { fill: red; }</pre>
 
 <p>Some styling properties can be specified not only in style sheets
 and <a>'style attribute'</a> attributes, but also in
-<dfn id="TermPresentationAttribute">presentation attributes</dfn>.
+<dfn id="TermPresentationAttribute" data-dfn-type="dfn" data-dfn-export>presentation attributes</dfn>.
 These are attributes whose name matches (or is similar to) a given CSS property
 and whose value is parsed as a value of that property.  Presentation
 attributes contribute to the

--- a/master/text.html
+++ b/master/text.html
@@ -148,9 +148,9 @@
 
 <h3 id="Definitions">Definitions</h3>
 
-  <dl class='definitions'  data-dfn-type="dfn" data-export="">
+  <dl class="definitions">
 
-    <dt id="TermCharacter">character</dt>
+    <dt><dfn id="TermCharacter" data-dfn-type="dfn" data-dfn-export>character</dfn></dt>
     <dd>
       A character is an atomic unit of text as defined in XML
       [<a href="https://www.w3.org/TR/2008/REC-xml-20081126/">XML</a>].
@@ -162,7 +162,7 @@
       </p>
     </dd>
 
-    <dt id="TermAddressableCharacter">addressable character</dt>
+    <dt><dfn id="TermAddressableCharacter" data-dfn-type="dfn" data-dfn-export>addressable character</dfn></dt>
     <dd>
       A <a>character</a> that is addressable by text positioning
       attributes and SVG DOM text methods. Characters discarded during
@@ -538,7 +538,7 @@
 
   <p>
     Glyphs are positioned relative to a particular point on each glyph
-    known as the <dfn><a>alignment point</a></dfn>. For horizontal
+    known as the <dfn id="TermAlignmentPoint" data-dfn-type="dfn" data-dfn-export><a>alignment point</a></dfn>. For horizontal
     writing-modes, the glyphs' <a>alignment points</a> are vertically
     aligned while for vertical writing-modes, they are horizontally
     aligned. The position of the <a>alignment point</a> depends on the
@@ -552,7 +552,7 @@
     Within a script and within a line of text having a single
     font-size, the sequence of alignment points defines, in the
     <a>inline-base direction</a>, a geometric line called a
-    <dfn>baseline</dfn>. Western and most other alphabetic and
+    <dfn id="TermBaseline" data-dfn-type="dfn" data-dfn-export>baseline</dfn>. Western and most other alphabetic and
     syllabic glyphs are aligned to an "alphabetic" baseline, the
     northern indic glyphs are aligned to a "hanging" baseline and the
     far-eastern glyphs are aligned to an "ideographic" baseline.
@@ -571,7 +571,7 @@
   <p>
     As glyphs are sequentially placed along a baseline, the
     <a>alignment point</a> of a glyph is typically positioned at the
-    <dfn><a>current text position</a></dfn> (some properties such as
+    <dfn id="TermCurrentTextPosition" data-dfn-type="dfn" data-dfn-export><a>current text position</a></dfn> (some properties such as
     <a>'vertical-align'</a> may alter the positioning). After each
     glyph is placed, the <a>current text position</a> is advanced by
     the glyph's <em>advance</em> value (typically the width for
@@ -616,7 +616,7 @@
   </p>
 
   <p>
-    A <dfn>baseline-table</dfn> specifies the position of one or more
+    A <dfn id="TermBaselineTable" data-dfn-type="dfn" data-dfn-export>baseline-table</dfn> specifies the position of one or more
     baselines in the design space coordinate system. The function of
     the baseline table is to facilitate the alignment of different
     scripts with respect to each other when they are mixed on the same
@@ -639,7 +639,7 @@
 
   <p>
     When a different font (or change in font size) is specified in the
-    middle of a run of text, the <dfn>dominant baseline</dfn>
+    middle of a run of text, the <dfn id="TermDominantBaseline" data-dfn-type="dfn" data-dfn-export>dominant baseline</dfn>
     determines the baseline used to align glyphs in the new font (new
     size) to those in the previous font. The
     <a>'dominant-baseline'</a> property is used to set the dominant
@@ -648,7 +648,7 @@
 
   <p>
     Alignment between an object relative to its parent is determined
-    by the <dfn>alignment baseline</dfn>. It is normally the same
+    by the <dfn id="TermAlignmentBaseline" data-dfn-type="dfn" data-dfn-export>alignment baseline</dfn>. It is normally the same
     baseline as the dominant baseline but by using the shorthand
     <a>'vertical-align'</a> property (preferred) or the longhand
     <a>'alignment-baseline'</a> another baseline can be chosen.
@@ -1008,7 +1008,7 @@
           <th>Animatable</th>
 	</tr>
 	<tr>
-          <td><dfn data-dfn-type="element-attr" data-dfn-for="text" id="TextElementXAttribute">x</dfn>, <dfn data-dfn-type="element-attr" data-dfn-for="text" id="TextElementYAttribute">y</dfn></td>
+          <td><dfn id="TextElementXAttribute" data-dfn-type="element-attr" data-dfn-for="text" data-dfn-export>x</dfn>, <dfn id="TextElementYAttribute" data-dfn-type="element-attr" data-dfn-for="text" data-dfn-export>y</dfn></td>
           <td>[ [ <a>&lt;length&gt;</a> | <a>&lt;percentage&gt;</a> | <a>&lt;number&gt;</a> ]+ ]#</td>
           <td>0 for <a>'text'</a>;<br/> (none) for <a>'tspan'</a></td>
           <td>yes</td>
@@ -1075,7 +1075,7 @@
           <th>Animatable</th>
 	</tr>
 	<tr>
-          <td><dfn data-dfn-type="element-attr" data-dfn-for="text" id="TextElementDXAttribute">dx</dfn>, <dfn data-dfn-type="element-attr" data-dfn-for="text" id="TextElementDYAttribute">dy</dfn></td>
+          <td><dfn id="TextElementDXAttribute" data-dfn-type="element-attr" data-dfn-for="text" data-dfn-export>dx</dfn>, <dfn id="TextElementDYAttribute" data-dfn-type="element-attr" data-dfn-for="text" data-dfn-export>dy</dfn></td>
           <td>[ [ <a>&lt;length&gt;</a> | <a>&lt;percentage&gt;</a> | <a>&lt;number&gt;</a> ]+ ]#</td>
           <td>(none)</td>
           <td>yes</td>
@@ -1141,7 +1141,7 @@
           <th>Animatable</th>
 	</tr>
 	<tr>
-          <td><dfn data-dfn-type="element-attr" data-dfn-for="text" id="TextElementRotateAttribute">rotate</dfn></td>
+          <td><dfn id="TextElementRotateAttribute" data-dfn-type="element-attr" data-dfn-for="text" data-dfn-export>rotate</dfn></td>
           <td>[ <a>&lt;number&gt;</a>+ ]#</td>
           <td>(none)</td>
           <td>yes (non-additive).</td>
@@ -1205,7 +1205,7 @@
           <th>Animatable</th>
 	</tr>
 	<tr>
-          <td><dfn data-dfn-type="element-attr" data-dfn-for="text" id="TextElementTextLengthAttribute">textLength</dfn></td>
+          <td><dfn id="TextElementTextLengthAttribute" data-dfn-type="element-attr" data-dfn-for="text" data-dfn-export>textLength</dfn></td>
           <td><a>&lt;length&gt;</a> | <a>&lt;percentage&gt;</a> | <a>&lt;number&gt;</a></td>
           <td>See below</td>
           <td>yes</td>
@@ -1286,7 +1286,7 @@
           <th>Animatable</th>
 	</tr>
 	<tr>
-          <td><dfn data-dfn-type="element-attr" data-dfn-for="text" id="TextElementLengthAdjustAttribute">lengthAdjust</dfn></td>
+          <td><dfn id="TextElementLengthAdjustAttribute" data-dfn-type="element-attr" data-dfn-for="text" data-dfn-export>lengthAdjust</dfn></td>
           <td>spacing | spacingAndGlyphs</td>
           <td>spacing</td>
           <td>yes</td>
@@ -1983,7 +1983,7 @@
   <table class="propdef def">
     <tr>
       <th>Name:</th>
-      <td><dfn id="InlineSizeProperty">inline-size</dfn></td>
+      <td><dfn id="InlineSizeProperty" data-dfn-type="property" data-dfn-export>inline-size</dfn></td>
     </tr>
     <tr>
       <th>Value:</th>
@@ -2155,7 +2155,7 @@
   <table class="propdef def">
     <tr>
       <th>Name:</th>
-      <td><dfn id="ShapeInsideProperty">shape-inside</dfn></td>
+      <td><dfn id="ShapeInsideProperty" data-dfn-type="property" data-dfn-export>shape-inside</dfn></td>
     </tr>
     <tr>
       <th>Value:</th>
@@ -2337,7 +2337,7 @@
   <table class="propdef def">
     <tr>
       <th>Name:</th>
-      <td><dfn id="ShapesubtractProperty">shape-subtract</dfn></td>
+      <td><dfn id="ShapesubtractProperty" data-dfn-type="property" data-dfn-export>shape-subtract</dfn></td>
     </tr>
     <tr>
       <th>Value:</th>
@@ -2468,7 +2468,7 @@
   <table class="propdef def">
     <tr>
       <th>Name:</th>
-      <td><dfn id="ShapeMarginProperty">shape-margin</dfn></td>
+      <td><dfn id="ShapeMarginProperty" data-dfn-type="property" data-dfn-export>shape-margin</dfn></td>
     </tr>
     <tr>
       <th>Value:</th>
@@ -3147,7 +3147,7 @@
 	  Set up:
 	  <ol>
 	    <li>
-	      Define <dfn>resolved descendant node</dfn> as a
+	      Define <dfn id="TermResolvedDescendantNode" data-dfn-type="dfn" data-dfn-export>resolved descendant node</dfn> as a
 	      descendant of node with a valid <a>'textLength'</a>
 	      attribute that is not itself a descendant node of a
 	      descendant node that has a valid <a>'textLength'</a>
@@ -4532,7 +4532,7 @@ style="font-weight:bold; color:green">path="M0,20 L80,40 160,20"</span>
     to the path. The box around the glyph shows the glyph is rotated
     such that its horizontal axis is parallel to the tangent of the
     curve at the point at which the glyph is attached to the path. The
-    box also shows the glyph's <dfn id="CharWidth">charwidth</dfn>
+    box also shows the glyph's <dfn id="CharWidth" data-dfn-type="dfn" data-dfn-export>charwidth</dfn>
     (i.e., the amount which the current text position advances
     horizontally when the glyph is drawn using horizontal text
     layout).
@@ -4555,7 +4555,7 @@ style="font-weight:bold; color:green">path="M0,20 L80,40 160,20"</span>
   <ul>
     <li>
       Determine the
-      <dfn id="StartPointOnPath">startpoint-on-the-path</dfn> for the
+      <dfn id="StartPointOnPath" data-dfn-type="dfn" data-dfn-export>startpoint-on-the-path</dfn> for the
       first glyph using attribute <a>'startOffset'</a> and property
       <a>'text-anchor'</a>. For <span class='prop-value'>text-anchor:start</span>,
       startpoint-on-the-path is the point on the path which represents
@@ -4599,14 +4599,14 @@ style="font-weight:bold; color:green">path="M0,20 L80,40 160,20"</span>
       this glyph, calculated using the user agent's
       <a href="paths.html#DistanceAlongAPath">distance along the
       path</a> algorithm. This point is the
-      <dfn id="EndPointOnPath">endpoint-on-the-path</dfn> for the
+      <dfn id="EndPointOnPath" data-dfn-type="dfn" data-dfn-export>endpoint-on-the-path</dfn> for the
       glyph. (In the picture above, the endpoint-on-the-path for the
       glyph is the rightmost dot on the path.)
     </li>
 
     <li>
       Determine the
-      <dfn id="MidPointOnPath">midpoint-on-the-path</dfn>, which is
+      <dfn id="MidPointOnPath" data-dfn-type="dfn" data-dfn-export>midpoint-on-the-path</dfn>, which is
       the point on the path which is "halfway" (user agents can choose
       either a distance calculation or a parametric calculation)
       between the startpoint-on-the-path and the
@@ -4615,7 +4615,7 @@ style="font-weight:bold; color:green">path="M0,20 L80,40 160,20"</span>
     </li>
 
     <li>
-      Determine the <dfn id="GlyphMidline">glyph-midline</dfn>, which
+      Determine the <dfn id="GlyphMidline" data-dfn-type="dfn" data-dfn-export>glyph-midline</dfn>, which
       is the vertical line in the glyph's coordinate system that goes
       through the glyph's x-axis midpoint. (In the picture above, the
       glyph-midline is shown as a dashed line.)
@@ -5017,7 +5017,7 @@ the dash pattern at the same positions across different implementations.</p>
   <table class="propdef def">
     <tr>
       <th>Name:</th>
-      <td><dfn id="TextAnchorProperty">text-anchor</dfn></td>
+      <td><dfn id="TextAnchorProperty" data-dfn-type="property" data-dfn-export>text-anchor</dfn></td>
     </tr>
     <tr>
       <th>Value:</th>
@@ -5695,7 +5695,7 @@ the dash pattern at the same positions across different implementations.</p>
   <table class="propdef def">
     <tr>
       <th>Name:</th>
-      <td><dfn id="WhiteSpaceProperty">white-space</dfn></td>
+      <td><dfn id="WhiteSpaceProperty" data-dfn-type="property" data-dfn-export>white-space</dfn></td>
     </tr>
     <tr>
       <th>Value:</th>
@@ -6061,7 +6061,7 @@ the dash pattern at the same positions across different implementations.</p>
   <table class="propdef def">
     <tr>
       <th>Name:</th>
-      <td><dfn id="TextDecorationFillProperty">text-decoration-fill</dfn></td>
+      <td><dfn id="TextDecorationFillProperty" data-dfn-type="property" data-dfn-export>text-decoration-fill</dfn></td>
     </tr>
     <tr>
       <th>Value:</th>
@@ -6101,7 +6101,7 @@ the dash pattern at the same positions across different implementations.</p>
   <table class="propdef def">
     <tr>
       <th>Name:</th>
-      <td><dfn id="TextDecorationStrokeProperty">text-decoration-stroke</dfn></td>
+      <td><dfn id="TextDecorationStrokeProperty" data-dfn-type="property" data-dfn-export>text-decoration-stroke</dfn></td>
     </tr>
     <tr>
       <th>Value:</th>
@@ -6429,7 +6429,7 @@ is called, the following steps are run:</p>
   Change to text length methods <a href="https://lists.w3.org/Archives/Public/www-svg/2015Aug/att-0009/SVGWG-F2F-minutes-20150824.html#item04">resolved at August 2015 Paris face-to-face</a>.
 </p>
 
-<p>To <dfn id="TermFindTypographicCharacterForCharacter">find the typographic
+<p>To <dfn id="TermFindTypographicCharacterForCharacter" data-dfn-type="dfn" data-dfn-export>find the typographic
 character for a character</dfn> at index <var>index</var> within an
 element <var>element</var>, the following steps are run:</p>
 

--- a/master/types.html
+++ b/master/types.html
@@ -18,8 +18,8 @@
 <h1>Basic Data Types and Interfaces</h1>
 
 <h2 id="definitions">Definitions</h2>
-<dl class='definitions'  data-dfn-type="dfn" data-export="">
-  <dt id="TermInitialValue">initial value</dt>
+<dl class="definitions">
+  <dt><dfn id="TermInitialValue" data-dfn-type="dfn" data-dfn-export>initial value</dt>
   <dd>
     <p>
       The initial value of an attribute or property is the value used when
@@ -31,7 +31,7 @@
     </p>
   </dd>
 
-  <dt id="TermInvalidValue">invalid value</dt>
+  <dt><dfn id="TermInvalidValue" data-dfn-type="dfn" data-dfn-export>invalid value</dfn></dt>
   <dd>An invalid value specified for a <a>property</a>, either in a style sheet
   or a <a>presentation attribute</a>, is one that is either not allowed according
   to the grammar defining the property's values, or is allowed by the grammar but
@@ -1157,7 +1157,7 @@ When convertToSpecifiedUnits(unitType) is called, the following steps are run:</
 </div>
 
 <p>Some SVG attributes contain lists of values, and to represent these values
-there are a number of SVG DOM <dfn id="TermListInterface">list interfaces</dfn>, one
+there are a number of SVG DOM <dfn id="TermListInterface" data-dfn-type="dfn" data-dfn-export>list interfaces</dfn>, one
 for each required element type – <a>SVGNumberList</a>, <a>SVGLengthList</a>,
 <a>SVGPointList</a>, <a>SVGTransformList</a> and <a>SVGStringList</a>.
 The first four are used to represent the base and
@@ -1214,7 +1214,7 @@ in an exception being thrown, as described below. <a>List interface</a> objects
 reflected through the animVal IDL attribute are always <em>read only</em>.</p>
 
 <p id="ListSynchronize">A <a>list interface</a> object
-is <dfn id="TermSynchronizeList">synchronized</dfn> by running
+is <dfn id="TermSynchronizeList" data-dfn-type="dfn" data-dfn-export>synchronized</dfn> by running
 the following steps:</p>
 
 <ol class='algorithm'>
@@ -1271,7 +1271,7 @@ the following steps:</p>
   </li>
 </ol>
 
-<p>Whenever a list element object is to be <dfn id="TermDetach">detached</dfn>,
+<p>Whenever a list element object is to be <dfn id="TermDetach" data-dfn-type="dfn" data-dfn-export>detached</dfn>,
 the following steps are run, depending on the list element type:</p>
 
 <dl class='switch'>
@@ -1308,7 +1308,7 @@ the following steps are run, depending on the list element type:</p>
   <dd>Nothing is done.</dd>
 </dl>
 
-<p>Whenever a list element object is to be <dfn id="TermAttach">attached</dfn>,
+<p>Whenever a list element object is to be <dfn id="TermAttach" data-dfn-type="dfn" data-dfn-export>attached</dfn>,
 the following steps are run, depending on the list element type:</p>
 <div class='ready-for-wider-review'>
 <dl class='switch'>
@@ -1578,7 +1578,7 @@ alias of baseVal.
 
 </div>
 
-<p>Some IDL attributes <dfn id="TermReflect">reflect</dfn> the value of a content attribute
+<p>Some IDL attributes <dfn id="TermReflect" data-dfn-type="dfn">reflect</dfn> the value of a content attribute
 or a property.  The way this reflection is done depends on the type of the IDL attribute:</p>
 
 <ul>
@@ -1607,7 +1607,7 @@ or a property.  The way this reflection is done depends on the type of the IDL a
 
 <div class="ready-for-wider-review">
 <p>Whenever a reflected content attribute's base value changes,
-then the reflecting object must be <dfn id="TermSynchronize">synchronized</dfn>,
+then the reflecting object must be <dfn id="TermSynchronize" data-dfn-type="dfn" data-dfn-export>synchronized</dfn>,
 immediately after the value changed, by running the following steps:</p>
 </div>
 
@@ -1623,7 +1623,7 @@ immediately after the value changed, by running the following steps:</p>
 </ol>
 
 <p>When a <a>reflected</a> content attribute is to be
-<dfn id="TermReserialize">reserialized</dfn>, optionally using a
+<dfn id="TermReserialize" data-dfn-type="dfn" data-dfn-export>reserialized</dfn>, optionally using a
 specific value, the following steps must be performed:</p>
 
 <ol class="algorithm">
@@ -1831,7 +1831,7 @@ following steps are run:</p>
   <li>Let <var>value</var> be the value of the reflected attribute
   (using the attribute's <a>initial value</a> if it is not present
   or invalid).</li>
-  <li>Return the <dfn id="TermNumericTypeValue">numeric type value</dfn>
+  <li>Return the <dfn id="TermNumericTypeValue" data-dfn-type="dfn" data-dfn-export>numeric type value</dfn>
   for <var>value</var>, according to the reflecting IDL attribute's
   definition.</li>
 </ol>


### PR DESCRIPTION
Fixes #417 

I've only touched the main spec and not the various sub specs, as that will take a while.

I included data-dfn-exports (seems to be a typo of using dfn-exports in the spec) to most things. I don't know if this is correct, but it seems if we want to mark things up as definitions then they are thinks that should be useful to export/link to. 