### PR TITLE
Update spec references for HTML, DOM and CSSOM

### DIFF
--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -986,8 +986,7 @@
   <interface name='SVGSolidcolorElement' href='pservers.html#InterfaceSVGSolidcolorElement'/>
   <interface name='SVGBoundingBoxOptions' href='types.html#SVGBoundingBoxOptions'/>
   <interface name='SVGNameList' href='types.html#ListInterfaces'/> <!-- not a real interface -->
-
-  <interface name='HTMLHyperlinkElementUtils' href='https://www.w3.org/TR/html5/links.html#htmlhyperlinkelementutils'/>
+  <interface name='HTMLHyperlinkElementUtils' href='https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils'/>
 
   <!-- ... grammar symbols ................................................ -->
   <symbol name='align' href='coords.html#DataTypeAlign'/>
@@ -1301,7 +1300,7 @@
   <interface name='CSSPrimitiveValue' href='https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-CSSPrimitiveValue'/>
   <interface name='CSSRule' href='https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-CSSRule'/>
   <interface name='Document' href='https://www.w3.org/TR/2015/REC-dom-20151119/#interface-document'/>
-  <interface name='DocumentAndElementEventHandlers' href='https://www.w3.org/TR/html5/webappapis.html#documentandelementeventhandlers'/>
+  <interface name='DocumentAndElementEventHandlers' href='https://html.spec.whatwg.org/multipage/webappapis.html#documentandelementeventhandlers'/>
   <interface name='DocumentFragment' href='https://www.w3.org/TR/2015/REC-dom-20151119/#interface-documentfragment'/>
   <interface name='ShadowRoot' href="https://www.w3.org/TR/shadow-dom/#the-shadowroot-interface" />
   <interface name='DocumentCSS' href='https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-DocumentCSS'/>
@@ -1337,7 +1336,7 @@
 
   <!-- ... terms .......................................................... -->
   <term name='event type' href='https://www.w3.org/TR/2013/WD-DOM-Level-3-Events-20131105/#event-types'/>
-  <term name='event handler content attribute' href='https://www.w3.org/TR/html51/webappapis.html#event-handler-content-event-handler-content-attribute'/>
+  <term name='event handler content attribute' href='https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes'/>
   <term name='compound selector' href='http://dev.w3.org/csswg/selectors4/#compound'/>
   <term name='compound selectors' href='http://dev.w3.org/csswg/selectors4/#compound'/>
   <term name='tree order' href='https://www.w3.org/TR/2014/WD-dom-20140204/#concept-tree-order'/>
@@ -1345,13 +1344,13 @@
   <term name='NoModificationAllowedError' href='https://heycam.github.io/webidl/#nomodificationallowederror'/>
   <term name='NotSupportedError' href='https://heycam.github.io/webidl/#notsupportederror'/>
   <term name='SyntaxError' href='https://heycam.github.io/webidl/#syntaxerror'/>
-  <term name='CORS settings attribute' href='https://www.w3.org/TR/html51/infrastructure.html#cors-settings-attribute'/>
-  <term name='limited to only known values' href='https://www.w3.org/TR/html51/infrastructure.html#limited-to-only-known-values'/>
-  <term name='No CORS' href='https://www.w3.org/TR/html51/infrastructure.html#cors-settings-attributes'/>
+  <term name='CORS settings attribute' href='https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attribute'/>
+  <term name='limited to only known values' href='https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#limited-to-only-known-values'/>
+  <term name='No CORS' href='https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attribute'/>
   <term name='origin' href='https://www.w3.org/TR/html/browsers.html#concept-cross-origin'/>
-  <term name='set of space-separated tokens' href='https://www.w3.org/TR/html51/infrastructure.html#set-of-space-separated-tokens'/>
-  <term name='set of comma-separated tokens' href='https://www.w3.org/TR/html51/infrastructure.html#set-of-comma-separated-tokens'/>
-  <term name='same origin' href='https://www.w3.org/TR/html51/browsers.html#same-origin'/>
+  <term name='set of space-separated tokens' href='https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#set-of-space-separated-tokens'/>
+  <term name='set of comma-separated tokens' href='https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#set-of-comma-separated-tokens'/>
+  <term name='same origin' href='https://html.spec.whatwg.org/multipage/origin.html#same-origin'/>
   <term name='throw' href='https://heycam.github.io/webidl/#dfn-throw'/>
   <term name='thrown' href='https://heycam.github.io/webidl/#dfn-throw'/>
 

--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -1294,25 +1294,25 @@
   <!-- ... interfaces ..................................................... -->
 
   <interface name='AbstractView' href='https://www.w3.org/TR/DOM-Level-2-Views/views.html#Views-AbstractView'/>
-  <interface name='CharacterData' href='https://www.w3.org/TR/2014/WD-dom-20140204/#interface-characterdata'/>
-  <interface name='Comment' href='https://www.w3.org/TR/2014/WD-dom-20140204/#comment'/>
-  <interface name='CSSStyleDeclaration' href='https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-CSSStyleDeclaration'/>
+  <interface name='CharacterData' href='https://dom.spec.whatwg.org/#interface-characterdata'/>
+  <interface name='Comment' href='https://dom.spec.whatwg.org/#interface-comment'/>
+  <interface name='CSSStyleDeclaration' href='https://www.w3.org/TR/cssom-1/#the-cssstyledeclaration-interface'/>
   <interface name='CSSPrimitiveValue' href='https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-CSSPrimitiveValue'/>
-  <interface name='CSSRule' href='https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-CSSRule'/>
-  <interface name='Document' href='https://www.w3.org/TR/2015/REC-dom-20151119/#interface-document'/>
+  <interface name='CSSRule' href='https://www.w3.org/TR/cssom-1/#the-cssrule-interface'/>
+  <interface name='Document' href='https://dom.spec.whatwg.org/#interface-document'/>
   <interface name='DocumentAndElementEventHandlers' href='https://html.spec.whatwg.org/multipage/webappapis.html#documentandelementeventhandlers'/>
-  <interface name='DocumentFragment' href='https://www.w3.org/TR/2015/REC-dom-20151119/#interface-documentfragment'/>
-  <interface name='ShadowRoot' href="https://www.w3.org/TR/shadow-dom/#the-shadowroot-interface" />
+  <interface name='DocumentFragment' href='https://dom.spec.whatwg.org/#interface-documentfragment'/>
+  <interface name='ShadowRoot' href='https://dom.spec.whatwg.org/#interface-shadowroot'/>
   <interface name='DocumentCSS' href='https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-DocumentCSS'/>
-  <interface name='DOMImplementation' href='https://www.w3.org/TR/2014/WD-dom-20140204/#domimplementation'/>
-  <interface name='DOMException' href='https://www.w3.org/TR/2014/WD-dom-20140204/#exception-domexception'/>
+  <interface name='DOMImplementation' href='https://dom.spec.whatwg.org/#interface-domimplementation'/>
+  <interface name='DOMException' href='https://heycam.github.io/webidl/#idl-DOMException'/>
   <interface name='DOMStringMap' href='https://html.spec.whatwg.org/multipage/dom.html#domstringmap'/>
-  <interface name='DOMTokenList' href='https://www.w3.org/TR/dom/#domtokenlist'/>
-  <interface name='Element' href='https://www.w3.org/TR/2014/WD-dom-20140204/#element'/>
+  <interface name='DOMTokenList' href='https://dom.spec.whatwg.org/#interface-domtokenlist'/>
+  <interface name='Element' href='https://dom.spec.whatwg.org/#interface-element'/>
   <interface name='EventHandler' href='https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler'/>
-  <interface name='EventListener' href='https://www.w3.org/TR/2014/WD-dom-20140204/#eventlistener'/>
-  <interface name='EventTarget' href='https://www.w3.org/TR/2014/WD-dom-20140204/#eventtarget'/>
-  <interface name='Event' href='https://www.w3.org/TR/2014/WD-dom-20140204/#event'/>
+  <interface name='EventListener' href='https://dom.spec.whatwg.org/#callbackdef-eventlistener'/>
+  <interface name='EventTarget' href='https://dom.spec.whatwg.org/#interface-eventtarget'/>
+  <interface name='Event' href='https://dom.spec.whatwg.org/#interface-event'/>
   <interface name='event handler content attributes' href='https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes'/>
   <interface name='event handler IDL attributes' href='https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes'/>
   <interface name='event handlers' href='https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers'/>
@@ -1326,8 +1326,8 @@
   <interface name='HTMLVideoElement' href='https://html.spec.whatwg.org/multipage/media.html#htmlvideoelement'/>
   <interface name='HTMLElement' href='https://html.spec.whatwg.org/multipage/dom.html#htmlelement'/>
   <interface name='LinkStyle' href='https://www.w3.org/TR/cssom-1/#the-linkstyle-interface'/>
-  <interface name='Node' href='https://www.w3.org/TR/2014/WD-dom-20140204/#node'/>
-  <interface name='NodeList' href='https://www.w3.org/TR/2014/WD-dom-20140204/#nodelist'/>
+  <interface name='Node' href='https://dom.spec.whatwg.org/#interface-node'/>
+  <interface name='NodeList' href='https://dom.spec.whatwg.org/#interface-nodelist'/>
   <interface name='RGBColor' href='https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-RGBColor'/>
   <interface name='ViewCSS' href='https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-ViewCSS'/>
   <interface name='Window' href='https://html.spec.whatwg.org/multipage/window-object.html#window'/>
@@ -1335,11 +1335,11 @@
   <interface name='Animation' href='https://www.w3.org/TR/web-animations-1/#the-animation-interface' />
 
   <!-- ... terms .......................................................... -->
-  <term name='event type' href='https://www.w3.org/TR/2013/WD-DOM-Level-3-Events-20131105/#event-types'/>
+  <term name='event type' href='https://dom.spec.whatwg.org/#ref-for-dom-event-type'/>
   <term name='event handler content attribute' href='https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes'/>
   <term name='compound selector' href='http://dev.w3.org/csswg/selectors4/#compound'/>
   <term name='compound selectors' href='http://dev.w3.org/csswg/selectors4/#compound'/>
-  <term name='tree order' href='https://www.w3.org/TR/2014/WD-dom-20140204/#concept-tree-order'/>
+  <term name='tree order' href='https://dom.spec.whatwg.org/#concept-tree-order'/>
   <term name='IndexSizeError' href='https://heycam.github.io/webidl/#indexsizeerror'/>
   <term name='NoModificationAllowedError' href='https://heycam.github.io/webidl/#nomodificationallowederror'/>
   <term name='NotSupportedError' href='https://heycam.github.io/webidl/#notsupportederror'/>


### PR DESCRIPTION
Updated the remaining references for HTML, DOM, and CSSOM.

There are various DOM L2 Views and Style references that I didn't update as they don't exist in either DOM or CSSOM. They need checked to see if they should be removed (AbstractView, CSSPrimitiveValue, DocumentCSS, RGBColor, ViewCSS). None of these interfaces are in Edge, and probably not in other browsers either.