### PR TITLE
Update property index

### DIFF
--- a/master/propidx.html
+++ b/master/propidx.html
@@ -61,39 +61,6 @@
           <td>yes</td>
         </tr>
         <tr>
-          <th><a>'clip'</a></th>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/visufx.html#value-def-shape">          <span          class="value-inst-shape noxref">&lt;shape&gt;</span></a>
-          | auto </td>
-          <td>auto</td>
-          <td><a href="coords.html#ElementsThatEstablishViewports">elements
-          which establish a new SVG viewport</a>, <a>'pattern'</a> elements and <a>'marker element'</a> elements</td>
-          <td>no</td>
-          <td>N/A</td>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
-          <td>yes</td>
-        </tr>
-        <tr>
-          <th><a>'clip-path'</a></th>
-          <td>&lt;basic-shape&gt; | <a>&lt;url&gt;</a> |
-          none </td>
-          <td>none</td>
-          <td><a>'use'</a>, <a>container elements</a> and <a>graphics elements</a></td>
-          <td>no</td>
-          <td>N/A</td>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
-          <td>yes</td>
-        </tr>
-        <tr>
-          <th><a>'clip-rule'</a></th>
-          <td>nonzero | evenodd </td>
-          <td>nonzero</td>
-          <td><a>'use'</a> and <a>graphics elements</a> within a <a>'clipPath'</a> element</td>
-          <td>yes</td>
-          <td>N/A</td>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
-          <td>yes</td>
-        </tr>
-        <tr>
           <th><a>'color'</a></th>
           <td><a>&lt;color&gt;</a>
           </td>
@@ -122,19 +89,6 @@
           <td>yes</td>
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
-          <td>yes</td>
-        </tr>
-        <tr>
-          <th><a>'cursor property'</a></th>
-          <td>[ [<a>&lt;url&gt;</a>
-          ,]* [ auto | crosshair | default | pointer | move |
-          e-resize | ne-resize | nw-resize | n-resize | se-resize |
-          sw-resize | s-resize | w-resize| text | wait | help ] ]</td>
-          <td>auto</td>
-          <td><a>container elements</a>, <a>graphics elements</a> and <a>'use'</a></td>
-          <td>yes</td>
-          <td>N/A</td>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a>, <a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#interactive-media-group">          interactive</a></td>
           <td>yes</td>
         </tr>
         <tr>
@@ -206,128 +160,8 @@
           <td>yes</td>
         </tr>
         <tr>
-          <th><a>'filter property'</a></th>
-          <td>&lt;filter-function-list&gt; | none </td>
-          <td>none</td>
-          <td><a>container elements</a>, <a>graphics elements</a> and <a>'use'</a></td>
-          <td>no</td>
-          <td>N/A</td>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
-          <td>yes</td>
-        </tr>
-        <tr>
-          <th><a>'flood-color'</a></th>
-          <td>currentColor |<br />
-           <a>&lt;color&gt;</a>
-           [<a>&lt;icccolor&gt;</a>]</td>
-          <td>black</td>
-          <td><a>'feFlood'</a> elements</td>
-          <td>no</td>
-          <td>N/A</td>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
-          <td>yes</td>
-        </tr>
-        <tr>
-          <th><a>'flood-opacity'</a></th>
-          <td><a>&lt;alpha-value&gt;</a> </td>
-          <td>1</td>
-          <td><a>'feFlood'</a> elements</td>
-          <td>no</td>
-          <td>N/A</td>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
-          <td>yes</td>
-        </tr>
-        <tr>
-          <th><a>'font property'</a></th>
-          <td>[ [ <a>'font-style'</a>
-          || <a>'font-variant'</a>
-          || <a>'font-weight'</a>
-          ]? <a>'font-size'</a>
-          [ / <a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/visudet.html#propdef-line-height">          <span          class="propinst-line-height noxref">'line-height'</span></a>
-          ]? <a>'font-family'</a>
-          ] | caption | icon | menu | message-box | small-caption |
-          status-bar </td>
-          <td>see individual properties</td>
-          <td><a>text content elements</a></td>
-          <td>yes</td>
-          <td>see individual properties</td>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
-          <td>yes <sup><a href='#note1'>[1]</a></sup></td>
-        </tr>
-        <tr>
-          <th><a>'font-family'</a></th>
-          <td>[[ <a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/fonts.html#value-def-family-name">          <span          class="value-inst-family-name noxref">&lt;family-name&gt;</span></a>
-          | <a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/fonts.html#value-def-generic-family">          <span          class="value-inst-generic-family noxref">&lt;generic-family&gt;</span></a>
-          ],]* [ <a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/fonts.html#value-def-family-name">          <span          class="value-inst-family-name noxref">&lt;family-name&gt;</span></a>
-          | <a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/fonts.html#value-def-generic-family">          <span          class="value-inst-generic-family noxref">&lt;generic-family&gt;</span></a>]
-          </td>
-          <td>depends on user agent</td>
-          <td><a>text content elements</a></td>
-          <td>yes</td>
-          <td>N/A</td>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
-          <td>yes</td>
-        </tr>
-        <tr>
-          <th><a>'font-size'</a></th>
-          <td><a href="https://www.w3.org/TR/css-fonts-3/#absolute-size-value"><span class="value-inst-absolute-size noxref">&lt;absolute-size&gt;</span></a>
-          | <a href="https://www.w3.org/TR/css-fonts-3/#relative-size-value"><span class="value-inst-relative-size noxref">&lt;relative-size&gt;</span></a>
-          | <a>&lt;length-percentage&gt;</a>
-          </td>
-          <td>medium</td>
-          <td><a>text content elements</a></td>
-          <td>yes, the computed value is inherited</td>
-          <td>refer to parent element's font size</td>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
-          <td>yes</td>
-        </tr>
-        <tr>
-          <th><a>'font-size-adjust'</a></th>
-          <td><a>&lt;number&gt;</a>| none</td>
-          <td>none</td>
-          <td><a>text content elements</a></td>
-          <td>yes</td>
-          <td>N/A</td>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
-          <td>yes <sup><a href='#note1'>[1]</a></sup></td>
-        </tr>
-        <tr>
-          <th><a>'font-stretch'</a></th>
-          <td>normal | wider | narrower | ultra-condensed |
-          extra-condensed | condensed | semi-condensed |
-          semi-expanded | expanded | extra-expanded |
-          ultra-expanded </td>
-          <td>normal</td>
-          <td><a>text content elements</a></td>
-          <td>yes</td>
-          <td>N/A</td>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
-          <td>yes</td>
-        </tr>
-        <tr>
-          <th><a>'font-style'</a></th>
-          <td>normal | italic | oblique </td>
-          <td>normal</td>
-          <td><a>text content elements</a></td>
-          <td>yes</td>
-          <td>N/A</td>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
-          <td>yes</td>
-        </tr>
-        <tr>
           <th><a>'font-variant'</a></th>
           <td>normal | small-caps </td>
-          <td>normal</td>
-          <td><a>text content elements</a></td>
-          <td>yes</td>
-          <td>N/A</td>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
-          <td>yes</td>
-        </tr>
-        <tr>
-          <th><a>'font-weight'</a></th>
-          <td>normal | bold | bolder | lighter | 100 | 200 | 300 |
-          400 | 500 | 600 | 700 | 800 | 900 </td>
           <td>normal</td>
           <td><a>text content elements</a></td>
           <td>yes</td>
@@ -351,30 +185,6 @@
           <td>auto</td>
           <td>images</td>
           <td>yes</td>
-          <td>N/A</td>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
-          <td>yes</td>
-        </tr>
-        <tr>
-          <th><a>'letter-spacing'</a></th>
-          <td>normal | <a>&lt;length&gt;</a> </td>
-          <td>normal</td>
-          <td><a>text content elements</a></td>
-          <td>yes</td>
-          <td>N/A</td>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
-          <td>yes</td>
-        </tr>
-        <tr>
-          <th><a>'lighting-color'</a></th>
-          <td>currentColor |<br />
-           <a>&lt;color&gt;</a>
-           [<a>&lt;icccolor&gt;</a>]</td>
-          <td>white</td>
-          <td><a>'feDiffuseLighting'</a> and
-          <a>'feSpecularLighting'</a>
-          elements</td>
-          <td>no</td>
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
@@ -407,16 +217,6 @@
           <td>none</td>
           <td><a>shapes</a></td>
           <td>yes</td>
-          <td>N/A</td>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
-          <td>yes</td>
-        </tr>
-        <tr>
-          <th><a>'mask property'</a></th>
-          <td><a>&lt;url&gt;</a> | none </td>
-          <td>none</td>
-          <td><a>container elements</a>, <a>graphics elements</a> and <a>'use'</a></td>
-          <td>no</td>
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
@@ -613,16 +413,6 @@
           <td>yes</td>
         </tr>
         <tr>
-          <th><a>'unicode-bidi'</a></th>
-          <td>normal | embed | bidi-override </td>
-          <td>normal</td>
-          <td><a>text content elements</a></td>
-          <td>no</td>
-          <td>N/A</td>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
-          <td>no</td>
-        </tr>
-        <tr>
           <th><a>'vector-effect'</a></th>
           <td>non-scaling-stroke | none</td>
           <td>none</td>
@@ -638,16 +428,6 @@
           <td>visible</td>
           <td><a>graphics elements</a>, <a>'use'</a> and the <a>'a'</a> element
             when it is a child of a <a>text content element</a></td>
-          <td>yes</td>
-          <td>N/A</td>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
-          <td>yes</td>
-        </tr>
-        <tr>
-          <th><a>'word-spacing'</a></th>
-          <td>normal | <a>&lt;length&gt;</a> </td>
-          <td>normal</td>
-          <td><a>text content elements</a></td>
           <td>yes</td>
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>

--- a/master/propidx.html
+++ b/master/propidx.html
@@ -32,6 +32,7 @@
           <th>Percentages</th>
           <th>Media</th>
           <th title='Animatable'><a href="https://svgwg.org/specs/animations/#Animatable">Anim.</a></th>
+          <th>Computed value</th>
         </tr>
       </thead>
       <tbody>
@@ -46,6 +47,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified</td>
         </tr>
         <tr>
           <th><a>'baseline-shift'</a></th>
@@ -59,6 +61,7 @@
           the case of SVG is defined to be equal to the font size</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>absolute length, percentage, or keyword specified</td>
         </tr>
         <tr>
           <th><a>'color'</a></th>
@@ -70,6 +73,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>an RGBA color</td>
         </tr>
         <tr>
           <th><a>'color-interpolation'</a></th>
@@ -80,6 +84,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified</td>
         </tr>
         <tr>
           <th><a>'color-rendering'</a></th>
@@ -90,6 +95,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified</td>
         </tr>
         <tr>
           <th><a>'direction'</a></th>
@@ -100,6 +106,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>no</td>
+          <td>as specified</td>
         </tr>
         <tr>
           <th><a>'display'</a></th>
@@ -113,8 +120,9 @@
           <a>'foreignObject'</a>, <a>'use'</a> and <a>graphics elements</a></td>
           <td>no</td>
           <td>N/A</td>
-          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#all-media-group">          all</a></td>
+          <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#all-media-group">all</a></td>
           <td>yes</td>
+          <td></td>
         </tr>
         <tr>
           <th><a>'dominant-baseline'</a></th>
@@ -127,6 +135,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified</td>
         </tr>
         <tr>
           <th><a>'fill'</a></th>
@@ -138,6 +147,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified, but with <a>&lt;color></a> values computed and <a>&lt;url></a> values made absolute</td>
         </tr>
         <tr>
           <th><a>'fill-opacity'</a></th>
@@ -148,6 +158,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>the specified value converted to a number, clamped to the range [0,1]</td>
         </tr>
         <tr>
           <th><a>'fill-rule'</a></th>
@@ -158,6 +169,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified</td>
         </tr>
         <tr>
           <th><a>'font-variant'</a></th>
@@ -168,6 +180,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>see individual properties</td>
         </tr>
         <tr>
           <th><a>'glyph-orientation-vertical'</a></th>
@@ -178,6 +191,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>no</td>
+          <td>as specified</td>
         </tr>
         <tr>
           <th><a>'image-rendering'</a></th>
@@ -188,6 +202,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified</td>
         </tr>
         <tr>
           <th><a>'line-height'</a></th>
@@ -198,6 +213,7 @@
           <td>refer to font size of element itself</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>for <a>&lt;length-percentage></a> the absolute value; otherwise as specified</td>
         </tr>
         <tr>
           <th><a>'marker property'</a></th>
@@ -208,6 +224,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>see individual properties</td>
         </tr>
         <tr>
           <th><a>'marker-end'</a><br />
@@ -220,6 +237,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified, but with <a>&lt;url></a> values (that are part of a <a>&lt;marker-ref></a>) made absolute</td>
         </tr>
         <tr>
           <th><a>'opacity'</a></th>
@@ -232,6 +250,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>the specified value converted to a number, clamped to the range [0,1]</td>
         </tr>
         <tr>
           <th><a>'overflow'</a></th>
@@ -243,6 +262,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified</td>
         </tr>
         <tr class="ready-for-wider-review">
           <th><a>'paint-order'</a></th>
@@ -253,6 +273,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified</td>
         </tr>
         <tr>
           <th><a>'pointer-events'</a></th>
@@ -265,6 +286,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified</td>
         </tr>
         <tr>
           <th><a>'shape-rendering'</a></th>
@@ -276,6 +298,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified</td>
         </tr>
         <tr>
           <th><a>'stop-color'</a></th>
@@ -288,6 +311,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td></td>
         </tr>
         <tr>
           <th><a>'stop-opacity'</a></th>
@@ -298,6 +322,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td></td>
         </tr>
         <tr>
           <th><a>'stroke'</a></th>
@@ -309,6 +334,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified, but with <a>&lt;color></a> values computed and <a>&lt;url></a> values made absolute</td>
         </tr>
         <tr>
           <th><a>'stroke-dasharray'</a></th>
@@ -319,6 +345,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes <sup><a href='#note1'>[1]</a></sup></td>
+          <td>absolute lengths or percentages for <a>&lt;dasharray></a>, or keyword specified</td>
         </tr>
         <tr>
           <th><a>'stroke-dashoffset'</a></th>
@@ -329,6 +356,7 @@
           <td>refer to the size of the current SVG viewport</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>absolute length or percentage</td>
         </tr>
         <tr>
           <th><a>'stroke-linecap'</a></th>
@@ -339,6 +367,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified</td>
         </tr>
         <tr>
           <th><a>'stroke-linejoin'</a></th>
@@ -349,6 +378,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified</td>
         </tr>
         <tr>
           <th><a>'stroke-miterlimit'</a></th>
@@ -359,6 +389,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified</td>
         </tr>
         <tr>
           <th><a>'stroke-opacity'</a></th>
@@ -369,6 +400,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>the specified value converted to a number, clamped to the range [0,1]</td>
         </tr>
         <tr>
           <th><a>'stroke-width'</a></th>
@@ -379,6 +411,7 @@
           <td>refer to the size of the current SVG viewport</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>absolute length or percentage</td>
         </tr>
         <tr>
           <th><a>'text-anchor'</a></th>
@@ -389,6 +422,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified</td>
         </tr>
         <tr>
           <th><a>'text-decoration'</a></th>
@@ -400,6 +434,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>see individual properties</td>
         </tr>
         <tr>
           <th><a>'text-rendering'</a></th>
@@ -411,6 +446,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified</td>
         </tr>
         <tr>
           <th><a>'vector-effect'</a></th>
@@ -421,6 +457,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified</td>
         </tr>
         <tr>
           <th><a>'visibility'</a></th>
@@ -432,6 +469,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified</td>
         </tr>
         <tr class="ready-for-wider-review">
           <th><a>'white-space'</a></th>
@@ -442,6 +480,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
+          <td>as specified</td>
         </tr>
         <tr>
           <th><a>'writing-mode'</a></th>
@@ -452,6 +491,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>no</td>
+          <td>as specified</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
First part of #82.

I've added the computed value column and removed all properties that link to other specs.

I've an open question about a number of the other ones. They're often defined elsewhere, so feel like they should be removed, but link to parts of the SVG spec. They sometimes just give some historical information about how it has changed since 1.1 that doesn't seem much value can can probably be removed and the information added to the changelog (if not there already). Others Give additional rules about SVG. 1 or 2 give the definition block in SVG and link to a CSS spec (which don't always match). White-space is an example of the latter: https://svgwg.org/svg2-draft/text.html#WhiteSpaceProperty vs https://www.w3.org/TR/css-text-3/#white-space-property I think the computed value saying to see individual properties is a typo in SVG.

Some are short hands in CSS but only include the old non-shorthand values in the SVG propindex. The description in SVG usually gives the historical differences and mentions to use the new definition, making the prop index definition out of date.  I'm not sure if these should just be removed from the index and perhaps the prose.

There are some that seem exactly the same in SVG and CSS but they just apply to different elements (CSS usually says all elements while SVG restricts them). This also applies to properties that link directly to the CSS spec that I've removed, so need to work out what to do here. Perhaps the CSS specs should be updated to include SVG info for these. Or we should remove from the prop index but keep the definitions, restricting to just the differences between how they apply to HTML and SVG? (leaving historical info to the changelog as mentioned previously?)

Also some like stop-colour and stop-opacity don't have a computed value defined in the SVG spec. That seems like an oversight. 