### PR TITLE
Remove unused defs and fix some linking issues

### DIFF
--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -309,7 +309,6 @@
       attributecategories='core, global event, document element event, presentation, style'
       interfaces='SVGStopElement'>
     <attribute name='offset' href='pservers.html#StopElementOffsetAttribute' animatable='yes'/>
-    <attribute name='path'   href='pservers.html#StopElementPathAttribute' animatable='yes'/>
   </element>
 
   <element
@@ -881,7 +880,6 @@
   <interface name='SVGRadialGradientElement' href='pservers.html#InterfaceSVGRadialGradientElement'/>
   <interface name='SVGStopElement' href='pservers.html#InterfaceSVGStopElement'/>
   <interface name='SVGPatternElement' href='pservers.html#InterfaceSVGPatternElement'/>
-  <interface name='SVGCursorElement' href='interact.html#InterfaceSVGCursorElement'/>
   <interface name='SVGAElement' href='linking.html#InterfaceSVGAElement'/>
   <interface name='SVGViewElement' href='linking.html#InterfaceSVGViewElement'/>
   <interface name='SVGScriptElement' href='interact.html#InterfaceSVGScriptElement'/>

--- a/master/refs.html
+++ b/master/refs.html
@@ -107,7 +107,7 @@
   <dd><div>Allen Wirfs-Brock. <a href="http://www.ecma-international.org/ecma-262/6.0/index.html"><cite>ECMA-262 6th Edition, The ECMAScript 2015 Language Specification</cite></a>. June 2015. Standard. URL:&nbsp;<a href="http://www.ecma-international.org/ecma-262/6.0/index.html">http://www.ecma-international.org/ecma-262/6.0/index.html</a></div></dd>
 
   <dt id="ref-filter-effects-1" class="normref">[<a href="https://www.w3.org/TR/filter-effects-1/">filter-effects-1</a>]</dt>
-  <dd><div>Dean Jackson; Erik Dahlström; Dirk Schulze. <a href="https://www.w3.org/TR/filter-effects-1/"><cite>Filter Effects Module Level 1</cite></a>. 25 November 2014. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/filter-effects-1/">https://www.w3.org/TR/filter-effects-1/</a> ED:&nbsp;<a href="http://dev.w3.org/fxtf/filters/">http://dev.w3.org/fxtf/filters/</a></div></dd>
+  <dd><div>Dean Jackson; Erik Dahlström; Dirk Schulze. <a href="https://www.w3.org/TR/filter-effects-1/"><cite>Filter Effects Module Level 1</cite></a>. 25 November 2014. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/filter-effects-1/">https://www.w3.org/TR/filter-effects-1/</a> ED:&nbsp;<a href="https://dev.w3.org/fxtf/filters/">https://dev.w3.org/fxtf/filters/</a></div></dd>
 
   <dt id="ref-html" class="normref">[<a href="https://html.spec.whatwg.org/multipage/">HTML</a>]</dt>
   <dd><div>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Living Standard. URL:&nbsp;<a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a></div></dd>

--- a/master/struct.html
+++ b/master/struct.html
@@ -2393,13 +2393,13 @@ specifications. [<a href="refs.html#ref-wai-aria">wai-aria</a>] [<a href="refs.h
     <tr>
       <td><a>'audio'</a></td>
       <td>platform-specific role mappings, 
-        as defined in the <a href="https://w3c.github.io/html-aam/#html-element-role-mappings">HTML Accessibility API Mappings</a> specification</td>
+        as defined in the <a href="https://w3c.github.io/html-aam/#x4-4-html-element-role-mappings">HTML Accessibility API Mappings</a> specification</td>
       <td>If specified, role must be <code>application</code></td>
     </tr>
     <tr>
       <td><a>'canvas'</a></td>
       <td>platform-specific role mappings, 
-        as defined in the <a href="https://w3c.github.io/html-aam/#html-element-role-mappings">HTML Accessibility API Mappings</a> specification</td>
+        as defined in the <a href="https://w3c.github.io/html-aam/#x4-4-html-element-role-mappings">HTML Accessibility API Mappings</a> specification</td>
       <td>no restrictions</td>
     </tr>
     <tr>
@@ -2578,7 +2578,7 @@ specifications. [<a href="refs.html#ref-wai-aria">wai-aria</a>] [<a href="refs.h
     <tr>
       <td><a>'iframe'</a></td>
       <td>platform-specific role mappings, 
-        as defined in the <a href="https://w3c.github.io/html-aam/#html-element-role-mappings">HTML Accessibility API Mappings</a> specification</td>
+        as defined in the <a href="https://w3c.github.io/html-aam/#x4-4-html-element-role-mappings">HTML Accessibility API Mappings</a> specification</td>
       <td>If Specified, role must be either <code title="attr-aria-role-application">application</code>, <code title="attr-aria-role-document">document</code>, or <code title="attr-aria-role-img">img</code> roles</td>
     </tr>
     <tr>
@@ -2730,7 +2730,7 @@ specifications. [<a href="refs.html#ref-wai-aria">wai-aria</a>] [<a href="refs.h
     <tr>
       <td><a>'video'</a></td>
       <td>platform-specific role mappings, 
-        as defined in the <a href="https://w3c.github.io/html-aam/#html-element-role-mappings">HTML Accessibility API Mappings</a> specification</td>
+        as defined in the <a href="https://w3c.github.io/html-aam/#x4-4-html-element-role-mappings">HTML Accessibility API Mappings</a> specification</td>
       <td>If specified, role must be <code>application</code></td>
     </tr>
     <tr>


### PR DESCRIPTION
Some of our links go to places that don't offer any exports. Updating the HTML AAM ones to the h3 which should automatically export. Filed a bug on Filters spec for them to fix the issue in their spec that causes linting issues here.