### PR TITLE
Remove defintion of white-space

### DIFF
--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -748,7 +748,6 @@
   <property name='shape-subtract'  href='text.html#TextShapeSubtract'/>
   <property name='shape-padding'   href='text.html#TextShapePadding'/>
   <property name='text-overflow'   href='text.html#TextOverflowProperty'/>
-  <property name='white-space'     href='text.html#WhiteSpaceProperty'/>
 
   <!-- ... font properties defined in CSS Fonts 3 -->
   <property name='font-kerning'     href='https://www.w3.org/TR/css-fonts-3/#font-kerning-prop'/>
@@ -776,6 +775,7 @@
   <property name='text-indent'     href='https://www.w3.org/TR/css-text-3/#text-indent-property'/>
   <property name='text-justify'    href='https://www.w3.org/TR/css-text-3/#text-justify-property'/>
   <property name='text-transform'  href='https://www.w3.org/TR/css-text-3/#text-transform-property'/>
+  <property name='white-space'     href='https://www.w3.org/TR/css-text-3/#white-space-property'/>
   <property name='word-break'      href='https://www.w3.org/TR/css-text-3/#word-break-property'/>
   <property name='word-spacing'    href='https://www.w3.org/TR/css-text-3/#word-spacing-property'/>
   <property name='word-wrap'       href='https://www.w3.org/TR/css-text-3/#overflow-wrap-property'/>

--- a/master/text.html
+++ b/master/text.html
@@ -5692,48 +5692,9 @@ the dash pattern at the same positions across different implementations.</p>
     <li>whether lines may wrap at unforced soft wrap opportunities</li>
   </ul>
 
-  <table class="propdef def">
-    <tr>
-      <th>Name:</th>
-      <td><dfn id="WhiteSpaceProperty" data-dfn-type="property" data-dfn-export="">white-space</dfn></td>
-    </tr>
-    <tr>
-      <th>Value:</th>
-      <td>normal | pre | nowrap | pre-wrap | pre-line </td>
-    </tr>
-    <tr>
-      <th>Initial:</th>
-      <td>normal </td>
-    </tr>
-    <tr>
-      <th>Applies to:</th>
-      <td><a>text content elements</a></td>
-    </tr>
-    <tr>
-      <th>Inherited:</th>
-      <td>yes</td>
-    </tr>
-    <tr>
-      <th>Percentages:</th>
-      <td>N/A</td>
-    </tr>
-    <tr>
-      <th>Media:</th>
-      <td>visual</td>
-    </tr>
-    <tr>
-      <th>Computed&#160;value:</th>
-      <td>see individual properties </td>
-    </tr>
-    <tr>
-      <th><a>Animatable</a>:</th>
-      <td>yes</td>
-    </tr>
-  </table>
-
   <p class="note">
     Values and their meanings are defined in
-    <a href="https://www.w3.org/TR/css-text-3/#white-space-property">CSS3
+    <a href="https://www.w3.org/TR/css-text-3/#white-space-property">CSS
     Text Module Level 3</a>.[<a href="refs.html#ref-css-text-3">css-text-3</a>]
   </p>
 
@@ -5764,8 +5725,7 @@ the dash pattern at the same positions across different implementations.</p>
       <p class="caption">
 	Example of multi-line vertical text with line breaks. The text
 	is from the Japanese poem <em>Iroha</em>. The lines are broken
-	at traditional places. <span class="annotation">Example does not
-	  render properly in Firefox. It is SVG 1.1 text. Bad Firefox.</span>
+	at traditional places.
       </p>
     </div>
   </div>


### PR DESCRIPTION
Fixes #447

The spec redefines white-space, which is defined in CSS Text Level 3 (which is also pointed out in the note). Removing this means the incorrect computed value is removed and makes sure implementers/devs use the CSS version.

Also removed the compat info about Firefox.