### PR TITLE
Remove unneeded 'shape-outside' definition. Fixes #288.

### DIFF
--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -731,7 +731,6 @@
   <property name='line-height'     href='text.html#LineHeightProperty'/>
   <property name='shape-image-threshold' href='text.html#TextShapeImageThreshold'/>
   <property name='shape-inside'    href='text.html#TextShapeInside'/>
-  <property name='shape-outside'   href='http://dev.w3.org/csswg/css-shapes/#shape-outside-property'/>
   <property name='shape-margin'    href='text.html#TextShapeMargin'/>
   <property name='shape-subtract'  href='text.html#TextShapeSubtract'/>
   <property name='shape-padding'   href='text.html#TextShapePadding'/>


### PR DESCRIPTION
No visible change in spec.