### PR TITLE
Fix reference for isolation property

### DIFF
--- a/master/styling.html
+++ b/master/styling.html
@@ -554,9 +554,12 @@ animating the corresponding property.</p>
     [<a href='refs.html#ref-css3-color'>css3-color</a>]</li>
 
   <li>the <a>'color-interpolation-filters'</a>, <a>'filter property'</a>,
-    <a>'flood-color'</a>, <a>'flood-opacity'</a>, <a>'isolation property'</a>
+    <a>'flood-color'</a>, <a>'flood-opacity'</a>
     and <a>'lighting-color'</a> properties
     [<a href='refs.html#ref-filter-effects-1'>filter-effects-1</a>]</li>
+
+  <li>the <a>'isolation property'</a> property
+    [<a href='refs.html#ref-compositing-1'>compositing-1</a>]</li>
 
   <li>the <a>'transform'</a>, <a>'transform-box'</a> and <a>'transform-origin'</a> properties
     [<a href='refs.html#ref-css-transforms-1'>css-transforms-1</a>]</li>


### PR DESCRIPTION
The isolation property mentioned in Required properties is defined in defined
in Compositing and Blending Level 1.

fixes #472