### PR TITLE
Textpath pathlength

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -546,9 +546,15 @@ have been made.</p>
 
 <div class='changed-since-cr1'>
 <ul>
+
   <li>Specify <a>DOMPointInit</a> as argument type for getCharNumAtPosition() instead of
     <a>DOMPoint</a>.
   </li>
+
+  <li>Removed unintended restriction that <a>'path/pathLength'</a> applied only to <span class='element'>path</span>s
+    and not <a>shapes</a>.
+  </li>
+
 </ul>
 </div>
 

--- a/master/text.html
+++ b/master/text.html
@@ -3521,8 +3521,7 @@
 		      <a>'textPath'</a> element's
 		      <a>'textPath/startOffset'</a> attribute, adjusted
 		      due to any <a>'path/pathLength'</a> attribute on the
-		      referenced element (if the referenced element is
-		      a <a>'path element'</a> element).
+		      referenced element.
 		    </li>
 		    <li>
 		      Let <var>advance</var> = the advance of


### PR DESCRIPTION
Remove unintended restriction that 'pathLength' only applied to paths and not shapes in regard to 'startOffset'.

Fixes #382.