### PR TITLE
remove redundant words

### DIFF
--- a/master/coords.html
+++ b/master/coords.html
@@ -3373,7 +3373,7 @@ the following steps are run:</p>
 
 <p>This specification imposes additional requirements on the behavior of <a>DOMMatrix</a>
 objects beyond those described in the
-the <a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/">Geometry Interfaces</a>
+<a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/">Geometry Interfaces</a>
 specification, so that they can be used to reflect presentation attributes
 that take transform values.</p>
 

--- a/master/implnote.html
+++ b/master/implnote.html
@@ -1909,7 +1909,7 @@ The steps for generating content that takes advantage of this are:
   the coordinate system which the original content has originally will be called source space. </li>
   <li>Generate a coordinate transformation matrix per tile to transform from
   source space to tile space, where tile space is a coordinate system with origin
-  <var>(0,0)</var> at the top left of the the tile. Each element of the
+  <var>(0,0)</var> at the top left of the tile. Each element of the
   transformation matrix must be within the range of single precision.</li>
   <li>Transform the contents of each tile from source space to tile space using
   the generated coordinate transformation matrix. The result is that the parameters of each object can now be

--- a/master/pservers.html
+++ b/master/pservers.html
@@ -1072,7 +1072,7 @@ gradient is drawn. The area stays untouched (transparent black).</p>
   <p class="caption">Two radial gradients with
   <span class="attr-value">spreadMethod="repeat"</span>. On the
   left, the focal point is just inside the right side of the circle
-  defined by by <a>'cx'</a>, <a>'cy'</a>, and <a>'r'</a>. On the
+  defined by <a>'cx'</a>, <a>'cy'</a>, and <a>'r'</a>. On the
   right, the focal point is on the circle. In this case, the area
   painted to the right of the circumference has a fill equal to
   the weighted average of the colors in the gradient vector.</p>
@@ -1577,7 +1577,7 @@ effect of clipping to the pattern tile.</p>
 
 <p class="note">
   Note that if the <a>'overflow'</a> property is set to
-  to <span class="prop-value">visible</span> the rendering behavior
+  <span class="prop-value">visible</span> the rendering behavior
   for the pattern outside the bounds of the pattern is currently
   undefined. A future version of SVG may require the overflow to be
   shown. SVG implementers are encouraged to render the overflow as

--- a/master/shapes.html
+++ b/master/shapes.html
@@ -711,7 +711,7 @@ defined in <a href="types.html#ListInterfaces">List interfaces</a>.</p>
 
 <p>This specification imposes additional requirements on the behaviour of <a>DOMPoint</a>
 objects beyond those described in the
-the <a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/">Geometry Interfaces</a>
+<a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/">Geometry Interfaces</a>
 specification, so that they can be used to reflect <a>'polygon/points'</a> attributes.</p>
 
 <div class='ready-for-wider-review'>

--- a/master/struct.html
+++ b/master/struct.html
@@ -2978,7 +2978,7 @@ to be interpreted, the following steps are run:</p>
           <li>If <var>descendants</var> is not empty, then append <var>child</var>
           to <var>result</var>.
             <p class="note">This means that although we look at the
-            the elements in the <a>use-element shadow tree</a>,
+            elements in the <a>use-element shadow tree</a>,
             we don't place the <a>element instances</a> or their <a>corresponding element</a>
             in the <var>result</var> list; only the <a>'use'</a>
             element itself is returned.</p>

--- a/master/text.html
+++ b/master/text.html
@@ -3577,7 +3577,6 @@
 			</dd>
 			<dt>(middle, ltr) or (middle, rtl)</dt>
 			<dd>
-			  If
 			  If <var>mid</var>−<var>offset</var> &lt; −<var>length</var>/2
 			  or <var>mid</var>−<var>offset</var> &gt;  <var>length</var>/2,
 			  set the "hidden" flag of <var>result</var>[<var>index</var>] to true.
@@ -4858,7 +4857,7 @@ the dash pattern at the same positions across different implementations.</p>
   <p>
     The list of CSS properties that must be supported on SVG text
     elements can be found in the
-    the <a href="styling.html#RequiredProperties">Styling</a> chapter.
+    <a href="styling.html#RequiredProperties">Styling</a> chapter.
   </p>
 
   <ul>
@@ -4991,7 +4990,7 @@ the dash pattern at the same positions across different implementations.</p>
     The <a>'text-anchor'</a> property is used to align (start-,
     middle- or end-alignment) a string of <em>pre-formatted</em> text
     or <em>auto-wrapped text</em> where the <a>wrapping area</a>
-    is determined from the the <a>'inline-size'</a> property
+    is determined from the <a>'inline-size'</a> property
     relative to a given point. It is not applicable to other types of
     <em>auto-wrapped text</em>, see instead <a>'text-align'</a>. For
     multi-line text, the alignment takes place for each line.
@@ -5571,7 +5570,7 @@ the dash pattern at the same positions across different implementations.</p>
 
   <p class="note">
     See the CSS3 UI specification for the definition of
-    of <a href="https://www.w3.org/TR/2015/CR-css-ui-3-20150707/#text-overflow">'text-overflow'</a>.
+    <a href="https://www.w3.org/TR/2015/CR-css-ui-3-20150707/#text-overflow">'text-overflow'</a>.
     [<a href="refs.html#ref-css-ui-3">css-ui-3</a>]
   </p>
 
@@ -6440,7 +6439,7 @@ called, the following steps are run:</p>
   <a href="#TermFindTypographicCharacterForCharacter">finding the typographic
   character for the character</a> at index <var>charnum</var> within
   the current element.</li>
-  <li>If <var>cluster</var> is null, then then <a>throw</a> an
+  <li>If <var>cluster</var> is null, then <a>throw</a> an
   <a>IndexSizeError</a>.</li>
   <li>Let <var>p</var> be the
   <a>alignment point</a> of <var>cluster</var>
@@ -6469,7 +6468,7 @@ is called, the following steps are run:</p>
   <a href="#TermFindTypographicCharacterForCharacter">finding the typographic
   character for the character</a> at index <var>charnum</var> within
   the current element.</li>
-  <li>If <var>cluster</var> is null, then then <a>throw</a> an
+  <li>If <var>cluster</var> is null, then <a>throw</a> an
   <a>IndexSizeError</a>.</li>
   <li>Let <var>quad</var> be the potentially rotated rectangle in
   the current element's coordinate system that
@@ -6490,7 +6489,7 @@ getRotationOfChar(<var>charnum</var>) is called, the following steps are run:</p
   <a href="#TermFindTypographicCharacterForCharacter">finding the typograhic
   character for the character</a> at index <var>charnum</var> within
   the current element.</li>
-  <li>If <var>cluster</var> is null, then then <a>throw</a> an
+  <li>If <var>cluster</var> is null, then <a>throw</a> an
   <a>IndexSizeError</a>.</li>
   <li>Let <var>direction</var> be the angle in degrees that represents
   the direction of the <var>cluster</var>'s advance.


### PR DESCRIPTION
I’ve checked for a few common words whether they occur twice in a row, which is a common typo, and fixed these.