### PR TITLE
Remove requirement for clip property support

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -358,6 +358,7 @@ have been made.</p>
     remove <a>'d'</a> as a presentation attribute for <a>'textPath'</a>;
     merge the discussion of gradientTransform and patternTransform into the main table.
   </li>
+  <li>Removed requirement for <a>'clip'</a> property support.</li>
 </ul>
 <div class='changed-since-cr1'>
   <ul>

--- a/master/styling.html
+++ b/master/styling.html
@@ -425,7 +425,6 @@ the presentation attribute name is the same as the property name, in lower-case 
     <td>
       <a>'alignment-baseline'</a>,
       <a>'baseline-shift'</a>,
-      <a>'clip'</a>,
       <a>'clip-path'</a>,
       <a>'clip-rule'</a>,
       <a>'color'</a>,
@@ -546,7 +545,7 @@ animating the corresponding property.</p>
   <li>the <a>'cursor property'</a> and <a>'text-overflow'</a> property
     [<a href='refs.html#ref-css-ui-3'>css-ui-3</a>]</li>
 
-  <li>the <a>'clip'</a>, <a>'clip-path'</a>, <a>'clip-rule'</a> and
+  <li>the <a>'clip-path'</a>, <a>'clip-rule'</a> and
     <a>'mask property'</a> properties
     [<a href='refs.html#ref-css-masking-1'>css-masking-1</a>]</li>
 


### PR DESCRIPTION
We no longer require clip support in SVG user agents.

CSS Masking has deprecated the clip property in favor of clip-path.

fixes #479