### PR TITLE
pathLength does not affect percentage calculations

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -453,7 +453,7 @@ have been made.</p>
 
   <li>Clarified that a value of zero for <a>'pathLength'</a> is valid.</li>
 </ul>
-<div class='changed-since-cr1'>
+<div class='changed-since-cr1 cr2'>
 <ul>
   <li>Clarified that percentage distances are not affected by zero <a>'pathLength'</a>.</li>
 </ul>

--- a/master/changes.html
+++ b/master/changes.html
@@ -453,6 +453,11 @@ have been made.</p>
 
   <li>Clarified that a value of zero for <a>'pathLength'</a> is valid.</li>
 </ul>
+<div class='changed-since-cr1'>
+<ul>
+  <li>Clarified that percentage distances are not affected by zero <a>'pathLength'</a>.</li>
+</ul>
+</div>
 
 <h3 id="shapes">Basic Shapes chapter (owner: BogdanBrinza)</h3>
 

--- a/master/paths.html
+++ b/master/paths.html
@@ -1165,10 +1165,12 @@ commands contribute to path length calculations.</p>
     various <a href="painting.html#StrokeProperties">stroke operations</a>.</p>
     <p class="ready-for-wider-review">
     A value of zero is valid and must be treated as a scaling factor of infinity.
-    A value of zero scaled infinitely must remain zero, while any value greater
+    A value of zero scaled infinitely must remain zero, while any non-percentage value greater
     than zero must become +Infinity.
     </p>
     <p>A negative value is an error (see <a href="paths.html#PathDataErrorHandling">Error handling</a>).</p>
+    <p><a>'pathLength'</a> has no effect on percentage
+    <a href="paths.html#DistanceAlongAPath">distance-along-a-path</a> calculations.</p>
   </dd>
 </dl>
 


### PR DESCRIPTION
When values like startOffset are expressed as percentages,
pathLength has no effect. This includes when pathLength is 0.

resolves #383