### PR TITLE
Mark SVGNameList as an example

### DIFF
--- a/master/types.html
+++ b/master/types.html
@@ -1196,7 +1196,7 @@ few unanimated attributes that take a list of strings.</p>
 
 <p>Most <a>list interfaces</a> take the following form:</p>
 
-<pre class="idl" edit:excludefromidl="true">interface <b>SVG<var>Name</var>List</b> {
+<pre class="example" edit:excludefromidl="true">interface <b>SVG<var>Name</var>List</b> {
 
   readonly attribute unsigned long <a href="types.html#__svg__SVGNameList__length">length</a>;
   readonly attribute unsigned long <a href="types.html#__svg__SVGNameList__numberOfItems">numberOfItems</a>;

--- a/master/types.html
+++ b/master/types.html
@@ -1196,7 +1196,7 @@ few unanimated attributes that take a list of strings.</p>
 
 <p>Most <a>list interfaces</a> take the following form:</p>
 
-<pre class="example" edit:excludefromidl="true">interface <b>SVG<var>Name</var>List</b> {
+<pre class="example">interface <b>SVG<var>Name</var>List</b> {
 
   readonly attribute unsigned long <a href="types.html#__svg__SVGNameList__length">length</a>;
   readonly attribute unsigned long <a href="types.html#__svg__SVGNameList__numberOfItems">numberOfItems</a>;


### PR DESCRIPTION
This change:

1. makes it visually look like an example
2. enables IDL crawlers to exclude it.