### PR TITLE
Use class="extract" to exclude IDL

### DIFF
--- a/master/struct.html
+++ b/master/struct.html
@@ -2771,7 +2771,7 @@ Authors are encouraged to use the <a href="https://www.w3.org/TR/dom/#dom-docume
 Other SVG implementations must support the following IDL fragment.
 </p>
 
-<pre class="idl" edit:excludefromidl="true"><span class="comment">// must only be implemented in certain implementations</span>
+<pre class="idl extract"><span class="comment">// must only be implemented in certain implementations</span>
 partial interface <a>Document</a> {
   readonly attribute DOMString title;
   readonly attribute DOMString referrer;

--- a/tools/publish/processing.js
+++ b/tools/publish/processing.js
@@ -413,8 +413,7 @@ function doCompleteIDL(conf, page, n) {
       if (n.nodeType == n.ELEMENT_NODE &&
           n.localName == "pre" &&
           n.getAttribute("class") == "idl") {
-        if (n.svg_excludefromidl) {
-          delete n.svg_excludefromidl;
+        if (n.classList.contains("extract")) {
           return;
         }
         if (idl.length) {
@@ -867,10 +866,6 @@ exports.formatMarkup = function(conf, page, doc) {
         }
       }
       n.removeAttribute("edit:toc");
-      if (n.hasAttribute("edit:excludefromidl")) {
-        n.svg_excludefromidl = true;
-        n.removeAttribute("edit:excludefromidl");
-      }
     }
   });
 


### PR DESCRIPTION
This is what bikeshed does e.g. in [CSSOM](https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-_webkit_cased_attribute). It doesn't remove the flag so that IDL crawlers can also detect it.