### PR TITLE
Marker: update <child-selector> syntax

### DIFF
--- a/specs/marker/Overview.bs
+++ b/specs/marker/Overview.bs
@@ -538,7 +538,7 @@ where:
 
 <div class="definition">
   <dfn>&lt;child-selector></dfn> =
-  <div style="margin-left: 4em">select(<a href="http://www.w3.org/TR/selectors4/#compound">compound selector</a>#)</div>
+  <div style="margin-left: 4em">select(<a href="http://www.w3.org/TR/selectors4/#compound">&lt;compound selector&gt;</a> #)</div>
 </div>
 
 Values have the following meaning


### PR DESCRIPTION
The definition is now select( `<compound-selector>` # ).

resolves #498