### PR TITLE
Consistently say dominant-baseline is inherited

### DIFF
--- a/master/propidx.html
+++ b/master/propidx.html
@@ -131,7 +131,7 @@
           central | middle | text-after-edge | text-before-edge</td>
           <td>auto</td>
           <td><a>text content elements</a></td>
-          <td>no</td>
+          <td>yes</td>
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>


### PR DESCRIPTION
text.html already mentions
> The property is now inherited. (Behavior is effectively unchanged.)

propidx.html (which is not normative) now also describes
dominant-baseline as inherited.

dominant-baseline became inherited when its definition moved from
SVG 1.1 to CSS. Confirmed today by CSS WG:
https://github.com/w3c/csswg-drafts/issues/2926