### PR TITLE
Make "Example of text auto-wrapped" example valid.

### DIFF
--- a/master/text.html
+++ b/master/text.html
@@ -1757,8 +1757,8 @@
 	<p>An example of auto-wrapped text.</p>
 
 	<pre><![CDATA[
-<svg xmlns="http://www.w3.org/2000/svg">
-     width="300" height="100" viewBox="0 0 300 100"
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="300" height="100" viewBox="0 0 300 100">
 
   <text x="20" y="45" style="font: 24px sans-serif; inline-size: 250px;">
     Example of text auto-wrapped.</text>


### PR DESCRIPTION
Move ">" symbol of svg element to include width, height, and viewBox attributes.