### PR TITLE
Make examples xml valid.

### DIFF
--- a/master/text.html
+++ b/master/text.html
@@ -1729,8 +1729,8 @@
 	<p>An example of multi-line pre-formatted text.</p>
 
 	<pre><![CDATA[
-<svg xmlns="http://www.w3.org/2000/svg">
-     width="300" height="100" viewBox="0 0 300 100"
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="300" height="100" viewBox="0 0 300 100">
 
      <text x="20" y="45" style="font: 24px sans-serif;">
        Example of multi-line,
@@ -1783,8 +1783,8 @@
 	<p>An example of text on a path.</p>
 
 	<pre><![CDATA[
-<svg xmlns="http://www.w3.org/2000/svg">
-     width="300" height="100" viewBox="0 0 300 100"
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="300" height="100" viewBox="0 0 300 100">
 
   <path id="MyPath" stroke="lightblue" fill="none"
 	d="M 50,50 C 100,0 200,100 250,50"/>


### PR DESCRIPTION
Make the "pre-formatted text" and "Text on a path" xml valid by shifting the ">" of the svg element after the attributes.

This follows a recent similar correction I made to another nearby example.