### PR TITLE
Language tags are case-insensitive. Closes #517

### DIFF
--- a/master/struct.html
+++ b/master/struct.html
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional+edit//EN" "xhtml1-transitional+edit.dtd">
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:edit="http://xmlns.grorg.org/SVGT12NG/">
 <head>
@@ -1647,11 +1647,11 @@ versions of a given extension.</p>
   </dd>
 </dl>
 
-<p>Evaluates to "true" if one of the languages indicated by
-user preferences exactly equals one of the languages given in
-the value of this parameter, or if one of the languages
-indicated by user preferences exactly equals a prefix of one of
-the languages given in the value of this parameter such that
+<p>Evaluates to "true" if one of the language tags indicated by
+user preferences is a case-insensitive match of one of the language tags given in
+the value of this parameter, or if one of the language tags
+indicated by user preferences is a case-insensitive prefix of one of
+the language tags given in the value of this parameter such that
 the first tag character following the prefix is "-".</p>
 
 <p>Evaluates to "false" otherwise.</p>


### PR DESCRIPTION
Changed description of systemLanguage matching to make it clear that it is a case-insensitive match rather than an "exact match".