### PR TITLE
Revert & replace changes from PR #495

### DIFF
--- a/master/struct.html
+++ b/master/struct.html
@@ -2767,7 +2767,7 @@ Authors are encouraged to use the <a href="https://www.w3.org/TR/dom/#dom-docume
 Other SVG implementations must support the following IDL fragment.
 </p>
 
-<pre class="idl extract"><span class="comment">// must only be implemented in certain implementations</span>
+<pre class="idl" edit:excludefromidl="true"><span class="comment">// must only be implemented in certain implementations</span>
 partial interface <a>Document</a> {
   readonly attribute DOMString title;
   readonly attribute DOMString referrer;

--- a/tools/publish/processing.js
+++ b/tools/publish/processing.js
@@ -419,8 +419,9 @@ function doCompleteIDL(conf, page, n) {
     utils.forEachNode(doc, function(n) {
       if (n.nodeType == n.ELEMENT_NODE &&
           n.localName == "pre" &&
-          n.getAttribute("class") == "idl") {
-        if (n.classList.contains("extract")) {
+          /\bidl\b/.test(n.getAttribute("class")) ) {
+        if (n.svg_excludefromidl) {
+          delete n.svg_excludefromidl;
           return;
         }
         if (idl.length) {
@@ -873,6 +874,12 @@ exports.formatMarkup = function(conf, page, doc) {
         }
       }
       n.removeAttribute("edit:toc");
+      if (n.hasAttribute("edit:excludefromidl")) {
+        n.svg_excludefromidl = true;
+        n.setAttribute("class", n.getAttribute("class")+" extract");
+        //`extract` class is used by Reffy when building IDL indexes
+        n.removeAttribute("edit:excludefromidl");
+      }
     }
   });
 


### PR DESCRIPTION
Reverts commit 63a42e41f0009ef737ab9f58f83e689ed88007ef

Creates the same effect using the build system:
elements with the `edit:excludefromidl="true"` attribute in the source
are given the class "extract" in the build.
Which apparently has an effect in the Reffy system
(for parsing the IDL of different specs),
though I'm not sure exactly what.
See https://github.com/tidoust/reffy/issues/123