### PR TITLE
Reintroduce segment-completing closepath as a theoretical concept

### DIFF
--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -964,7 +964,6 @@
   <term name='direction at the end of a path segment' href='paths.html#TermPathSegmentEndDirection'/>
   <term name='direction at the end of the path segment' href='paths.html#TermPathSegmentEndDirection'/>
   <term name='segment-completing close path' href='paths.html#TermSegment-CompletingClosePath'/>
-  <term name='segment-completing close path command' href='paths.html#TermSegment-CompletingClosePath'/>
   <term name='initial coordinate system' href='coords.html#InitialCoordinateSystem'/>
   <term name='inherit' href='https://www.w3.org/TR/2008/REC-CSS2-20080411/cascade.html#value-def-inherit'/>
   <term name='object bounding box units' href='coords.html#ObjectBoundingBoxUnits'/>

--- a/master/paths.html
+++ b/master/paths.html
@@ -61,7 +61,11 @@ implementation notes</a>.</p>
 <p>The <a>basic shapes</a> are all described in terms of what their
 <dfn id="TermEquivalentPath">equivalent path</dfn> is, which is
 what their shape is as a path.  (The equivalent path of a
-<a>'path'</a> element is simply the path itself.)</p>
+<a>'path'</a> element is simply the path itself.)
+In order to define the basic shapes as equivalent paths,
+a <a>segment-completing close path</a> operation is defined,
+which cannot currently be represented in the basic path syntax.
+</p>
 
 <h2 id="PathElement">The <span class="element-name">'path'</span> element</h2>
 
@@ -402,6 +406,31 @@ rather than joined using the current value of <a>'stroke-linejoin'</a>.</p>
 next subpath. If a "closepath" is followed immediately by any
 other command, then the next subpath must start at the same <a>initial point</a>
 as the current subpath.</p>
+
+<h4 id="Segment-CompletingClosePath">Segment-completing close path operation</h4>
+
+<p>
+In order to represent the basic shapes as equivalent paths,
+there must be a way to close curved shapes
+without introducing an additional straight-line segment
+(even if that segment would have zero length).
+For that purpose, a segment-completing close path operation is defined here.
+</p>
+<p>
+A <dfn id="TermSegment-CompletingClosePath">segment-completing close path</dfn> operation <em>combines</em> with the previous path command,
+with two effects:
+</p>
+<ul>
+  <li>It ensures that the final coordinate point of the previous command exactly matches
+  the <a>initial point</a> of the current subpath.</li>
+  <li>It joins the final and initial points of the subpath, making it a closed subpath.</li>
+</ul>
+
+<p class="note">
+Segment-completing close path operations are not currently supported
+as a command in the path data syntax.
+The working group has proposed such a syntax for future versions of the specification.
+</p>
 
 <h3 id="PathDataLinetoCommands">The <strong>"lineto"</strong> commands</h3>
 

--- a/master/shapes.html
+++ b/master/shapes.html
@@ -162,7 +162,7 @@ following the rules specified above and in <a href="coords.html#Units">Units</a>
 
   <li><em>if</em> both <var>rx</var> and <var>ry</var> are greater than zero,
   perform an absolute <a href="paths.html#PathDataEllipticalArcCommands">elliptical arc</a>
-  operation with a <a>segment-completing close path</a> command,
+  operation with a <a>segment-completing close path</a> operation,
   using the same parameters as previously.</li>
 </ol>
 
@@ -225,7 +225,7 @@ radius.</p>
   <li>arc to <var>cx</var>,<var>cy+r</var>;</li>
   <li>arc to <var>cx-r</var>,<var>cy</var>;</li>
   <li>arc to <var>cx</var>,<var>cy-r</var>;</li>
-  <li>arc with a <a>segment-completing close path command</a>.</li>
+  <li>arc with a <a>segment-completing close path</a> operation.</li>
 </ol>
 
 <p class="annotation">
@@ -306,7 +306,7 @@ with the current <a>local coordinate system</a> based on a center point and two 
   <li>arc to <var>cx</var>,<var>cy+ry</var>;</li>
   <li>arc to <var>cx-rx</var>,<var>cy</var>;</li>
   <li>arc to <var>cx</var>,<var>cy-ry</var>;</li>
-  <li>arc with a <a>segment-completing close path command</a>.</li>
+  <li>arc with a <a>segment-completing close path</a> operation.</li>
 </ol>
 
 <p class="annotation">


### PR DESCRIPTION
Because we use it to define the equivalent paths of basic shapes.

I've changed the terminology to refer to the segment-completing close path as an _operation_ instead of a _command_, and have added a short sub-section defining it.

I also included a very short note about the proposal for adding it to the path data syntax, in a future version of the specification.

This fixes build problems introduced by PR #398.

@ewilligers can you take a look at the new text I've added & let me know if you think it works to patch over the disconnect.