### PR TITLE
 Add stub files for removed chapters/appendices

### DIFF
--- a/master/backward.html
+++ b/master/backward.html
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>Removed: Backwards Compatibility — SVG 2</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport"           content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+  <link rel="stylesheet" href="//www.w3.org/StyleSheets/TR/2016/base.css" type="text/css" media="screen">
+</head>
+<body>
+  <h1>Removed: Backwards Compatibility</h1>
+  <p>This chapter is no longer part of the SVG specification.</p>
+  <p>
+    You can view <a href="https://www.w3.org/TR/SVG11/backward.html">the chapter in SVG 1.1</a>,
+    or <a href="Overview.html">go back to the main page for SVG 2</a>.
+  </p>
+</body>
+</html>

--- a/master/color.html
+++ b/master/color.html
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>Removed: Color — SVG 2</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport"           content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+  <link rel="stylesheet" href="//www.w3.org/StyleSheets/TR/2016/base.css" type="text/css" media="screen">
+</head>
+<body>
+  <h1>Removed: Color</h1>
+  <p>This chapter is no longer part of the SVG specification.</p>
+  <p>
+    Color formats and color profiles are now defined in the
+    CSS Color Module
+    (<a href="https://drafts.csswg.org/css-color/">latest editor's draft</a>,
+     <a href="https://www.w3.org/TR/css-color/">latest technical report</a>).
+  </p>
+  <p>
+    You can also view <a href="https://www.w3.org/TR/SVG11/color.html">the chapter in SVG 1.1</a>,
+    or <a href="Overview.html">go back to the main page for SVG 2</a>.
+  </p>
+</body>
+</html>

--- a/master/concepts.html
+++ b/master/concepts.html
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>Removed: Concepts — SVG 2</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport"           content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+  <link rel="stylesheet" href="//www.w3.org/StyleSheets/TR/2016/base.css" type="text/css" media="screen">
+</head>
+<body>
+  <h1>Removed: Concepts</h1>
+  <p>This chapter is no longer part of the SVG specification.</p>
+  <p>
+    You can view <a href="https://www.w3.org/TR/SVG11/concepts.html">the chapter in SVG 1.1</a>,
+    or <a href="Overview.html">go back to the main page for SVG 2</a>.
+  </p>
+</body>
+</html>

--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -964,7 +964,6 @@
   <term name='direction at the end of a path segment' href='paths.html#TermPathSegmentEndDirection'/>
   <term name='direction at the end of the path segment' href='paths.html#TermPathSegmentEndDirection'/>
   <term name='segment-completing close path' href='paths.html#TermSegment-CompletingClosePath'/>
-  <term name='segment-completing close path command' href='paths.html#TermSegment-CompletingClosePath'/>
   <term name='initial coordinate system' href='coords.html#InitialCoordinateSystem'/>
   <term name='inherit' href='https://www.w3.org/TR/2008/REC-CSS2-20080411/cascade.html#value-def-inherit'/>
   <term name='object bounding box units' href='coords.html#ObjectBoundingBoxUnits'/>

--- a/master/escript.html
+++ b/master/escript.html
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>Removed: ECMAScript Language Binding — SVG 2</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport"           content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+  <link rel="stylesheet" href="//www.w3.org/StyleSheets/TR/2016/base.css" type="text/css" media="screen">
+</head>
+<body>
+  <h1>Removed: ECMAScript Language Binding</h1>
+  <p>This appendix is no longer part of the SVG specification.</p>
+  <p>
+    SVG language bindings are now defined by <a href="https://heycam.github.io/webidl/">Web IDL</a>.
+  </p>
+  <p>
+    You can view <a href="https://www.w3.org/TR/SVG11/escript.html">the appendix in SVG 1.1</a>,
+    or <a href="Overview.html">go back to the main page for SVG 2</a>.
+  </p>
+</body>
+</html>

--- a/master/extend.html
+++ b/master/extend.html
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>Removed: Extensibility — SVG 2</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport"           content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+  <link rel="stylesheet" href="//www.w3.org/StyleSheets/TR/2016/base.css" type="text/css" media="screen">
+</head>
+<body>
+  <h1>Removed: Extensibility</h1>
+  <p>This chapter is no longer part of the SVG specification.</p>
+  <p>
+    The content of this chapter has been moved into the
+    <a href="embedded.html">Embedded Content</a> and
+    <a href="struct.html">Document Structure</a> chapters.
+  </p>
+  <p>
+    You can also view <a href="https://www.w3.org/TR/SVG11/extend.html">the chapter in SVG 1.1</a>,
+    or <a href="Overview.html">go back to the main page for SVG 2</a>.
+  </p>
+</body>
+</html>

--- a/master/feature.html
+++ b/master/feature.html
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>Removed: Feature Strings — SVG 2</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport"           content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+  <link rel="stylesheet" href="//www.w3.org/StyleSheets/TR/2016/base.css" type="text/css" media="screen">
+</head>
+<body>
+  <h1>Removed: Feature Strings</h1>
+  <p>This appendix is no longer part of the SVG specification.</p>
+  <p>
+    No new feature strings are added in SVG 2,
+    as the <span class="attr-name">requiredFeatures</span> attribute has been dropped.
+    Authors wishing to use feature testing to exclude older SVG viewers
+    should use the strings as defined in SVG 1.1.
+  </p>
+  <p>
+    You can view <a href="https://www.w3.org/TR/SVG11/feature.html">the appendix in SVG 1.1</a>,
+    or <a href="Overview.html">go back to the main page for SVG 2</a>.
+  </p>
+</body>
+</html>

--- a/master/filters.html
+++ b/master/filters.html
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>Removed: Filter Effects — SVG 2</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport"           content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+  <link rel="stylesheet" href="//www.w3.org/StyleSheets/TR/2016/base.css" type="text/css" media="screen">
+</head>
+<body>
+  <h1>Removed: Filter Effects</h1>
+  <p>This chapter is no longer part of the SVG specification.</p>
+  <p>
+    The filter property and elements are now defined in
+    the Filter Effects Module
+    (<a href="https://drafts.fxtf.org/filter-effects/">latest editor's draft</a>,
+     <a href="https://www.w3.org/TR/filter-effects/">latest technical report</a>).
+  </p>
+  <p>
+    You can also view <a href="https://www.w3.org/TR/SVG11/filters.html">the chapter in SVG 1.1</a>,
+    or <a href="Overview.html">go back to the main page for SVG 2</a>.
+  </p>
+</body>
+</html>

--- a/master/fonts.html
+++ b/master/fonts.html
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>Removed: Fonts — SVG 2</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport"           content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+  <link rel="stylesheet" href="//www.w3.org/StyleSheets/TR/2016/base.css" type="text/css" media="screen">
+</head>
+<body>
+  <h1>Removed: Fonts</h1>
+  <p>This chapter is no longer part of the SVG specification.</p>
+  <p>
+    The elements that were defined in this chapter are now obsolete.
+    The CSS Fonts Module defines how to specify fonts for documents including SVG
+    (<a href="https://drafts.fxtf.org/css-fonts/">latest editor's draft</a>,
+     <a href="https://www.w3.org/TR/css-fonts/">latest technical report</a>).
+    See the <a href="text.html">Text chapter</a> for SVG-specific details.
+  </p>
+  <p>
+    You can also view <a href="https://www.w3.org/TR/SVG11/fonts.html">the chapter in SVG 1.1</a>,
+    or <a href="Overview.html">go back to the main page for SVG 2</a>.
+  </p>
+</body>
+</html>

--- a/master/i18n.html
+++ b/master/i18n.html
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>Removed: Internationalization Support — SVG 2</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport"           content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+  <link rel="stylesheet" href="//www.w3.org/StyleSheets/TR/2016/base.css" type="text/css" media="screen">
+</head>
+<body>
+  <h1>Removed: Internationalization Support</h1>
+  <p>This appendix is no longer part of the SVG specification.</p>
+  <p>
+    Internationalization features related to text are defined
+    in the <a href="text.html">Text chapter</a>.
+  </p>
+  <p>
+    You can view <a href="https://www.w3.org/TR/SVG11/i18n.html">the appendix in SVG 1.1</a>,
+    or <a href="Overview.html">go back to the main page for SVG 2</a>.
+  </p>
+</body>
+</html>

--- a/master/java.html
+++ b/master/java.html
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>Removed: Java Language Binding — SVG 2</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport"           content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+  <link rel="stylesheet" href="//www.w3.org/StyleSheets/TR/2016/base.css" type="text/css" media="screen">
+</head>
+<body>
+  <h1>Removed: Java Language Binding</h1>
+  <p>This appendix is no longer part of the SVG specification.</p>
+  <p>
+    SVG language bindings are now defined by <a href="https://heycam.github.io/webidl/">Web IDL</a>.
+  </p>
+  <p>
+    You can view <a href="https://www.w3.org/TR/SVG11/java.html">the appendix in SVG 1.1</a>,
+    or <a href="Overview.html">go back to the main page for SVG 2</a>.
+  </p>
+</body>
+</html>

--- a/master/masking.html
+++ b/master/masking.html
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>Removed: Clipping, Masking and Compositing — SVG 2</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport"           content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+  <link rel="stylesheet" href="//www.w3.org/StyleSheets/TR/2016/base.css" type="text/css" media="screen">
+</head>
+<body>
+  <h1>Removed: Clipping, Masking and Compositing</h1>
+  <p>This chapter is no longer part of the SVG specification.</p>
+  <p>
+    The mask and clip-path elements and properties are now defined in
+    the CSS Masking Module
+    (<a href="https://drafts.fxtf.org/css-masking/">latest editor's draft</a>,
+     <a href="https://www.w3.org/TR/css-masking/">latest technical report</a>).
+  </p>
+  <p>
+    SVG-specific aspects of compositing are defined in the <a href="render.html">Rendering chapter</a>.
+  </p>
+  <p>
+    You can also view <a href="https://www.w3.org/TR/SVG11/masking.html">the chapter in SVG 1.1</a>,
+    or <a href="Overview.html">go back to the main page for SVG 2</a>.
+  </p>
+</body>
+</html>

--- a/master/metadata.html
+++ b/master/metadata.html
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>Removed: Metadata — SVG 2</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport"           content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+  <link rel="stylesheet" href="//www.w3.org/StyleSheets/TR/2016/base.css" type="text/css" media="screen">
+</head>
+<body>
+  <h1>Removed: Metadata</h1>
+  <p>This chapter is no longer part of the SVG specification.</p>
+  <p>
+    The content of this chapter has been merged into the
+    <a href="struct.html">Document Structure chapter</a>.
+  </p>
+  <p>
+    You can also view <a href="https://www.w3.org/TR/SVG11/metadata.html">the chapter in SVG 1.1</a>,
+    or <a href="Overview.html">go back to the main page for SVG 2</a>.
+  </p>
+</body>
+</html>

--- a/master/minimize.html
+++ b/master/minimize.html
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>Removed: Minimizing SVG File Sizes — SVG 2</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport"           content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+  <link rel="stylesheet" href="//www.w3.org/StyleSheets/TR/2016/base.css" type="text/css" media="screen">
+</head>
+<body>
+  <h1>Removed: Minimizing SVG File Sizes</h1>
+  <p>This appendix is no longer part of the SVG specification.</p>
+  <p>
+    You can view <a href="https://www.w3.org/TR/SVG11/minimize.html">the appendix in SVG 1.1</a>,
+    or <a href="Overview.html">go back to the main page for SVG 2</a>.
+  </p>
+</body>
+</html>

--- a/master/paths.html
+++ b/master/paths.html
@@ -61,7 +61,11 @@ implementation notes</a>.</p>
 <p>The <a>basic shapes</a> are all described in terms of what their
 <dfn id="TermEquivalentPath">equivalent path</dfn> is, which is
 what their shape is as a path.  (The equivalent path of a
-<a>'path'</a> element is simply the path itself.)</p>
+<a>'path'</a> element is simply the path itself.)
+In order to define the basic shapes as equivalent paths,
+a <a>segment-completing close path</a> operation is defined,
+which cannot currently be represented in the basic path syntax.
+</p>
 
 <h2 id="PathElement">The <span class="element-name">'path'</span> element</h2>
 
@@ -402,6 +406,31 @@ rather than joined using the current value of <a>'stroke-linejoin'</a>.</p>
 next subpath. If a "closepath" is followed immediately by any
 other command, then the next subpath must start at the same <a>initial point</a>
 as the current subpath.</p>
+
+<h4 id="Segment-CompletingClosePath">Segment-completing close path operation</h4>
+
+<p>
+In order to represent the basic shapes as equivalent paths,
+there must be a way to close curved shapes
+without introducing an additional straight-line segment
+(even if that segment would have zero length).
+For that purpose, a segment-completing close path operation is defined here.
+</p>
+<p>
+A <dfn id="TermSegment-CompletingClosePath">segment-completing close path</dfn> operation <em>combines</em> with the previous path command,
+with two effects:
+</p>
+<ul>
+  <li>It ensures that the final coordinate point of the previous command exactly matches
+  the <a>initial point</a> of the current subpath.</li>
+  <li>It joins the final and initial points of the subpath, making it a closed subpath.</li>
+</ul>
+
+<p class="note">
+Segment-completing close path operations are not currently supported
+as a command in the path data syntax.
+The working group has proposed such a syntax for future versions of the specification.
+</p>
 
 <h3 id="PathDataLinetoCommands">The <strong>"lineto"</strong> commands</h3>
 

--- a/master/publish.xml
+++ b/master/publish.xml
@@ -39,6 +39,23 @@
   <resource href='images'/>
   <resource href='examples'/>
 
+<!-- stub pages for removed chapters (copy to build unaltered) -->
+  <resource href="backward.html"/>
+  <resource href='color.html'/>
+  <resource href='concepts.html'/>
+  <resource href='escript.html'/>
+  <resource href='extend.html'/>
+  <resource href='feature.html'/>
+  <resource href='filters.html'/>
+  <resource href='fonts.html'/>
+  <resource href='i18n.html'/>
+  <resource href='java.html'/>
+  <resource href='masking.html'/>
+  <resource href='metadata.html'/>
+  <resource href='minimize.html'/>
+  <resource href='script.html'/>
+  <resource href='svgdtd.html'/>
+
   <toc href='Overview.html'/>
   <elementindex href='eltindex.html'/>
   <attributeindex href='attindex.html'/>

--- a/master/script.html
+++ b/master/script.html
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>Removed: Scripting — SVG 2</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport"           content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+  <link rel="stylesheet" href="//www.w3.org/StyleSheets/TR/2016/base.css" type="text/css" media="screen">
+</head>
+<body>
+  <h1>Removed: Scripting</h1>
+  <p>This chapter is no longer part of the SVG specification.</p>
+  <p>
+    The content of this chapter has been merged into the
+    <a href="interact.html">Scripting and Interactivity chapter</a>.
+  </p>
+  <p>
+    You can also view <a href="https://www.w3.org/TR/SVG11/script.html">the chapter in SVG 1.1</a>,
+    or <a href="Overview.html">go back to the main page for SVG 2</a>.
+  </p>
+</body>
+</html>

--- a/master/shapes.html
+++ b/master/shapes.html
@@ -162,7 +162,7 @@ following the rules specified above and in <a href="coords.html#Units">Units</a>
 
   <li><em>if</em> both <var>rx</var> and <var>ry</var> are greater than zero,
   perform an absolute <a href="paths.html#PathDataEllipticalArcCommands">elliptical arc</a>
-  operation with a <a>segment-completing close path</a> command,
+  operation with a <a>segment-completing close path</a> operation,
   using the same parameters as previously.</li>
 </ol>
 
@@ -225,7 +225,7 @@ radius.</p>
   <li>arc to <var>cx</var>,<var>cy+r</var>;</li>
   <li>arc to <var>cx-r</var>,<var>cy</var>;</li>
   <li>arc to <var>cx</var>,<var>cy-r</var>;</li>
-  <li>arc with a <a>segment-completing close path command</a>.</li>
+  <li>arc with a <a>segment-completing close path</a> operation.</li>
 </ol>
 
 <p class="annotation">
@@ -306,7 +306,7 @@ with the current <a>local coordinate system</a> based on a center point and two 
   <li>arc to <var>cx</var>,<var>cy+ry</var>;</li>
   <li>arc to <var>cx-rx</var>,<var>cy</var>;</li>
   <li>arc to <var>cx</var>,<var>cy-ry</var>;</li>
-  <li>arc with a <a>segment-completing close path command</a>.</li>
+  <li>arc with a <a>segment-completing close path</a> operation.</li>
 </ol>
 
 <p class="annotation">

--- a/master/struct.html
+++ b/master/struct.html
@@ -2767,7 +2767,7 @@ Authors are encouraged to use the <a href="https://www.w3.org/TR/dom/#dom-docume
 Other SVG implementations must support the following IDL fragment.
 </p>
 
-<pre class="idl extract"><span class="comment">// must only be implemented in certain implementations</span>
+<pre class="idl" edit:excludefromidl="true"><span class="comment">// must only be implemented in certain implementations</span>
 partial interface <a>Document</a> {
   readonly attribute DOMString title;
   readonly attribute DOMString referrer;

--- a/master/svgdtd.html
+++ b/master/svgdtd.html
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <title>Removed: Document Type Definition — SVG 2</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+  <meta name="viewport"           content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+  <link rel="stylesheet" href="//www.w3.org/StyleSheets/TR/2016/base.css" type="text/css" media="screen">
+</head>
+<body>
+  <h1>Removed: Document Type Definition</h1>
+  <p>This appendix is no longer part of the SVG specification.</p>
+  <p>
+    SVG is no longer defined using a DTD syntax.
+  </p>
+  <p>
+    You can view <a href="https://www.w3.org/TR/SVG11/svgdtd.html">the appendix in SVG 1.1</a>,
+    or <a href="Overview.html">go back to the main page for SVG 2</a>.
+  </p>
+</body>
+</html>

--- a/tools/publish/processing.js
+++ b/tools/publish/processing.js
@@ -419,8 +419,9 @@ function doCompleteIDL(conf, page, n) {
     utils.forEachNode(doc, function(n) {
       if (n.nodeType == n.ELEMENT_NODE &&
           n.localName == "pre" &&
-          n.getAttribute("class") == "idl") {
-        if (n.classList.contains("extract")) {
+          /\bidl\b/.test(n.getAttribute("class")) ) {
+        if (n.svg_excludefromidl) {
+          delete n.svg_excludefromidl;
           return;
         }
         if (idl.length) {
@@ -873,6 +874,12 @@ exports.formatMarkup = function(conf, page, doc) {
         }
       }
       n.removeAttribute("edit:toc");
+      if (n.hasAttribute("edit:excludefromidl")) {
+        n.svg_excludefromidl = true;
+        n.setAttribute("class", n.getAttribute("class")+" extract");
+        //`extract` class is used by Reffy when building IDL indexes
+        n.removeAttribute("edit:excludefromidl");
+      }
     }
   });
 


### PR DESCRIPTION
As resolved in the [13 August 2018 teleconference](https://www.w3.org/2018/08/13-svg-minutes.html#resolution01):

> RESOLUTION: If possible, add stub pages to spec for SVG 1.1 chapters that no longer exist, redirecting to correct specs for the content.

So that links to URLs of the form https://www.w3.org/TR/SVG/backward.html won't 404.

Where relevant, the stubs include a very brief description of what happened to the content, with links to its current location (e.g., another chapter or a CSS spec). There are also links back to the SVG11 TR version of the chapter, and to the main SVG2 Overview page.

To include these files in the final build, without messing up building the actual spec, they are included as "resource" files in publish.xml. This means that they are copied as-is to the final directory, with no build system modifications.

_________________________________

Note: this branch includes the changes from PR #539 and #540, since I needed to get a clean test build running locally. **Those PRs should be merged first.**