### PR TITLE
Change from HTML 5.1 to HTML LS, #514

### DIFF
--- a/master/animate.html
+++ b/master/animate.html
@@ -50,7 +50,7 @@ SVG content can be animated in the following ways:</p>
   accessible to scripting, and SVG offers a set of additional
   DOM interfaces to support efficient animation via scripting.
   Ideally, user agents that support scripting will also implement
-  the <a href="https://www.w3.org/TR/html51/webappapis.html#animation-frames">animation frames</a> APIs
+  the <a href="https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#animation-frames">animation frames</a> APIs
   defined in HTML [<a href="refs.html#ref-html">HTML</a>].</li>
 
   <li>Using the <a href="https://www.w3.org/TR/web-animations-1/">Web Animations API</a>

--- a/master/animate.html
+++ b/master/animate.html
@@ -51,7 +51,7 @@ SVG content can be animated in the following ways:</p>
   DOM interfaces to support efficient animation via scripting.
   Ideally, user agents that support scripting will also implement
   the <a href="https://www.w3.org/TR/html51/webappapis.html#animation-frames">animation frames</a> APIs
-  defined in HTML [<a href="refs.html#ref-html51">HTML</a>].</li>
+  defined in HTML [<a href="refs.html#ref-html">HTML</a>].</li>
 
   <li>Using the <a href="https://www.w3.org/TR/web-animations-1/">Web Animations API</a>
   [<a href="refs.html#ref-web-animations-1">web-animations-1</a>].

--- a/master/changes.html
+++ b/master/changes.html
@@ -97,6 +97,15 @@ have been made.</p>
 </ul>
 </div>
 
+<div class='changed-since-cr1 cr2'>
+  <ul>
+    <li>Refer to HTML LS throughout.
+      <a href="https://github.com/w3c/svgwg/issues/514">Issue discussion</a>
+      <a href="mmm, recursion">Edits</a>
+    </li>
+  </ul>
+</div>
+
 <h3 id="concepts">Concepts chapter (SVG 1.1 only)</h3>
 
 <ul>
@@ -707,7 +716,7 @@ have been made.</p>
   attribute to the <a>'marker/orient'</a> attribute on <a>'marker element'</a>.</li>
 
   <li>Removed the SVGPaint interface.</li>
-  
+
   <li>Added the 'z-index' property. (Later removed.)</li>
 
   <li>Split out some new marker and stroke related

--- a/master/changes.html
+++ b/master/changes.html
@@ -101,7 +101,7 @@ have been made.</p>
   <ul>
     <li>Refer to HTML LS throughout.
       <a href="https://github.com/w3c/svgwg/issues/514">Issue discussion</a>
-      <a href="mmm, recursion">Edits</a>
+      <a href="https://github.com/w3c/svgwg/pull/544">Edits</a>
     </li>
   </ul>
 </div>

--- a/master/conform.html
+++ b/master/conform.html
@@ -362,7 +362,7 @@ would likely use static mode.
       such as an HTML <span class='element-name'>'img'</span> element or
       in any CSS property that takes an
       <a href='https://www.w3.org/TR/css3-values/#images'>&lt;image&gt;</a> data type.
-      This is consistent with <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-img-element">HTML's requirement</a>
+      This is consistent with <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element">HTML's requirement</a>
       that image sources must reference
       "a non-interactive, optionally animated, image resource that is neither paged nor scripted"
       [<a href="refs.html#ref-html">HTML</a>]</p>
@@ -374,7 +374,7 @@ would likely use static mode.
       an HTML <a>'iframe'</a> element in an SVG document must use the
       same processing mode as the embedding document,
       subject to any restrictions defined by the
-      <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-iframe-sandbox"><span class="attr-name">sandbox</span> attribute</a>
+      <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox"><span class="attr-name">sandbox</span> attribute</a>
       on the embedding <a>'iframe'</a>.</p>
 
       <p class="note">The same processing rules are intended to be used when

--- a/master/conform.html
+++ b/master/conform.html
@@ -382,7 +382,7 @@ would likely use static mode.
       <span class='element-name'>'embed'</span>,
       <span class='element-name'>'iframe'</span> or
       <span class='element-name'>'object'</span> element
-      <a href="refs.html#ref-html51">[HTML]</a>.
+      <a href="refs.html#ref-html">[HTML]</a>.
       An HTML document that is a
       <a href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>
       in an interactive web browser is equivalent to SVG's

--- a/master/conform.html
+++ b/master/conform.html
@@ -384,7 +384,7 @@ would likely use static mode.
       <span class='element-name'>'object'</span> element
       <a href="refs.html#ref-html51">[HTML]</a>.
       An HTML document that is a
-      <a href="https://www.w3.org/TR/html/browsers.html#top-level-browsing-context">top-level browsing context</a>
+      <a href="https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">top-level browsing context</a>
       in an interactive web browser is equivalent to SVG's
       <a>dynamic interactive processing mode</a>.
       </p>

--- a/master/conform.html
+++ b/master/conform.html
@@ -365,7 +365,7 @@ would likely use static mode.
       This is consistent with <a href="https://www.w3.org/TR/html/semantics-embedded-content.html#the-img-element">HTML's requirement</a>
       that image sources must reference
       "a non-interactive, optionally animated, image resource that is neither paged nor scripted"
-      [<a href="refs.html#ref-html51">HTML</a>]</p>
+      [<a href="refs.html#ref-html">HTML</a>]</p>
     </dd>
 
     <dt id="embedded-document-mode"><a>'iframe'</a> references</dt>

--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -1232,7 +1232,7 @@
   <term name='CORS settings attribute' href='https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attribute'/>
   <term name='limited to only known values' href='https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#limited-to-only-known-values'/>
   <term name='No CORS' href='https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attribute'/>
-  <term name='origin' href='https://www.w3.org/TR/html/browsers.html#concept-cross-origin'/>
+  <term name='origin' href='https://html.spec.whatwg.org/#cors-cross-origin'/>
   <term name='set of space-separated tokens' href='https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#set-of-space-separated-tokens'/>
   <term name='set of comma-separated tokens' href='https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#set-of-comma-separated-tokens'/>
   <term name='same origin' href='https://html.spec.whatwg.org/multipage/origin.html#same-origin'/>

--- a/master/embedded.html
+++ b/master/embedded.html
@@ -431,7 +431,7 @@ elements within an SVG file.</p>
 
 <h2 id="HTMLElements">HTML elements in SVG subtrees</h2>
 
-<p>The following HTML elements render when included in an SVG subtree as a child of a <a>container element</a> and when using the <a href="https://www.w3.org/TR/html51/infrastructure.html#namespaces">HTML namespace</a>:</p>
+<p>The following HTML elements render when included in an SVG subtree as a child of a <a>container element</a> and when using the <a href="https://html.spec.whatwg.org/multipage/infrastructure.html#xml">HTML namespace</a>:</p>
 <ul>
 <li><a href="https://html.spec.whatwg.org/multipage/media.html#the-video-element">'video'</a></li>
 <li><a href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element">'audio'</a></li>

--- a/master/embedded.html
+++ b/master/embedded.html
@@ -47,7 +47,7 @@ This is the same definition as <a href="https://html.spec.whatwg.org/multipage/"
 
 <p>SVG supports embedded content with the use of <a>'image'</a> and <a>'foreignObject'</a> elements.</p>
 
-<p>Additionally SVG allows embedded content using HTML <a href="https://html.spec.whatwg.org/multipage/media.html#the-video-element">'video'</a>, <a href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element">'audio'</a>, <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">'iframe'</a> and <a href="https://www.w3.org/TR/html51/semantics-scripting.html#the-canvas-element">'canvas'</a> elements.</p>
+<p>Additionally SVG allows embedded content using HTML <a href="https://html.spec.whatwg.org/multipage/media.html#the-video-element">'video'</a>, <a href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element">'audio'</a>, <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">'iframe'</a> and <a href="https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-element">'canvas'</a> elements.</p>
 
 <p class="note">Except <a>'canvas'</a> and <a>'foreignObject'</a>, embedded content is compatible with <a href="https://www.w3.org/TR/resource-hints/">Resource Hints</a> for prioritizing downloading of external resources. </p>
 
@@ -436,12 +436,12 @@ elements within an SVG file.</p>
 <li><a href="https://html.spec.whatwg.org/multipage/media.html#the-video-element">'video'</a></li>
 <li><a href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element">'audio'</a></li>
 <li><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">'iframe'</a></li>
-<li><a href="https://www.w3.org/TR/html51/semantics-scripting.html#the-canvas-element">'canvas'</a></li>
+<li><a href="https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-element">'canvas'</a></li>
 </ul>
 
 <edit:example href='images/embedded/videoinsvg.svg' name='videoinsvg' link='no' image='no'/>
 
-<p>HTML elements, in the HTML namespace, used as children of <a href="https://html.spec.whatwg.org/multipage/media.html#the-video-element">'video'</a>, <a href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element">'audio'</a>, <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">'iframe'</a> and <a href="https://www.w3.org/TR/html51/semantics-scripting.html#the-canvas-element">'canvas'</a> elements within an SVG document fragment behave as specified in HTML. This applies in particular to <a href="https://www.w3.org/TR/html51/dom.html#fallback-content">fallback content</a>;
+<p>HTML elements, in the HTML namespace, used as children of <a href="https://html.spec.whatwg.org/multipage/media.html#the-video-element">'video'</a>, <a href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element">'audio'</a>, <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">'iframe'</a> and <a href="https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-element">'canvas'</a> elements within an SVG document fragment behave as specified in HTML. This applies in particular to <a href="https://www.w3.org/TR/html51/dom.html#fallback-content">fallback content</a>;
 if fallback content is rendered,
 the embedded element behaves like an SVG <a>'foreignObject'</a> element to contain the HTML content.
 This would occur, for example,

--- a/master/embedded.html
+++ b/master/embedded.html
@@ -43,11 +43,11 @@
 
 <h2 id="Overview">Overview</h2>
 <p>Embedded content is content that imports another resource into the document, or content from another vocabulary that is inserted into the document.
-This is the same definition as <a href="https://www.w3.org/TR/html51/">HTML's</a> <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#semantics-embedded-content">embedded content</a>.</p>
+This is the same definition as <a href="https://www.w3.org/TR/html51/">HTML's</a> <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#embedded-content">embedded content</a>.</p>
 
 <p>SVG supports embedded content with the use of <a>'image'</a> and <a>'foreignObject'</a> elements.</p>
 
-<p>Additionally SVG allows embedded content using HTML <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#the-video-element">'video'</a>, <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#the-audio-element">'audio'</a>, <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#the-iframe-element">'iframe'</a> and <a href="https://www.w3.org/TR/html51/semantics-scripting.html#the-canvas-element">'canvas'</a> elements.</p>
+<p>Additionally SVG allows embedded content using HTML <a href="https://html.spec.whatwg.org/multipage/media.html#the-video-element">'video'</a>, <a href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element">'audio'</a>, <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">'iframe'</a> and <a href="https://www.w3.org/TR/html51/semantics-scripting.html#the-canvas-element">'canvas'</a> elements.</p>
 
 <p class="note">Except <a>'canvas'</a> and <a>'foreignObject'</a>, embedded content is compatible with <a href="https://www.w3.org/TR/resource-hints/">Resource Hints</a> for prioritizing downloading of external resources. </p>
 
@@ -66,7 +66,7 @@ This is the same definition as <a href="https://www.w3.org/TR/html51/">HTML's</a
         The elements in the HTML namespace do not have SVG presentation attributes
         for the geometry properties.
         Most of these elements, however, accept the HTML
-        <code>width</code> and <code>height</code> <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#dimension-attributes">dimensional attributes</a>,
+        <code>width</code> and <code>height</code> <a href="https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes">dimensional attributes</a>,
         which are used as presentational hints
         to set default values for the corresponding sizing properties.
       </p>
@@ -433,15 +433,15 @@ elements within an SVG file.</p>
 
 <p>The following HTML elements render when included in an SVG subtree as a child of a <a>container element</a> and when using the <a href="https://www.w3.org/TR/html51/infrastructure.html#namespaces">HTML namespace</a>:</p>
 <ul>
-<li><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#the-video-element">'video'</a></li>
-<li><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#the-audio-element">'audio'</a></li>
-<li><a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#the-iframe-element">'iframe'</a></li>
+<li><a href="https://html.spec.whatwg.org/multipage/media.html#the-video-element">'video'</a></li>
+<li><a href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element">'audio'</a></li>
+<li><a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">'iframe'</a></li>
 <li><a href="https://www.w3.org/TR/html51/semantics-scripting.html#the-canvas-element">'canvas'</a></li>
 </ul>
 
 <edit:example href='images/embedded/videoinsvg.svg' name='videoinsvg' link='no' image='no'/>
 
-<p>HTML elements, in the HTML namespace, used as children of <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#the-video-element">'video'</a>, <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#the-audio-element">'audio'</a>, <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#the-iframe-element">'iframe'</a> and <a href="https://www.w3.org/TR/html51/semantics-scripting.html#the-canvas-element">'canvas'</a> elements within an SVG document fragment behave as specified in HTML. This applies in particular to <a href="https://www.w3.org/TR/html51/dom.html#fallback-content">fallback content</a>;
+<p>HTML elements, in the HTML namespace, used as children of <a href="https://html.spec.whatwg.org/multipage/media.html#the-video-element">'video'</a>, <a href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element">'audio'</a>, <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">'iframe'</a> and <a href="https://www.w3.org/TR/html51/semantics-scripting.html#the-canvas-element">'canvas'</a> elements within an SVG document fragment behave as specified in HTML. This applies in particular to <a href="https://www.w3.org/TR/html51/dom.html#fallback-content">fallback content</a>;
 if fallback content is rendered,
 the embedded element behaves like an SVG <a>'foreignObject'</a> element to contain the HTML content.
 This would occur, for example,
@@ -451,7 +451,7 @@ or for a <a>'canvas'</a> element if scripting is disabled.
 
 <edit:example href='images/embedded/videofallback.svg' name='videofallback' link='no' image='no'/>
 
-<p>The HTML specification is applicable also for the <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#the-track-element">'track'</a> and <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#elementdef-media-source">'source'</a> elements.</p>
+<p>The HTML specification is applicable also for the <a href="https://html.spec.whatwg.org/multipage/media.html#the-track-element">'track'</a> and <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element">'source'</a> elements.</p>
 
 <edit:example href='images/embedded/sourceinsvg.svg' name='sourceinsvg' link='no' image='no'/>
 

--- a/master/embedded.html
+++ b/master/embedded.html
@@ -43,7 +43,7 @@
 
 <h2 id="Overview">Overview</h2>
 <p>Embedded content is content that imports another resource into the document, or content from another vocabulary that is inserted into the document.
-This is the same definition as <a href="https://www.w3.org/TR/html51/">HTML's</a> <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#embedded-content">embedded content</a>.</p>
+This is the same definition as <a href="https://html.spec.whatwg.org/multipage/">HTML's</a> <a href="https://html.spec.whatwg.org/multipage/embedded-content.html#embedded-content">embedded content</a>.</p>
 
 <p>SVG supports embedded content with the use of <a>'image'</a> and <a>'foreignObject'</a> elements.</p>
 

--- a/master/embedded.html
+++ b/master/embedded.html
@@ -72,7 +72,7 @@ This is the same definition as <a href="https://www.w3.org/TR/html51/">HTML's</a
       </p>
       <p>
         The HTML dimensional attributes must be parsed and interpretted
-        as defined in the HTML specification  [<a href="refs.html#ref-html51">HTML</a>].
+        as defined in the HTML specification  [<a href="refs.html#ref-html">HTML</a>].
         Specifically, they only accept integer values, not CSS lengths with units.
         On a <a>'canvas'</a> element,
         <a href="https://www.w3.org/TR/html51/semantics-scripting.html#element-attrdef-canvas-width">the attributes</a> are slightly different:
@@ -370,7 +370,7 @@ elements within an SVG file.</p>
     </table>
   </dt>
   <dd>
-    <p>The crossorigin attribute is a <a>CORS settings attribute</a>, and unless otherwise specified follows the same processing rules as in HTML [<a href="refs.html#ref-html51">HTML</a>].</p>
+    <p>The crossorigin attribute is a <a>CORS settings attribute</a>, and unless otherwise specified follows the same processing rules as in HTML [<a href="refs.html#ref-html">HTML</a>].</p>
   </dd>
   <dt>
     <table class="attrdef def">

--- a/master/embedded.html
+++ b/master/embedded.html
@@ -75,7 +75,7 @@ This is the same definition as <a href="https://html.spec.whatwg.org/multipage/"
         as defined in the HTML specification  [<a href="refs.html#ref-html">HTML</a>].
         Specifically, they only accept integer values, not CSS lengths with units.
         On a <a>'canvas'</a> element,
-        <a href="https://www.w3.org/TR/html51/semantics-scripting.html#element-attrdef-canvas-width">the attributes</a> are slightly different:
+        <a href="https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-element:the-canvas-element-19">the attributes</a> are slightly different:
         they affect the rendered bitmap, not only its layout.
       </p>
       <p>

--- a/master/embedded.html
+++ b/master/embedded.html
@@ -441,7 +441,7 @@ elements within an SVG file.</p>
 
 <edit:example href='images/embedded/videoinsvg.svg' name='videoinsvg' link='no' image='no'/>
 
-<p>HTML elements, in the HTML namespace, used as children of <a href="https://html.spec.whatwg.org/multipage/media.html#the-video-element">'video'</a>, <a href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element">'audio'</a>, <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">'iframe'</a> and <a href="https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-element">'canvas'</a> elements within an SVG document fragment behave as specified in HTML. This applies in particular to <a href="https://www.w3.org/TR/html51/dom.html#fallback-content">fallback content</a>;
+<p>HTML elements, in the HTML namespace, used as children of <a href="https://html.spec.whatwg.org/multipage/media.html#the-video-element">'video'</a>, <a href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element">'audio'</a>, <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element">'iframe'</a> and <a href="https://html.spec.whatwg.org/multipage/canvas.html#the-canvas-element">'canvas'</a> elements within an SVG document fragment behave as specified in HTML. This applies in particular to <a href="https://html.spec.whatwg.org/multipage/dom.html#fallback-content">fallback content</a>;
 if fallback content is rendered,
 the embedded element behaves like an SVG <a>'foreignObject'</a> element to contain the HTML content.
 This would occur, for example,

--- a/master/interact.html
+++ b/master/interact.html
@@ -901,7 +901,7 @@ will have no effect on the SVG user agent.</p>
 </div>
 
 <p>Note that SVG elements do not have an equivalent of HTML's
-<a href="https://www.w3.org/TR/html51/editing.html#the-accesskey-attribute">accesskey</a>
+<a href="https://html.spec.whatwg.org/multipage/interaction.html#the-accesskey-attribute">accesskey</a>
 attribute.</p>
 </div>
 

--- a/master/interact.html
+++ b/master/interact.html
@@ -869,7 +869,7 @@ will have no effect on the SVG user agent.</p>
 
 <p> As in HTML, an SVG element that is <a>focusable</a>
     but does not have a defined
-    <a href="https://www.w3.org/TR/html51/editing.html#activation-behavior">activation behavior</a>
+    <a href="https://dom.spec.whatwg.org/#eventtarget-activation-behavior">activation behavior</a>
     has an activation behaviour that does nothing
     (unless a script specifically responds to it).
 </p>

--- a/master/interact.html
+++ b/master/interact.html
@@ -804,7 +804,7 @@ will have no effect on the SVG user agent.</p>
     For the purpose of the HTML focus model,
     interactive user agents must treat them as
     <a href="https://html.spec.whatwg.org/multipage/interaction.html#focusable">focusable areas</a>
-    whose <a href="https://www.w3.org/TR/html51/editing.html#can-be-focused">tabindex focus flag</a> should be set:
+    whose <a href="https://html.spec.whatwg.org/multipage/interaction.html#specially-focusable">tabindex focus flag</a> should be set:
 </p>
 <ul>
     <li>the document root element</li>
@@ -822,7 +822,7 @@ will have no effect on the SVG user agent.</p>
     for each sub-control.
 </p>
 <p> In addition, all <a>'a'</a> elements that are valid links are <a>focusable</a>,
-    and their <a href="https://www.w3.org/TR/html51/editing.html#can-be-focused">tabindex focus flag</a> must be set
+    and their <a href="https://html.spec.whatwg.org/multipage/interaction.html#specially-focusable">tabindex focus flag</a> must be set
     <em>unless</em> the user agent normally provides an alternative method
     of keyboard traversal of links.
 </p>

--- a/master/interact.html
+++ b/master/interact.html
@@ -848,7 +848,7 @@ will have no effect on the SVG user agent.</p>
 <p>
     The sequential focus order is generated from the set of all <a>focusable</a> elements,
     processing <a>'tabindex'</a> attributes on SVG elements
-    in the same way as <a href="https://www.w3.org/TR/html51/editing.html#the-tabindex-attribute">tabindex attributes on HTML elements</a>.
+    in the same way as <a href="https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute">tabindex attributes on HTML elements</a>.
     Content within a <a>use-element shadow tree</a>
     is inserted in the focus order as if it was child content
     of the <a>'use'</a> element.

--- a/master/interact.html
+++ b/master/interact.html
@@ -812,7 +812,7 @@ will have no effect on the SVG user agent.</p>
     <li>any element (such as within a <a>'foreignObject'</a>)
         that generates a scrollable region
     </li>
-    <li><a>'iframe'</a> elements that are <a href="https://www.w3.org/TR/html51/browsers.html#browsing-context-container"></a>browsing context containers</li>
+    <li><a>'iframe'</a> elements that are <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context-container"></a>browsing context containers</li>
     <li><a>'audio'</a> and <a>'video'</a> elements with user controls</li>
     <li>any directly <a>rendered element</a>
         with a valid integer <a>'tabindex'</a> attribute</li>

--- a/master/interact.html
+++ b/master/interact.html
@@ -779,9 +779,9 @@ will have no effect on the SVG user agent.</p>
 <h2 id="Focus">Focus</h2>
 
 <p>
-    SVG uses the same <a href="https://www.w3.org/TR/html51/editing.html#focus">focus model</a>
+    SVG uses the same <a href="https://html.spec.whatwg.org/multipage/interaction.html#focus">focus model</a>
     as HTML, modified for SVG as described in this section.
-    At most one element in each document is <a href="https://www.w3.org/TR/html51/editing.html#focused">focused</a> at a time;
+    At most one element in each document is <a href="https://html.spec.whatwg.org/multipage/interaction.html#focused">focused</a> at a time;
     if the document as a whole has system focus,
     this element becomes the target of all keyboard events.
 </p>
@@ -803,7 +803,7 @@ will have no effect on the SVG user agent.</p>
     is also focusable.
     For the purpose of the HTML focus model,
     interactive user agents must treat them as
-    <a href="https://www.w3.org/TR/html51/editing.html#focusable">focusable areas</a>
+    <a href="https://html.spec.whatwg.org/multipage/interaction.html#focusable">focusable areas</a>
     whose <a href="https://www.w3.org/TR/html51/editing.html#can-be-focused">tabindex focus flag</a> should be set:
 </p>
 <ul>

--- a/master/interact.html
+++ b/master/interact.html
@@ -916,7 +916,7 @@ attribute.</p>
   </dl>
 
   <p>For every <a>event type</a> that the <a>user agent</a> supports, SVG supports that as an event attribute,
-    following the same requirements as for <a>event handler content attributes</a> [<a href="refs.html#ref-html51">HTML</a>].
+    following the same requirements as for <a>event handler content attributes</a> [<a href="refs.html#ref-html">HTML</a>].
     The <a>event attributes</a> are available on all <a>SVG elements</a>.
   </p>
 
@@ -1104,7 +1104,7 @@ attribute.</p>
       </table>
     </dt>
     <dd>
-      <p>The crossorigin attribute is a <a>CORS settings attribute</a>, and unless otherwise specified follows the same processing rules as in html [<a href="refs.html#ref-html51">HTML</a>].</p>
+      <p>The crossorigin attribute is a <a>CORS settings attribute</a>, and unless otherwise specified follows the same processing rules as in html [<a href="refs.html#ref-html">HTML</a>].</p>
     </dd>
     <dt>
       <table class="attrdef def">

--- a/master/interact.html
+++ b/master/interact.html
@@ -161,7 +161,7 @@ the SVG language:</p>
 <p class="note">A number of events defined in SVG 1.1, <span class="event-name">SVGLoad</span>,
   <span class="event-name">SVGError</span> etc, have been replaced with the equivalent
 unprefixed events defined in <a href="https://www.w3.org/TR/uievents/#events-uievent-types">UI EVENTS</a>
-and <a href="https://www.w3.org/TR/html51/fullindex.html#events-table">HTML</a>.
+and <a href="https://html.spec.whatwg.org/multipage/indices.html#events-2">HTML</a>.
 </p>
 
 <p class="issue" data-issue="8">

--- a/master/intro.html
+++ b/master/intro.html
@@ -62,7 +62,7 @@ is helpful for many people to understand the content provided.
 and standards efforts, as described in the following:</p>
 
 <ul>
-  <li>SVG can be integrated with <a href="https://www.w3.org/TR/html51/">HTML</a> either by using SVG in HTML or by using HTML in SVG, in both cases either by inclusion or reference.</li>
+  <li>SVG can be integrated with <a href="https://html.spec.whatwg.org/multipage/">HTML</a> either by using SVG in HTML or by using HTML in SVG, in both cases either by inclusion or reference.</li>
 
   <li>SVG is an application of XML and is compatible with <a href="https://www.w3.org/TR/2008/REC-xml-20081126/">XML 1.0</a> and with the <a href="https://www.w3.org/TR/2006/REC-xml-names-20060816/">Namespaces in XML</a> specification. However, when SVG content is included in HTML document, the HTML syntax applies and may not be compatible with XML. See <a href="https://www.w3.org/TR/svg-integration/">SVG Integration</a> for details.</li>
 

--- a/master/intro.html
+++ b/master/intro.html
@@ -24,7 +24,7 @@
 <p>SVG is a language for describing two-dimensional graphics.
 As a standalone format or when mixed with other XML, it uses the
 XML syntax [<a href="refs.html#ref-xml">xml</a>].
-SVG code used inside HTML documents uses the HTML syntax [<a href="refs.html#ref-html51">HTML</a>].
+SVG code used inside HTML documents uses the HTML syntax [<a href="refs.html#ref-html">HTML</a>].
 SVG allows for three types of graphic objects: vector graphic
 shapes (e.g., paths consisting of straight lines and curves),
 images and text. Graphical objects can be grouped, styled,

--- a/master/linking.html
+++ b/master/linking.html
@@ -522,7 +522,7 @@ in section 3.1 of the <a href="http://www.ietf.org/rfc/rfc3987.txt">URL specific
 
 <p>
   When fetching external resources from the Internet,
-  user agents must use a <a href="https://www.w3.org/TR/html51/infrastructure.html#creating-a-potential-cors-request">potentially CORS-enabled request</a>
+  user agents must use a <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#create-a-potential-cors-request">potentially CORS-enabled request</a>
   as defined in HTML [<a href="refs.html#ref-html">HTML</a>]
   with the <em>corsAttributeState</em> as follows:
 </p>

--- a/master/linking.html
+++ b/master/linking.html
@@ -352,7 +352,7 @@ XLink attributes. For example:</p>
   </li>
   <li>For source URLs on embedded HTML media elements,
     as required based on source selection rules
-    <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#the-media-elements">in the HTML specification</a> [<a href="refs.html#ref-html">HTML</a>].
+    <a href="https://html.spec.whatwg.org/multipage/media.html#media-elements">in the HTML specification</a> [<a href="refs.html#ref-html">HTML</a>].
   </li>
   <li>For all presentation attributes and style properties,
     at the time the property is required for rendering an element.

--- a/master/linking.html
+++ b/master/linking.html
@@ -430,7 +430,7 @@ in section 3.1 of the <a href="http://www.ietf.org/rfc/rfc3987.txt">URL specific
   <li>
     <p>
       If the URL is being processed following the activation of a link,
-      the user agent must follow the <a href="https://www.w3.org/TR/html51/browsers.html#browsing-the-web">algorithm for navigating to a URL</a>
+      the user agent must follow the <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#browsing-the-web">algorithm for navigating to a URL</a>
       described in the HTML specification [<a href="refs.html#ref-html">HTML</a>].
       The outcome of this algorithm varies depending on the
       <a>'a/target'</a> browsing context and security restrictions between browsing contexts,

--- a/master/linking.html
+++ b/master/linking.html
@@ -418,7 +418,7 @@ The absolute URL should be generated using one of the following methods:
   this includes SVG documents and XHTML documents but not HTML documents that are not XML.
   In contrast, a <a class="html" href="https://www.w3.org/TR/html/document-metadata.html#the-base-element"><code>base</code></a> element
   affects relative URLs in any SVG or HTML document,
-  by altering the <a href="https://www.w3.org/TR/html51/infrastructure.html#document-base-url">document base URL</a>.
+  by altering the <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#document-base-url">document base URL</a>.
 </p>
 
 <p>If the protocol, such as HTTP, does not support <a>URLs</a> directly,

--- a/master/linking.html
+++ b/master/linking.html
@@ -352,7 +352,7 @@ XLink attributes. For example:</p>
   </li>
   <li>For source URLs on embedded HTML media elements,
     as required based on source selection rules
-    <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#the-media-elements">in the HTML specification</a> [<a href="refs.html#ref-html51">HTML</a>].
+    <a href="https://www.w3.org/TR/html51/semantics-embedded-content.html#the-media-elements">in the HTML specification</a> [<a href="refs.html#ref-html">HTML</a>].
   </li>
   <li>For all presentation attributes and style properties,
     at the time the property is required for rendering an element.
@@ -408,7 +408,7 @@ The absolute URL should be generated using one of the following methods:
   <li>
     as described in the <a href="https://www.w3.org/TR/html51/infrastructure.html#parsing-urls">HTML specification</a>
     if the reference occurs in a non-presentation attribute
-    in an HTML document that is not an XML document [<a href="refs.html#ref-html51">HTML</a>]
+    in an HTML document that is not an XML document [<a href="refs.html#ref-html">HTML</a>]
   </li>
 </ul>
 
@@ -431,7 +431,7 @@ in section 3.1 of the <a href="http://www.ietf.org/rfc/rfc3987.txt">URL specific
     <p>
       If the URL is being processed following the activation of a link,
       the user agent must follow the <a href="https://www.w3.org/TR/html51/browsers.html#browsing-the-web">algorithm for navigating to a URL</a>
-      described in the HTML specification [<a href="refs.html#ref-html51">HTML</a>].
+      described in the HTML specification [<a href="refs.html#ref-html">HTML</a>].
       The outcome of this algorithm varies depending on the
       <a>'a/target'</a> browsing context and security restrictions between browsing contexts,
       and on whether the link is to the same document as is currently contained in that browsing context
@@ -523,7 +523,7 @@ in section 3.1 of the <a href="http://www.ietf.org/rfc/rfc3987.txt">URL specific
 <p>
   When fetching external resources from the Internet,
   user agents must use a <a href="https://www.w3.org/TR/html51/infrastructure.html#creating-a-potential-cors-request">potentially CORS-enabled request</a>
-  as defined in HTML [<a href="refs.html#ref-html51">HTML</a>]
+  as defined in HTML [<a href="refs.html#ref-html">HTML</a>]
   with the <em>corsAttributeState</em> as follows:
 </p>
 <ul>
@@ -829,7 +829,7 @@ or frame to be replaced by the W3C home page.</p>
     </dl>
     <p> The normative definitions for browsing contexts and security
         restrictions on navigation actions between browsing contexts
-        is HTML [<a href="refs.html#ref-html51">HTML</a>], specifically
+        is HTML [<a href="refs.html#ref-html">HTML</a>], specifically
         <a href="https://www.w3.org/TR/html51/browsers.html">the chapter on
             loading web pages</a>.
     </p>
@@ -1047,7 +1047,7 @@ formed <em>SVGViewSpec</em>.</p>
 
 <p>When a source document performs a link into an SVG document, for example
 via an <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element">HTML anchor element</a>
-([<a href="refs.html#ref-html51">HTML</a>]; i.e.,
+([<a href="refs.html#ref-html">HTML</a>]; i.e.,
 <span class="attr-value">&lt;a href=...&gt;</span> element in HTML) or an
 XLink specification [<a href="refs.html#ref-xlink">xlink</a>], then
 the SVG fragment identifier specifies the initial view into the SVG document,

--- a/master/linking.html
+++ b/master/linking.html
@@ -824,7 +824,7 @@ or frame to be replaced by the W3C home page.</p>
       (the same as <span class="attr-value">'_blank'</span>, except that
       it now has a name).  The name must be a valid XML Name [XML11], and should not start
       with an underscore (U+005F LOW LINE character), to meet the requirements of a
-      <a href="https://www.w3.org/TR/html51/browsers.html#valid-browsing-context-name">valid
+      <a href="https://html.spec.whatwg.org/multipage/browsers.html#valid-browsing-context-name">valid
       browsing context name</a> from HTML.</dd>
     </dl>
     <p> The normative definitions for browsing contexts and security

--- a/master/linking.html
+++ b/master/linking.html
@@ -1046,7 +1046,7 @@ in any order, but each type may only occur at most one time in a correctly
 formed <em>SVGViewSpec</em>.</p>
 
 <p>When a source document performs a link into an SVG document, for example
-via an <a href="https://www.w3.org/TR/html/textlevel-semantics.html#the-a-element">HTML anchor element</a>
+via an <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">HTML anchor element</a>
 ([<a href="refs.html#ref-html">HTML</a>]; i.e.,
 <span class="attr-value">&lt;a href=...&gt;</span> element in HTML) or an
 XLink specification [<a href="refs.html#ref-xlink">xlink</a>], then

--- a/master/linking.html
+++ b/master/linking.html
@@ -416,7 +416,7 @@ The absolute URL should be generated using one of the following methods:
   The <a href="https://www.w3.org/TR/xmlbase/#syntax"><span class="attr-name">'xml:base'</span></a> attribute
   will only have an effect in XML documents;
   this includes SVG documents and XHTML documents but not HTML documents that are not XML.
-  In contrast, a <a class="html" href="https://www.w3.org/TR/html/document-metadata.html#the-base-element"><code>base</code></a> element
+  In contrast, a <a class="html" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element"><code>base</code></a> element
   affects relative URLs in any SVG or HTML document,
   by altering the <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#document-base-url">document base URL</a>.
 </p>
@@ -541,7 +541,7 @@ in section 3.1 of the <a href="http://www.ietf.org/rfc/rfc3987.txt">URL specific
     For all other references,
     the "no-cors" state.
   </li>
-</ul><a class="html" href="https://www.w3.org/TR/html/document-metadata.html#the-base-element"><code>base</code></a>
+</ul><a class="html" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element"><code>base</code></a>
 <p>
   The request's <em>origin</em> is computed using the
   <a href="https://fetch.spec.whatwg.org/#concept-cors-check" >same rules as HTML</a>,

--- a/master/linking.html
+++ b/master/linking.html
@@ -907,7 +907,7 @@ or frame to be replaced by the W3C home page.</p>
   <dd>
     These attributes further describe the targetted resource
     and its relationship to the current document.
-    Allowed values and meaning are <a href="https://www.w3.org/TR/html51/textlevel-semantics.html#the-a-element">as defined for the <code>a</code> element in HTML</a>.
+    Allowed values and meaning are <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">as defined for the <code>a</code> element in HTML</a>.
   </dd>
 </dl>
 

--- a/master/linking.html
+++ b/master/linking.html
@@ -830,7 +830,7 @@ or frame to be replaced by the W3C home page.</p>
     <p> The normative definitions for browsing contexts and security
         restrictions on navigation actions between browsing contexts
         is HTML [<a href="refs.html#ref-html">HTML</a>], specifically
-        <a href="https://www.w3.org/TR/html51/browsers.html">the chapter on
+        <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsers">the chapter on
             loading web pages</a>.
     </p>
     <!--

--- a/master/linking.html
+++ b/master/linking.html
@@ -406,7 +406,7 @@ The absolute URL should be generated using one of the following methods:
     if the reference occurs in any other attribute in an XML document
   </li>
   <li>
-    as described in the <a href="https://www.w3.org/TR/html51/infrastructure.html#parsing-urls">HTML specification</a>
+    as described in the <a href="https://html.spec.whatwg.org/multipage/urls-and-fetching.html#resolving-urls">HTML specification</a>
     if the reference occurs in a non-presentation attribute
     in an HTML document that is not an XML document [<a href="refs.html#ref-html">HTML</a>]
   </li>

--- a/master/refs.html
+++ b/master/refs.html
@@ -108,9 +108,6 @@
   <dt id="ref-html" class="normref">[<a href="https://html.spec.whatwg.org/multipage/">HTML</a>]</dt>
   <dd><div>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Living Standard. URL:&nbsp;<a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a></div></dd>
 
-  <dt id="ref-html51" class="normref">[<a href="https://www.w3.org/TR/html51/">html51</a>]</dt>
-  <dd><div>Steve Faulkner; Arron Eicholz; Travis Leithead; Alex Danilo. <a href="https://www.w3.org/TR/html51/"><cite>HTML 5.1</cite></a>. 21 June 2016. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/html51/">https://www.w3.org/TR/html51/</a> ED:&nbsp;<a href="https://w3c.github.io/html/">https://w3c.github.io/html/</a></div></dd>
-
   <dt id="ref-jpeg" class="normref">[<a href="https://www.w3.org/Graphics/JPEG/jfif3.pdf">JPEG</a>]</dt>
   <dd><div>Eric Hamilton. <a href="https://www.w3.org/Graphics/JPEG/jfif3.pdf"><cite>JPEG File Interchange Format</cite></a>. September 1992. URL:&nbsp;<a href="https://www.w3.org/Graphics/JPEG/jfif3.pdf">https://www.w3.org/Graphics/JPEG/jfif3.pdf</a></div></dd>
 

--- a/master/render.html
+++ b/master/render.html
@@ -638,7 +638,7 @@ positions required on the output device. Resampling
 requirements are discussed under
 <a href="conform.html">conformance requirements</a>.</p>
 <p class="ready-for-wider-review">
-As in HTML [<a href="refs.html#ref-html51">HTML</a>, 10.4.2],
+As in HTML [<a href="refs.html#ref-html">HTML</a>, 10.4.2],
 all animated images with the same absolute URL and the same image
 data are expected to be rendered synchronised to the same timeline as a group,
 with the timeline starting at the time of the least recent addition to the

--- a/master/struct.html
+++ b/master/struct.html
@@ -1939,10 +1939,10 @@ the HTML namespace) must be supported in SVG documents:</p>
 
 <ul>
   <li>the <a class="html" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element"><code>base</code></a> element</li>
-  <li>the <a class="html" href="https://www.w3.org/TR/html/document-metadata.html#the-link-element"><code>link</code></a> element</li>
-  <li>the <a class="html" href="https://www.w3.org/TR/html/document-metadata.html#the-meta-element"><code>meta</code></a> element</li>
-  <li>the <a class="html" href="https://www.w3.org/TR/html/document-metadata.html#the-style-element"><code>style</code></a> element</li>
-  <li>the <a class="html" href="https://www.w3.org/TR/html/semantics-scripting.html#the-script-element"><code>script</code></a> element</li>
+  <li>the <a class="html" href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element"><code>link</code></a> element</li>
+  <li>the <a class="html" href="https://html.spec.whatwg.org/multipage/semantics.html#the-meta-element"><code>meta</code></a> element</li>
+  <li>the <a class="html" href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element"><code>style</code></a> element</li>
+  <li>the <a class="html" href="https://html.spec.whatwg.org/multipage/scripting.html#the-script-element"><code>script</code></a> element</li>
 </ul>
 
 <p class="note">

--- a/master/struct.html
+++ b/master/struct.html
@@ -2762,7 +2762,7 @@ Authors are encouraged to use the <a href="https://www.w3.org/TR/dom/#dom-docume
 <!--<p class="issue" data-issue="47">Data point: <a href="https://www.chromestatus.com/metrics/feature/timeline/popularity/251">UseCounter in blink</a> shows ~0.010.</p>-->
 
 <p>SVG implementations that implement HTML must support the
-<a href="https://www.w3.org/TR/html51/dom.html#the-document-object">HTML extensions to the document interface</a>.
+<a href="https://html.spec.whatwg.org/multipage/dom.html#the-document-object">HTML extensions to the document interface</a>.
 
 Other SVG implementations must support the following IDL fragment.
 </p>
@@ -2776,7 +2776,7 @@ partial interface <a>Document</a> {
 };</pre>
 
 <p>The title, referrer, domain and <span id="__svg__SVGDocument__activeElement">activeElement</span> IDL attributes must behave the same as
-<a href="https://www.w3.org/TR/html51/dom.html#the-document-object">the corresponding IDL attributes defined in HTML</a>.</p>
+<a href="https://html.spec.whatwg.org/multipage/dom.html#the-document-object">the corresponding IDL attributes defined in HTML</a>.</p>
 
 <h3 id="InterfaceSVGSVGElement">Interface SVGSVGElement</h3>
 

--- a/master/struct.html
+++ b/master/struct.html
@@ -1938,7 +1938,7 @@ based on RDF, can be used also.)</p>
 the HTML namespace) must be supported in SVG documents:</p>
 
 <ul>
-  <li>the <a class="html" href="https://www.w3.org/TR/html/document-metadata.html#the-base-element"><code>base</code></a> element</li>
+  <li>the <a class="html" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element"><code>base</code></a> element</li>
   <li>the <a class="html" href="https://www.w3.org/TR/html/document-metadata.html#the-link-element"><code>link</code></a> element</li>
   <li>the <a class="html" href="https://www.w3.org/TR/html/document-metadata.html#the-meta-element"><code>meta</code></a> element</li>
   <li>the <a class="html" href="https://www.w3.org/TR/html/document-metadata.html#the-style-element"><code>style</code></a> element</li>
@@ -1946,7 +1946,7 @@ the HTML namespace) must be supported in SVG documents:</p>
 </ul>
 
 <p class="note">
-Note that the <a class="html" href="https://www.w3.org/TR/html/document-metadata.html#the-base-element"><code>base</code></a> element will affect all URL values in the document, including e.g. paint server references or <a>'use'</a> element references.
+Note that the <a class="html" href="https://html.spec.whatwg.org/multipage/semantics.html#the-base-element"><code>base</code></a> element will affect all URL values in the document, including e.g. paint server references or <a>'use'</a> element references.
 However, when <a href="linking.html#processingURL-absolute">processing URL references</a>
 to identify a specific target element,
 the user agent must always compare the generated absolute URL against the current document base URL

--- a/master/styling.html
+++ b/master/styling.html
@@ -62,7 +62,7 @@ these are required.</p>
 style sheets to be embedded directly within SVG content.
 SVG's <a>'style element'</a> element has the same
 attributes as the
-<a href="https://www.w3.org/TR/html51/document-metadata.html#the-style-element">corresponding
+<a href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">corresponding
 element in HTML</a>.</p>
 
 <edit:elementsummary name='style'/>
@@ -140,7 +140,7 @@ element in HTML</a>.</p>
 
 <p>The semantics and processing of a <a>'style element'</a> and its
 attributes must be the same as is defined for the
-<a href="https://www.w3.org/TR/html51/document-metadata.html#the-style-element">HTML
+<a href="https://html.spec.whatwg.org/multipage/semantics.html#the-style-element">HTML
 <span class='element-name'>'style'</span> element</a>.</p>
 
 <p>The style sheet's text content is never directly rendered;

--- a/master/styling.html
+++ b/master/styling.html
@@ -258,7 +258,7 @@ attributes on all elements to support element-specific styling.</p>
 SVG DOM (in the <a href="types.html#__svg__SVGElement__className">className</a>
 IDL attribute on <a>SVGElement</a>), the semantics and behavior of the
 <a>'class'</a> and <a>'style attribute'</a> attributes must be the same
-as that for <a href="https://www.w3.org/TR/html51/dom.html#global-attributes">the corresponding
+as that for <a href="https://html.spec.whatwg.org/multipage/dom.html#global-attributes">the corresponding
 attributes in HTML</a>.</p>
 
 <div class='example'>

--- a/master/styling.html
+++ b/master/styling.html
@@ -153,7 +153,7 @@ and this declaration must have importance over any other CSS rule or presentatio
 
 <h2 id="LinkElement">External style sheets: the effect of the HTML <span class='element-name'>'link'</span> element</h2>
 
-<p>An <a href="https://www.w3.org/TR/html51/document-metadata.html#the-link-element">HTML
+<p>An <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">HTML
 <span class='element-name'>'link'</span> element</a> in an SVG document (that is,
 an element in the HTML namespace with local name "link")
 with its <span class='attr-name'>'rel'</span>
@@ -163,7 +163,7 @@ loaded and applied to the document.  Such elements in HTML documents outside
 of an inline SVG fragment must also apply to the SVG content.</p>
 
 <p class='note'>Because the element is required to be in the HTML namespace, it
-is not possible for an <a href="https://www.w3.org/TR/html51/document-metadata.html#the-link-element">HTML
+is not possible for an <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">HTML
 <span class='element-name'>'link'</span> element</a> to be parsed as
 part of an inline SVG fragment in a text/html document.  However, when
 parsing an SVG document using XML syntax, XML namespace declarations
@@ -171,7 +171,7 @@ can be used to place the element in the HTML namespace.</p>
 
 <div class='note'>
   <p>Note that an alternative way to reference external style sheets
-  without using the <a href="https://www.w3.org/TR/html51/document-metadata.html#the-link-element">HTML
+  without using the <a href="https://html.spec.whatwg.org/multipage/semantics.html#the-link-element">HTML
   <span class='element-name'>'link'</span> element</a> is to use an @import
   rule in an inline style sheet.  For example:</p>
 

--- a/master/text.html
+++ b/master/text.html
@@ -1835,7 +1835,7 @@
     SVG's text layout options are designed to cover most general use
     cases. If more complex layout is required (bulleted lists, tables,
     etc.), text can be rendered in another XML namespace such as XHTML
-    [<a href="refs.html#ref-html51">HTML</a>] embedded inline within a
+    [<a href="refs.html#ref-html">HTML</a>] embedded inline within a
     <a>'foreignObject'</a> element.
   </p>
 

--- a/master/types.html
+++ b/master/types.html
@@ -88,7 +88,7 @@ six methods for describing an attribute's syntax:</p>
   <span class="syntax">[URL]</span> appearing in the Value column.</li>
 
   <li>As a type as defined by the <a href="https://html.spec.whatwg.org/">HTML
-  Standard</a> [<a href="refs.html#ref-html51">HTML</a>].  This is indicated by
+  Standard</a> [<a href="refs.html#ref-html">HTML</a>].  This is indicated by
   <span class="syntax">[HTML]</span> appearing in the Value column.</li>
 
   <li>In prose, below the attibute definition table.  This is indicated by the


### PR DESCRIPTION
Update all internal links to [HTML] which were linking to HTML 5.1 in the refs (with the wrong bibliographic reference). Actual [HTML51] was not found.