### PR TITLE
Fix #532 with informative refs to ICC  & ICC support in css-color-4

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -135,6 +135,14 @@ have been made.</p>
     high-precision graphics to the Implementation Requirements appendix.
   </li>
 </ul>
+<div class='changed-since-cr1 cr2'>
+  <ul>
+    <li>Add informative references to ICC and to CSS Color 4
+      <a href="https://github.com/w3c/svgwg/issues/532">Issue discussion</a>
+      <a href="">Edits</a>
+    </li>
+  </ul>
+</div>
 
 <h3 id="rendering">Rendering Model chapter</h3>
 <ul>

--- a/master/changes.html
+++ b/master/changes.html
@@ -139,7 +139,7 @@ have been made.</p>
   <ul>
     <li>Add informative references to ICC and to CSS Color 4
       <a href="https://github.com/w3c/svgwg/issues/532">Issue discussion</a>
-      <a href="">Edits</a>
+      <a href="https://github.com/w3c/svgwg/pull/549">Edits</a>
     </li>
   </ul>
 </div>

--- a/master/conform.html
+++ b/master/conform.html
@@ -1372,8 +1372,8 @@ support the following additional features:</p>
   text. (Smoothing is often accomplished using anti-aliasing
   techniques.)</li>
 
-  <li>Color management via ICC profile support (i.e., the
-  ability to support colors defined using ICC profiles).</li>
+  <li>Color management via ICC profile support [[ICC]] (i.e., the
+  ability to support colors defined using ICC profiles) [[css-color-4]].</li>
 
   <li>Resampling of image data must conform to the requirements
   for conforming high-quality SVG viewers as specified in the

--- a/master/conform.html
+++ b/master/conform.html
@@ -1372,8 +1372,10 @@ support the following additional features:</p>
   text. (Smoothing is often accomplished using anti-aliasing
   techniques.)</li>
 
-  <li>Color management via ICC profile support [[ICC]] (i.e., the
-  ability to support colors defined using ICC profiles) [[css-color-4]].</li>
+  <li>Color management via ICC profile support
+  [<a href="refs.html#ref-icc">ICC</a>] (i.e., the
+  ability to support colors defined using ICC profiles)
+  [<a href="refs.html#ref-css-color-4">css-color-4</a>]</li>
 
   <li>Resampling of image data must conform to the requirements
   for conforming high-quality SVG viewers as specified in the

--- a/master/refs.html
+++ b/master/refs.html
@@ -224,6 +224,15 @@
   <dt id="ref-selectors-3" class="informref">[<a href="https://www.w3.org/TR/selectors-3/">css-selectors-3</a>]</dt>
   <dd><div>Tantek Çelik; Elika Etemad; Daniel Glazman; Ian Hickson; Peter Linss; John Williams et al. <a href="https://www.w3.org/TR/css-selectors-3/"><cite>Selectors Level 3</cite></a>. 30 January 2018. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/selectors-3/">https://www.w3.org/TR/selectors-3/</a></div></dd>
 
+  <dt id="ref-css-color-4" class="informref">[css-color-4]</dt>
+  <dd>
+    <cite class="w3cwd"><a href="https://www.w3.org/TR/css-color-4/">CSS Color Module Level 4</a></cite>,
+    Tab Atkins; Chris Lilley eds.
+    World Wide Web Consortium, 5 July 2016.
+    <br/>The <a href="https://www.w3.org/TR/css-color-4/">latest
+      edition of CSS Color 4</a> is available at
+      https://www.w3.org/TR/css-color-4/.
+  </dd>
   <dt id="ref-css-shapes-2" class="informref">[css-shapes-2]</dt>
   <dd>
     <cite class="w3cwd"><a href="http://dev.w3.org/csswg/css-shapes-2/">CSS Shapes Module Level 2</a></cite>,
@@ -248,6 +257,10 @@
 
   <dt id="ref-editing" class="informref">[<a href="https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html">EDITING</a>]</dt>
   <dd><div>A. Gregor. <a href="https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html"><cite>HTML Editing APIs</cite></a>. URL:&nbsp;<a href="https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html">https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html</a></div></dd>
+
+  <dt id="ref-icc" class="informref">[<a href="www.color.org/specification/ICC1v43_2010-12.pdf">ICC</a>]</dt>
+  <dd><div>International Color Consortium, <a href="http://www.color.org/specification/ICC1v43_2010-12.pdf"><cite>ICC.1:2010 (Profile version 4.3.0.0)</cite></a>. December 2010. URL:&nbsp;<a href="http://www.color.org/specification/ICC1v43_2010-12.pdf">http://www.color.org/specification/ICC1v43_2010-12.pdf</a></div></dd>
+  </dt>
 
   <dt id="ref-mathml3" class="informref">[<a href="https://www.w3.org/TR/MathML3/">MathML3</a>]</dt>
   <dd><div>David Carlisle; Patrick D F Ion; Robert R Miner. <a href="https://www.w3.org/TR/MathML3/"><cite>Mathematical Markup Language (MathML) Version 3.0 2nd Edition</cite></a>. 10 April 2014. W3C Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/MathML3/">https://www.w3.org/TR/MathML3/</a></div></dd>


### PR DESCRIPTION
As this is an optional feature, informative references are fine. CSS Color 4 defines how to use ICC profiles in CSS, while the ICC ref covers the actual ICC profile format and meaning.