### PR TITLE
Allow any non-negative number for stroke-miterlimit

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -785,6 +785,11 @@ have been made.</p>
         they are deferred to the next level of the spec.
         <a href="https://github.com/w3c/svgwg/pull/533/">Edits and discussion</a>
       </li>
+      <li>
+        Make any non-negative number a valid value for <a>'stroke-miterlimit'</a>.
+        <a href="https://github.com/w3c/svgwg/issues/545">Issue discussion</a>
+        <a href="">Edits</a>
+      </li>
     </ul>
   </div>
 </ul>

--- a/master/changes.html
+++ b/master/changes.html
@@ -788,7 +788,7 @@ have been made.</p>
       <li>
         Make any non-negative number a valid value for <a>'stroke-miterlimit'</a>.
         <a href="https://github.com/w3c/svgwg/issues/545">Issue discussion</a>
-        <a href="">Edits</a>
+        <a href="https://github.com/w3c/svgwg/pull/551">Edits</a>
       </li>
     </ul>
   </div>

--- a/master/painting.html
+++ b/master/painting.html
@@ -1012,12 +1012,17 @@ the <a href="paths.html#PathElementImplementationNotes">path implementation note
     <span class='prop-value'>miter</span>,
     <span class='prop-value'>miter-clip</span>, or
     <span class='prop-value'>arcs</span> line join as a multiple of
-    the <a>'stroke-width'</a> value. The value of
-    <a>'stroke-miterlimit'</a> must be a <a>&lt;number&gt;</a> greater
-    than or equal to 1. Any other value is an error (see
-    <a href="conform.html#ErrorProcessing">Error processing</a>).
+    the <a>'stroke-width'</a> value.
+    A negative value for <a>'stroke-miterlimit'</a> must be treated as an <a>illegal value</a>.
   </dd>
 </dl>
+
+<p class="note">
+  Previous versions of the SVG specification
+  also stated that values between 0 and 1 were in error,
+  but this was not well implemented by user agent's CSS parsers.
+  In practice, any miter join will exceed a miter limit between 0 and 1.
+</p>
 
 <p>
   For the <span class='prop-value'>miter</span> or the

--- a/master/propidx.html
+++ b/master/propidx.html
@@ -381,7 +381,7 @@
         </tr>
         <tr>
           <th><a>'stroke-miterlimit'</a></th>
-          <td>&lt;miterlimit&gt; </td>
+          <td><a>&lt;number&gt;</a> (non-negative)</td>
           <td>4</td>
           <td><a>shapes</a> and <a>text content elements</a></td>
           <td>yes</td>


### PR DESCRIPTION
Addresses (but does not close) #545. 

Note:
The interpretation of numerical values for miter-clip and arcs joins hasn't been changed.
In these cases, values less than 1 won't have the same rendering as 1.