### PR TITLE
<circle> with r=0 has rendering disabled

### DIFF
--- a/master/shapes.html
+++ b/master/shapes.html
@@ -201,7 +201,8 @@ radius.</p>
 
 <p>
   The <a>'r'</a> attribute defines the radius of the circle.
-  A negative value for either property is illegal and <a href="https://www.w3.org/TR/CSS21/syndata.html#parsing-errors">must be ignored as a parsing error</a>.
+  A negative value is illegal and <a href="https://www.w3.org/TR/CSS21/syndata.html#parsing-errors">must be ignored as a parsing error</a>.
+  A computed value of zero disables rendering of the element.
 </p>
 
 <p>


### PR DESCRIPTION
A computed radius value of zero disables rendering of the circle element.

This restores a sentence that was accidentally removed.

fixes #560