### PR TITLE
[interactivity] pointer-events auto

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -910,6 +910,7 @@ have been made.</p>
         <a href="https://github.com/w3c/svgwg/issues/520">Issue discussion</a>
         <a href="https://github.com/w3c/svgwg/pull/548">Edits</a>
     </li>
+    <li>Added the <span class="prop-value">auto</span> keyword to <a>'pointer-events'</a>.</li>
   </ul>
 </div>
 

--- a/master/interact.html
+++ b/master/interact.html
@@ -294,7 +294,7 @@ attributes are resolved to concrete times only in response to "bubbling" and
 <h3 id="RelationshipWithUIEVENTS">Relationship with UI Events</h3>
 
 <p>The SVG DOM is compatible with all interfaces defined in, and
-all the event types from, 
+all the event types from,
 <a href="https://www.w3.org/TR/uievents/">UI Events</a>,
 and the event types defined in
 <a href="https://www.w3.org/TR/clipboard-apis/">Clipboard API and events</a>
@@ -552,12 +552,12 @@ the circumstances under which the following are processed:</p>
   </tr>
   <tr>
     <th>Value:</th>
-    <td>bounding-box | visiblePainted | visibleFill | visibleStroke | visible | painted |
+    <td>auto | bounding-box | visiblePainted | visibleFill | visibleStroke | visible | painted |
     fill | stroke | all | none</td>
   </tr>
   <tr>
     <th>Initial:</th>
-    <td>visiblePainted</td>
+    <td>auto</td>
   </tr>
   <tr>
     <th>Applies to:</th>
@@ -586,6 +586,9 @@ the circumstances under which the following are processed:</p>
 </table>
 
 <dl>
+  <dt><span class="prop-value">auto</span></dt>
+  <dd>The default behavior, which is the same as for <span class="prop-value">visiblePainted</span>.</dd>
+
   <dt><span class="prop-value">bounding-box</span></dt>
   <dd>The given element must be a target element for pointer events when the pointer is over the <a>bounding box</a> of the element.</dd>
 

--- a/master/propidx.html
+++ b/master/propidx.html
@@ -242,7 +242,7 @@
           <th><a>'opacity'</a></th>
           <td><a>&lt;alpha-value&gt;</a> </td>
           <td>1</td>
-          <td><a>'svg'</a>, <a>'g'</a>, <a>'symbol'</a>, <a>'marker element'</a>, 
+          <td><a>'svg'</a>, <a>'g'</a>, <a>'symbol'</a>, <a>'marker element'</a>,
             <a>'a'</a>, <a>'switch'</a>, <a>'use'</a>, <a>'unknown'</a> elements
             and <a>graphics elements</a></td>
           <td>no</td>
@@ -276,10 +276,10 @@
         </tr>
         <tr>
           <th><a>'pointer-events'</a></th>
-          <td>bounding-box | visiblePainted | visibleFill | visibleStroke |
+          <td>auto | bounding-box | visiblePainted | visibleFill | visibleStroke |
           visible |<br />
            painted | fill | stroke | all | none </td>
-          <td>visiblePainted</td>
+          <td>auto</td>
           <td><a>container elements</a>, <a>graphics elements</a> and <a>'use'</a></td>
           <td>yes</td>
           <td>N/A</td>


### PR DESCRIPTION
Add the keyword 'auto' as the initial value for pointer-events.

Browsers already support 'auto' as the initial value.

resolves #574