### PR TITLE
CSS pointer-events on (raster) images does not require scanning pixels

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -883,7 +883,7 @@ have been made.</p>
   the 'cursor element' element to take an URL that is not in a CSS-like
   functional form.</li>
   <li>Added the <span class="prop-value">bounding-box</span> keyword to <a>'pointer-events'</a>.</li>
-  <div class='changed-since-cr1 cr2'>
+  <div class='changed-since-cr1 cr2 cr3'>
     <li>Remove requirements on <a>'pointer-events'</a> for raster images to check individual pixels for transparency.</li>
   </div>
   <li>Replaced SVGLoad, SVGAbort, SVGError and SVGUnload with load, abort, error and unload respectively.</li>

--- a/master/changes.html
+++ b/master/changes.html
@@ -883,6 +883,9 @@ have been made.</p>
   the 'cursor element' element to take an URL that is not in a CSS-like
   functional form.</li>
   <li>Added the <span class="prop-value">bounding-box</span> keyword to <a>'pointer-events'</a>.</li>
+  <div class='changed-since-cr1 cr2'>
+    <li>Remove requirements on <a>'pointer-events'</a> for raster images to check individual pixels for transparency.</li>
+  </div>
   <li>Replaced SVGLoad, SVGAbort, SVGError and SVGUnload with load, abort, error and unload respectively.</li>
   <li>Required that only <a>structurally external elements</a> and the <a>outermost svg element</a> must fire load events.</li>
   <li>Replaced SVGResize and SVGScroll with resize and scroll respectively.</li>

--- a/master/interact.html
+++ b/master/interact.html
@@ -590,7 +590,11 @@ the circumstances under which the following are processed:</p>
   <dd>The default behavior, which is the same as for <span class="prop-value">visiblePainted</span>.</dd>
 
   <dt><span class="prop-value">bounding-box</span></dt>
-  <dd>The given element must be a target element for pointer events when the pointer is over the <a>bounding box</a> of the element.</dd>
+  <dd>The given element can be a target element for pointer events when the pointer is over the
+  <a>bounding box</a> of the element. The actual value of <a>'clip-path'</a> does not contribute
+  to the decision if the element is a target for pointer events. Thus, the given element can
+  be a target element for pointer events even if the pointer is not
+  within a <a>clipping path</a> but within the <a>bounding box</a> of the element.</dd>
 
   <dt><span class="prop-value">visiblePainted</span></dt>
   <dd>The given element can be the target element for pointer events when
@@ -690,18 +694,15 @@ the circumstances under which the following are processed:</p>
   text does not receive pointer events.</li>
 </ul>
 
-<p>For raster images, hit-testing is either performed on a
+<p>For raster images, hit-testing is performed on a
 whole-image basis (i.e., the rectangular area for the image is
-one of the determinants for whether the image receives the
-event) or on a per-pixel basis (i.e., the alpha values for
-pixels under the pointer help determine whether the image
-receives the event):</p>
+the determinant for whether the image receives the
+event):</p>
 
 <ul>
   <li>The value <span class="prop-value">visiblePainted</span> means that the
-  raster image can receive events anywhere within the bounds of the image
-  if any pixel from the raster image which is under the pointer is not
-  fully transparent, with the additional requirement that the <a>'visibility'</a>
+  raster image can receive events anywhere within the bounds of the image,
+  with the additional requirement that the <a>'visibility'</a>
   property is set to <span class="prop-value">visible</span>.</li>
 
   <li>The values <span class="prop-value">visibleFill</span>,
@@ -712,9 +713,8 @@ receives the event):</p>
   <span class="prop-value">visible</span>.</li>
 
   <li>The value <span class="prop-value">painted</span> means that the raster
-  image can receive events anywhere within the bounds of the image if any
-  pixel from the raster image which is under the pointer is not fully
-  transparent. The value of the <a>'visibility'</a> property does not affect
+  image can receive events anywhere within the bounds of the image.
+  The value of the <a>'visibility'</a> property does not affect
   event processing.</li>
 
   <li>The values <span class="prop-value">fill</span>,

--- a/master/interact.html
+++ b/master/interact.html
@@ -591,10 +591,7 @@ the circumstances under which the following are processed:</p>
 
   <dt><span class="prop-value">bounding-box</span></dt>
   <dd>The given element can be a target element for pointer events when the pointer is over the
-  <a>bounding box</a> of the element. The actual value of <a>'clip-path'</a> does not contribute
-  to the decision if the element is a target for pointer events. Thus, the given element can
-  be a target element for pointer events even if the pointer is not
-  within a <a>clipping path</a> but within the <a>bounding box</a> of the element.</dd>
+  <a>bounding box</a> of the element.</dd>
 
   <dt><span class="prop-value">visiblePainted</span></dt>
   <dd>The given element can be the target element for pointer events when


### PR DESCRIPTION
…requirement to scan raster image pixels. #322