### PR TITLE
inline-size has initial value auto

### DIFF
--- a/master/text.html
+++ b/master/text.html
@@ -1994,11 +1994,11 @@
     </tr>
     <tr>
       <th>Value:</th>
-      <td><a>&lt;length-percentage&gt;</a></td>
+      <td><a>auto | &lt;length-percentage&gt;</a></td>
     </tr>
     <tr>
       <th>Initial:</th>
-      <td>0</td>
+      <td>auto</td>
     </tr>
     <tr>
       <th>Applies to:</th>


### PR DESCRIPTION
For consistency with browsers and CSS,
the initial value of inline-size is auto

https://drafts.csswg.org/css-logical/#dimension-properties