### PR TITLE
Painting: numeric stroke-width, stroke-dashoffset

### DIFF
--- a/master/painting.html
+++ b/master/painting.html
@@ -728,7 +728,7 @@ property</h3>
   </tr>
   <tr>
     <th>Value:</th>
-    <td><a>&lt;length-percentage&gt;</a></td>
+    <td><a>&lt;length-percentage&gt;</a> | <a>&lt;number&gt;</a></td>
   </tr>
   <tr>
     <th>Initial:</th>
@@ -1229,7 +1229,7 @@ to the author's path length as specified by <a>'path/pathLength'</a>.</p>
   </tr>
   <tr>
     <th>Value:</th>
-    <td><a>&lt;length-percentage&gt;</a></td>
+    <td><a>&lt;length-percentage&gt;</a> | <a>&lt;number&gt;</a></td>
   </tr>
   <tr>
     <th>Initial:</th>


### PR DESCRIPTION
SVG 1.1 allowed stroke-width and stroke-dashoffset lengths
to be specified without units.
https://www.w3.org/TR/SVG11/types.html#DataTypeLength

SVG 2 needs to do the same, for web compatibility.

Discussed in  https://github.com/w3c/svgwg/issues/534