### PR TITLE
Fixes #596

### DIFF
--- a/master/styling.html
+++ b/master/styling.html
@@ -305,10 +305,10 @@ text.error   { fill: red; }</pre>
 and <a>'style attribute'</a> attributes, but also in
 <dfn id="TermPresentationAttribute" data-dfn-type="dfn" data-export="">presentation attributes</dfn>.
 These are attributes whose name matches (or is similar to) a given CSS property
-and whose value is parsed as a value of that property.  Presentation
+and whose value is parsed as a value of that property. Presentation
 attributes contribute to the
 <a href="https://drafts.csswg.org/css-cascade-3/#preshint">author level</a>
-of the cascade, following all other author-level style sheets,
+of the cascade, followed by all other author-level style sheets,
 and have specificity 0.</p>
 
 <p>Since presentation attributes are parsed as CSS values, not declarations, an


### PR DESCRIPTION
Fixes the priority of the presentation attributes in the CSS cascade (reverting it to the SVG 1.1 definition, which matches the browser reality).