### PR TITLE
stop-opacity computed value is clamped

### DIFF
--- a/master/propidx.html
+++ b/master/propidx.html
@@ -321,7 +321,7 @@
           <td>N/A</td>
           <td><a href="https://www.w3.org/TR/2008/REC-CSS2-20080411/media.html#visual-media-group">visual</a></td>
           <td>yes</td>
-          <td></td>
+          <td>the specified value converted to a number, clamped to the range [0,1]</td>
         </tr>
         <tr>
           <th><a>'stroke'</a></th>

--- a/master/pservers.html
+++ b/master/pservers.html
@@ -1202,6 +1202,7 @@ colors..." but "ramp" is used nowhere else in this section.</p>
         <dt>Inherited</dt>          <dd>no</dd>
         <dt>Percentages</dt>        <dd>N/A</dd>
         <dt>Media</dt>              <dd>visual</dd>
+        <dt>Computed value</dt>     <dd>the specified value converted to a number, clamped to the range [0,1]</dd>
         <dt><a>Animatable</a></dt>  <dd>yes</dd>
       </dl>
       <dl class="propdef-values">


### PR DESCRIPTION
Like other *-opacity properties, the computed value for stop-opacity is clamped to [0,1].

stop-opacity is currently the only one of the following properties not to have this clamping mentioned in "Computed value:" wording.
- [opacity](https://drafts.csswg.org/css-color/#propdef-opacity)
- [flood-opacity](https://drafts.fxtf.org/filter-effects/#FloodOpacityProperty)
- [fill-opacity](https://drafts.fxtf.org/fill-stroke/#fill-opacity) (also in [SVG2](https://svgwg.org/svg2-draft/painting.html#FillOpacity))
- [stroke-opacity](https://drafts.fxtf.org/fill-stroke/#stroke-opacity) (also in [SVG2](https://svgwg.org/svg2-draft/painting.html#StrokeOpacity))
- stop-opacity (in [SVG2](https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty))
