### PR TITLE
[References] Fix broken links

### DIFF
--- a/master/refs.html
+++ b/master/refs.html
@@ -25,7 +25,7 @@
   <dt id="ref-bcp47" class="normref">[<a href="https://tools.ietf.org/html/bcp47">BCP47</a>]</dt>
   <dd><div>A. Phillips; M. Davis. <a href="https://tools.ietf.org/html/bcp47"><cite>Tags for Identifying Languages</cite></a>. September 2009. IETF Best Current Practice. URL:&nbsp;<a href="https://tools.ietf.org/html/bcp47">https://tools.ietf.org/html/bcp47</a></div></dd>
 
-  <dt id="ref-clipboard-apis" class="normref">[<a href="#">clipboard-apis</a>]</dt>
+  <dt id="ref-clipboard-apis" class="normref">[<a href="https://www.w3.org/TR/clipboard-apis/">clipboard-apis</a>]</dt>
   <dd><div>Gary Kacmarcik; Grisha Lyukshin; Hallvord Steen. <a href="https://www.w3.org/TR/clipboard-apis/"><cite>Clipboard API and events</cite></a>. 29 September 2017. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/clipboard-apis/">https://www.w3.org/TR/clipboard-apis/</a> ED:&nbsp;<a href="https://w3c.github.io/clipboard-apis/">https://w3c.github.io/clipboard-apis/</a></div></dd>
 
   <dt id="ref-compositing-1" class="normref">[<a href="https://www.w3.org/TR/compositing-1/">compositing-1</a>]</dt>
@@ -75,8 +75,8 @@
   <dt id="ref-css-values-3" class="normref">[<a href="https://www.w3.org/TR/css-values/">css-values</a>]</dt>
   <dd><div>Tab Atkins Jr.; Elika Etemad. <a href="https://www.w3.org/TR/css-values-3/"><cite>CSS Values and Units Module Level 3</cite></a>. 14 August 2018. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-values-3/">https://www.w3.org/TR/css-values/</a> ED:&nbsp;<a href="http://dev.w3.org/csswg/css-values-3/">http://dev.w3.org/csswg/css-values/</a></div></dd>
 
-  <dt id="ref-css-images-3" class="normref">[<a href="https://www.w3.org/TR/css-images-3/">css-images-3</a>]</dt>
-  <dd><div>Elika Etemad; Tab Atkins Jr.. <a href="https://www.w3.org/TR/css-images-3/"><cite>CSS Image Values and Replaced Content Module Level 3</cite></a>. 17 April 2012. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-images-3/">https://www.w3.org/TR/css-images-3/</a> ED: <a href="https://drafts.csswg.org/css-images-3/">https://drafts.csswg.org/css-images-3/</a></div></dd>
+  <dt id="ref-css-images-3" class="normref">[<a href="https://www.w3.org/TR/css3-images/">css-images-3</a>]</dt>
+  <dd><div>Elika Etemad; Tab Atkins Jr.. <a href="https://www.w3.org/TR/css3-images/"><cite>CSS Image Values and Replaced Content Module Level 3</cite></a>. 17 April 2012. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css3-images/">https://www.w3.org/TR/css3-images/</a> ED: <a href="https://drafts.csswg.org/css-images-3/">https://drafts.csswg.org/css-images-3/</a></div></dd>
 
   <dt id="ref-css-shapes-1" class="normref">[<a href="https://www.w3.org/TR/css-shapes-1/">css-shapes-1</a>]</dt>
   <dd><div>Vincent Hardy; Rossen Atanassov; Alan Stearns. <a href="https://www.w3.org/TR/css-shapes-1/"><cite>CSS Shapes Module Level 1</cite></a>. 20 March 2014. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-shapes-1/">https://www.w3.org/TR/css-shapes-1/</a> ED:&nbsp;<a href="http://dev.w3.org/csswg/css-shapes/">http://dev.w3.org/csswg/css-shapes/</a></div></dd>
@@ -112,7 +112,7 @@
   <dd><div>Simon Pieters; Dirk Schulze; Rik Cabanier. <a href="https://www.w3.org/TR/geometry-1/"><cite>Geometry Interfaces Module Level 1</cite></a>. 25 November 2014. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/geometry-1/">https://www.w3.org/TR/geometry-1/</a> ED:&nbsp;<a href="https://drafts.fxtf.org/geometry/">https://drafts.fxtf.org/geometry/</a></div></dd>
 
   <dt id="ref-graphics-aria-1.0" class="normref">[<a href="https://www.w3.org/TR/graphics-aria-1.0/">graphics-aria-1.0</a>]</dt>
-  <dd><div>Amelia Bellamy-Royds; Fred Esch; Richard Schwerdtfeger; Léonie Watson. <a href="https://www.w3.org/TR/graphics-aria-1.0/"><cite>WAI-<strong class="highlight">ARIA Graphics</strong> Module</cite></a>. 26 June 2018. W3C Proposed Recommendation . URL:&nbsp;<a href="https://www.w3.org/TR/graphics-aria-1.0/">https://www.w3.org/TR/graphics-aria-1.0/</a> ED:&nbsp;<a href="https://w3c.github.io/aria/aria/graphics.html">https://w3c.github.io/aria/aria/graphics.html</a></div></dd>
+  <dd><div>Amelia Bellamy-Royds; Fred Esch; Richard Schwerdtfeger; Léonie Watson. <a href="https://www.w3.org/TR/graphics-aria-1.0/"><cite>WAI-<strong class="highlight">ARIA Graphics</strong> Module</cite></a>. 26 June 2018. W3C Proposed Recommendation . URL:&nbsp;<a href="https://www.w3.org/TR/graphics-aria-1.0/">https://www.w3.org/TR/graphics-aria-1.0/</a> ED:&nbsp;<a href="https://w3c.github.io/graphics-aria/">https://w3c.github.io/graphics-aria/</a></div></dd>
 
   <dt id="ref-html" class="normref">[<a href="https://html.spec.whatwg.org/multipage/">HTML</a>]</dt>
   <dd><div>Anne van Kesteren; et al. <a href="https://html.spec.whatwg.org/multipage/"><cite>HTML Standard</cite></a>. Living Standard. URL:&nbsp;<a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a></div></dd>
@@ -182,7 +182,7 @@
   <dd><div><a href="https://webstore.iec.ch/publication/6169"><cite>Multimedia systems and equipment - Colour measurement and management - Part 2-1: Colour management - Default RGB colour space - sRGB.</cite></a> IEC 61966-2-1 (1999-10). ISBN: 2-8318-4989-6 - ICS codes: 33.160.60, 37.080 - TC 100 - 51 pp. URL: <a href="https://webstore.iec.ch/publication/6169">https://webstore.iec.ch/publication/6169</a></div></dd>
 
   <dt id="ref-svg-aam-1.0" class="normref">[<a href="https://www.w3.org/TR/svg-aam-1.0/">svg-aam-1.0</a>]</dt>
-  <dd><div>Amelia Bellamy-Royds; Richard Schwerdtfeger. <a href="https://www.w3.org/TR/svg-aam-1.0/"><cite>SVG Accessibility API Mappings</cite></a>. Draft 10 May 2018. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/svg-aam-1.0/">https://www.w3.org/TR/svg-aam-1.0/</a> ED:&nbsp;<a href="https://w3c.github.io/aria/svg-aam/svg-aam.html">https://w3c.github.io/aria/svg-aam/svg-aam.html</a></div></dd>
+  <dd><div>Amelia Bellamy-Royds; Richard Schwerdtfeger. <a href="https://www.w3.org/TR/svg-aam-1.0/"><cite>SVG Accessibility API Mappings</cite></a>. Draft 10 May 2018. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/svg-aam-1.0/">https://www.w3.org/TR/svg-aam-1.0/</a> ED:&nbsp;<a href="https://w3c.github.io/svg-aam/">https://w3c.github.io/svg-aam/</a></div></dd>
 
   <dt id="ref-uievents" class="normref">[<a href="https://www.w3.org/TR/uievents/">uievents</a>]</dt>
   <dd><div>Gary Kacmarcik; Travis Leithead. <a href="https://www.w3.org/TR/uievents/"><cite>UI Events Specification</cite></a>. 04 August 2016. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/uievents/">https://www.w3.org/TR/uievents/</a> ED:&nbsp;<a href="https://w3c.github.io/uievents/">https://w3c.github.io/uievents/</a></div></dd>
@@ -228,7 +228,7 @@
   <dd><div>Martin Dürst; François Yergeau; Richard Ishida; Misha Wolf; Tex Texin et al. <a href="https://www.w3.org/TR/charmod/"><cite>Character Model for the World Wide Web 1.0: Fundamentals</cite></a>. 15 February 2005. W3C Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/charmod/">https://www.w3.org/TR/charmod/</a></div></dd>
 
   <dt id="ref-selectors-3" class="informref">[<a href="https://www.w3.org/TR/selectors-3/">css-selectors-3</a>]</dt>
-  <dd><div>Tantek Çelik; Elika Etemad; Daniel Glazman; Ian Hickson; Peter Linss; John Williams et al. <a href="https://www.w3.org/TR/css-selectors-3/"><cite>Selectors Level 3</cite></a>. 30 January 2018. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/selectors-3/">https://www.w3.org/TR/selectors-3/</a></div></dd>
+  <dd><div>Tantek Çelik; Elika Etemad; Daniel Glazman; Ian Hickson; Peter Linss; John Williams et al. <a href="https://www.w3.org/TR/selectors-3/"><cite>Selectors Level 3</cite></a>. 30 January 2018. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/selectors-3/">https://www.w3.org/TR/selectors-3/</a></div></dd>
 
   <dt id="ref-css-color-4" class="informref">[css-color-4]</dt>
   <dd>
@@ -261,7 +261,7 @@
   <dt id="ref-editing" class="informref">[<a href="https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html">EDITING</a>]</dt>
   <dd><div>A. Gregor. <a href="https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html"><cite>HTML Editing APIs</cite></a>. URL:&nbsp;<a href="https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html">https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html</a></div></dd>
 
-  <dt id="ref-icc" class="informref">[<a href="www.color.org/specification/ICC1v43_2010-12.pdf">ICC</a>]</dt>
+  <dt id="ref-icc" class="informref">[<a href="http://www.color.org/specification/ICC1v43_2010-12.pdf">ICC</a>]</dt>
   <dd><div>International Color Consortium, <a href="http://www.color.org/specification/ICC1v43_2010-12.pdf"><cite>ICC.1:2010 (Profile version 4.3.0.0)</cite></a>. December 2010. URL:&nbsp;<a href="http://www.color.org/specification/ICC1v43_2010-12.pdf">http://www.color.org/specification/ICC1v43_2010-12.pdf</a></div></dd>
 
   <dt id="ref-mathml3" class="informref">[<a href="https://www.w3.org/TR/MathML3/">MathML3</a>]</dt>


### PR DESCRIPTION
We now link to
https://www.w3.org/TR/clipboard-apis/
https://www.w3.org/TR/css3-images/
https://w3c.github.io/graphics-aria/
https://w3c.github.io/svg-aam/
https://www.w3.org/TR/selectors-3/
http://www.color.org/specification/ICC1v43_2010-12.pdf