### PR TITLE
<path d> parsing spec needs a special case to not use CSS syntax

### DIFF
--- a/master/styling.html
+++ b/master/styling.html
@@ -314,8 +314,9 @@ and have specificity 0.</p>
 <p>Since presentation attributes are parsed as CSS values, not declarations, an
 <a href="https://www.w3.org/TR/2011/REC-CSS2-20110607/cascade.html#important-rules"><span class="prop-value">!important</span> declaration</a>
 within a presentation attribute will cause it to have an <a>invalid value</a>.
-See <a href="types.html#presentation-attribute-css-value">Attribute syntax</a>
-for details on how presentation attributes are parsed.</p>
+Except as noted in thetable for the <a>'d'</a> presentation attribute,
+the value of presentation attributes is parsed
+<a href="types.html#presentation-attribute-css-value">using the CSS Value Definition Syntax</a>.
 
 <p>Not all style properties that can affect SVG rendering have a corresponding
 presentation attribute.
@@ -382,6 +383,20 @@ the presentation attribute name is the same as the property name, in lower-case 
     </td>
     <td>
       <a>'path'</a>
+      <p>
+        Unlike other presentation attributes,
+        the value is not parsed as CSS syntax
+        but directly according to the <a href="#PathDataBNF">svg-path</a>
+        <a href="types.html#syntax">EBNF grammar</a>,
+        and errors within the string are handled according to the rules in the
+        <a href="paths.html#PathDataErrorHandling">Path Data Error Handling</a> section.
+      </p>
+      <p class="note">
+        In particular, the attribute value does not accept the <code>none</code> keyword,
+        does not have the quotes of a CSS <a>&lt;string&gt;</a> token
+        (in addition to those delimiting the attribute value in XML or HTML syntax),
+        and does not unescape CSS backslash-escapes.
+      </p>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
When reading the spec literally before this changes, https://svgwg.org/svg2-draft/styling.html#PresentationAttributes specifies that all presentation properties are parsed according to https://svgwg.org/svg2-draft/types.html#presentation-attribute-css-value

For the `d` property, this means the CSS grammar `none | <string>`.

The following would be valid:

* `<path d="none">`
* `<path d="'M 100 100 L 300 100 L 200 300 z'">` (not the single quotes)
* `<path d="/**/'M 100 100 \L \33 00 100 L 200 300 z'">` (equivalent to the previous)

But `<path d="M 100 100 L 300 100 L 200 300 z">` or indeed any SVG 1.1 path would not be valid because they parse as CSS ident and number tokens, not as a `<string>`.

https://github.com/w3c/svgwg/issues/320 poposes changing the syntax of the `d` CSS propery to be even further to the 1.1 attribute syntax.

This does not appear to be an intentional change from SVG 1.1, so this pull request "reverts" it.