### PR TITLE
Update current/former editors list

### DIFF
--- a/master/Overview.html
+++ b/master/Overview.html
@@ -34,19 +34,19 @@
     <dd><a href="mailto:www-svg@w3.org" class='url'>www-svg@w3.org</a> (<a href="http://lists.w3.org/Archives/Public/www-svg/">archive</a>)</dd>
     <dt class="top-editors">Editors:</dt>
     <dd>Amelia Bellamy-Royds, Invited Expert &lt;<a href="mailto:amelia.bellamy.royds@gmail.com" class='url'>amelia.bellamy.royds@gmail.com</a>&gt;</dd>
-    <dd>Bogdan Brinza, Microsoft Co. &lt;<a href="mailto:bbrinza@microsoft.com" class='url'>bbrinza@microsoft.com</a>&gt;</dd>
+    <dd>Tavmjong Bah, Invited Expert &lt;<a href="mailto:tavmjong@free.fr" class='url'>tavmjong@free.fr</a>&gt;</dd>
     <dd>Chris Lilley, W3C &lt;<a href="mailto:chris@w3.org" class='url'>chris@w3.org</a>&gt;</dd>
     <dd>Dirk Schulze, Adobe Systems &lt;<a href="mailto:dschulze@adobe.com" class='url'>dschulze@adobe.com</a>&gt;</dd>
-    <dd>David Storey,  Microsoft Co. &lt;<a href="mailto:dstorey@microsoft.com" class='url'>dstorey@microsoft.com</a>&gt;</dd>
     <dd>Eric Willigers, Google</dd>
     <dt class="top-editors">Former Editors:</dt>
     <dd>Nikos Andronikos, Canon, Inc. &lt;<a href="mailto:nikos.andronikos@cisra.canon.com.au" class='url'>nikos.andronikos@cisra.canon.com.au</a>&gt;</dd>
     <dd>Rossen Atanassov, Microsoft Co. &lt;<a href="mailto:ratan@microsoft.com" class='url'>ratan@microsoft.com</a>&gt;</dd>
-    <dd>Tavmjong Bah, Invited Expert &lt;<a href="mailto:tavmjong@free.fr" class='url'>tavmjong@free.fr</a>&gt;</dd>
     <dd>Brian Birtles, Mozilla Japan &lt;<a href="mailto:bbirtles@mozilla.com" class='url'>bbirtles@mozilla.com</a>&gt;</dd>
+    <dd>Bogdan Brinza, Microsoft Co. &lt;<a href="mailto:bbrinza@microsoft.com" class='url'>bbrinza@microsoft.com</a>&gt;</dd>
     <dd>Cyril Concolato, Telecom ParisTech &lt;<a href="mailto:cyril.concolato@telecom-paristech.fr" class='url'>cyril.concolato@telecom-paristech.fr</a>&gt;</dd>
     <dd>Erik Dahlström, Invited Expert &lt;<a href="mailto:erik@xn--dahlstrm-t4a.net" class='url'>erik@dahlström.net</a>&gt;</dd>
     <dd>Cameron McCormack, Mozilla Corporation &lt;<a href="mailto:cam@mcc.id.au" class='url'>cam@mcc.id.au</a>&gt;</dd>
+    <dd>David Storey,  Microsoft Co. &lt;<a href="mailto:dstorey@microsoft.com" class='url'>dstorey@microsoft.com</a>&gt;</dd>
     <dd>Doug Schepers, W3C &lt;<a href="mailto:schepers@w3.org" class='url'>schepers@w3.org</a>&gt;</dd>
     <dd>Richard Schwerdtfeger, IBM &lt;<a href="mailto:schwer@us.ibm.com" class='url'>schwer@us.ibm.com</a>&gt;</dd>
     <dd>Satoru Takagi, KDDI Corporation &lt;<a href="mailto:sa-takagi@kddi.com" class='url'>sa-takagi@kddi.com</a>&gt;</dd>


### PR DESCRIPTION
- Move @Tavmjong back to the active editors list (he really shouldn't have ever been removed)
- Move @boggydigital and @dstorey to the former editors list (unless one of you is going to be reassigned back to the WG when it reconvenes in the new year…?)

Also: @satakagi, do you expect to do any active work on the spec this year?