### PR TITLE
[References] Fix missing links

### DIFF
--- a/master/refs.html
+++ b/master/refs.html
@@ -38,7 +38,7 @@
   <dt id="ref-css2" class="normref">[<a href="https://www.w3.org/TR/CSS2">CSS2</a>]</dt>
   <dd><div>Bert Bos; Tantek Çelik; Ian Hickson; Håkon Wium Lie et al. <a href="https://www.w3.org/TR/CSS2"><cite>Cascading Style Sheets Level 2 Revision 1 (CSS 2.1) Specification</cite></a>. 7 June 2011. W3C Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/CSS2">https://www.w3.org/TR/CSS2</a></div></dd>
 
-  <dt id="ref-css-cascade-4" class="normref">[css-cascade-4]</dt>
+  <dt id="ref-css-cascade-4" class="normref">[<a href="https://www.w3.org/TR/css-cascade-4/">css-cascade-4</a>]</dt>
   <dd><div>Elika Etemad; Tab Atkins Jr.. <a href="https://www.w3.org/TR/css-cascade-4/"><cite>CSS Cascading and Inheritance Level 4</cite></a>. 14 January 2016. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-cascade-4/">https://www.w3.org/TR/<strong class="highlight">css-cascade</strong>-4/</a> ED:&nbsp;<a href="http://dev.w3.org/csswg/css-cascade/">http://dev.w3.org/csswg/<strong class="highlight">css-cascade</strong>/</a></div></dd>
 
   <dt id="ref-css-color-3" class="normref">[<a href="https://www.w3.org/TR/css-color-3">css-color-3</a>]</dt>
@@ -85,7 +85,7 @@
   <dt id="ref-css-writing-modes-3" class="normref">[<a href="https://www.w3.org/TR/css-writing-modes-3/">css-writing-modes-3</a>]</dt>
   <dd><div>Elika Etemad; Koji Ishii. <a href="https://www.w3.org/TR/css-writing-modes-3/"><cite>CSS <strong class="highlight">Writing Modes</strong> Level 3</cite></a>. 24 May 2018. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-writing-modes-3/">https://www.w3.org/TR/css-writing-modes-3/</a> ED:&nbsp;<a href="http://dev.w3.org/csswg/css-writing-modes-3/">http://dev.w3.org/csswg/css-writing-modes-3/</a></div></dd>
 
-  <dt id="ref-css-scoping-1" class="normref">[css-scoping-1]</dt>
+  <dt id="ref-css-scoping-1" class="normref">[<a href="https://www.w3.org/TR/css-scoping-1/">css-scoping-1</a>]</dt>
   <dd><div>Tab Atkins Jr.; Elika Etemad. <a href="https://www.w3.org/TR/css-scoping-1/"><cite>CSS Scoping Module Level 1</cite></a>. 3 April 2014. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/css-scoping-1/">https://www.w3.org/TR/<strong class="highlight">css-scoping</strong>-1/</a> ED:&nbsp;<a href="http://dev.w3.org/csswg/css-scoping/">http://dev.w3.org/csswg/<strong class="highlight">css-scoping</strong>/</a></div></dd>
 
   <!-- replace references to DOM 4 with references to DOM LS
@@ -167,7 +167,7 @@
   <dd><div>Dimitri Glazkov; Hayato Ito. <a href="https://www.w3.org/TR/shadow-dom/"><cite>Shadow DOM</cite></a>. 24 June 2016. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/shadow-dom/">https://www.w3.org/TR/shadow-dom/</a> ED:&nbsp;<a href="https://w3c.github.io/webcomponents/spec/shadow/">https://w3c.github.io/webcomponents/spec/shadow/</a></div></dd>
   -->
 
-  <dt id="ref-SMIL" class="normref">[SMIL]</dt>
+  <dt id="ref-SMIL" class="normref">[<a href="https://www.w3.org/TR/2008/REC-SMIL3-20081201/">SMIL</a>]</dt>
   <dd>
     <cite class="w3crec"><a href="https://www.w3.org/TR/2008/REC-SMIL3-20081201/">Synchronized Multimedia Integration Language (SMIL 3.0)</a></cite>,
     D. Bulterman <em>et al.</em>, eds.  01 December 2008.
@@ -196,7 +196,7 @@
   <dt id="ref-wai-aria" class="normref">[<a href="https://www.w3.org/TR/wai-aria/">wai-aria</a>]</dt>
   <dd><div>Joanmarie Diggs et al. <a href="https://www.w3.org/TR/wai-aria-1.1/"><cite>Accessible Rich Internet Applications (WAI-ARIA) 1.1</cite></a>. 14 December 2017. W3C Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/wai-aria-1.1/">https://www.w3.org/TR/wai-aria-1.1/</a></div></dd>
 
-  <dt id="ref-web-animations-1" class="normref">[web-animations-1]</dt>
+  <dt id="ref-web-animations-1" class="normref">[<a href="https://www.w3.org/TR/web-animations-1/">web-animations-1</a>]</dt>
   <dd><div>Brian Birtles; Shane Stephens; Alex Danilo; Tab Atkins Jr.. <a href="https://www.w3.org/TR/web-animations-1/"><cite><strong class="highlight">Web Animations</strong></cite></a>. 13 September 2016. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/web-animations-1/">https://www.w3.org/TR/web-animations-1/</a> ED:&nbsp;<a href="https://w3c.github.io/web-animations/">https://w3c.github.io/web-animations/</a></div></dd>
 
   <dt id="ref-webidl" class="normref">[<a href="https://www.w3.org/TR/WebIDL-1/">WebIDL</a>]</dt>
@@ -230,7 +230,7 @@
   <dt id="ref-selectors-3" class="informref">[<a href="https://www.w3.org/TR/selectors-3/">css-selectors-3</a>]</dt>
   <dd><div>Tantek Çelik; Elika Etemad; Daniel Glazman; Ian Hickson; Peter Linss; John Williams et al. <a href="https://www.w3.org/TR/selectors-3/"><cite>Selectors Level 3</cite></a>. 30 January 2018. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/selectors-3/">https://www.w3.org/TR/selectors-3/</a></div></dd>
 
-  <dt id="ref-css-color-4" class="informref">[css-color-4]</dt>
+  <dt id="ref-css-color-4" class="informref">[<a href="https://www.w3.org/TR/css-color-4/">css-color-4</a>]</dt>
   <dd>
     <cite class="w3cwd"><a href="https://www.w3.org/TR/css-color-4/">CSS Color Module Level 4</a></cite>,
     Tab Atkins; Chris Lilley eds.
@@ -239,7 +239,7 @@
       edition of CSS Color 4</a> is available at
       https://www.w3.org/TR/css-color-4/.
   </dd>
-  <dt id="ref-css-shapes-2" class="informref">[css-shapes-2]</dt>
+  <dt id="ref-css-shapes-2" class="informref">[<a href="http://dev.w3.org/csswg/css-shapes-2/">css-shapes-2</a>]</dt>
   <dd>
     <cite class="w3cwd"><a href="http://dev.w3.org/csswg/css-shapes-2/">CSS Shapes Module Level 2</a></cite>,
     Alan Stearns ed.
@@ -281,7 +281,7 @@
   <dd><div>Cameron McCormack; Doug Schepers; Dirk Schulze. <a href="https://www.w3.org/TR/svg-integration/"><cite><strong class="highlight">SVG Integration</strong></cite></a>. 17 April 2014. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/svg-integration/">https://www.w3.org/TR/svg-integration/</a> ED:&nbsp;<a href="https://dvcs.w3.org/hg/svg2/specs/integration">https://dvcs.w3.org/hg/svg2/specs/integration</a></div></dd>
   -->
 
-  <dt id="ref-svg-animation" class="informref">[svg-animation]</dt>
+  <dt id="ref-svg-animation" class="informref">[<a href="https://svgwg.org/specs/animations">svg-animation</a>]</dt>
   <dd><div>Brian Birtles. <a href="https://svgwg.org/specs/animations"><cite><strong class="highlight">SVG Animations</strong></cite></a>. W3C Editor's Draft. URL:&nbsp;<a href="https://svgwg.org/specs/animations">https://svgwg.org/specs/animations</a></div></dd>
 
   <dt id="ref-uaag20" class="informref">[<a href="https://www.w3.org/TR/UAAG20/">UAAG20</a>]</dt>


### PR DESCRIPTION
In the [References](https://svgwg.org/svg2-draft/refs.html) appendix, the following are now links:

[css-cascade-4]
[css-scoping-1]
[SMIL]
[web-animations-1]
[css-color-4]
[css-shapes-2]
[svg-animation]

resolves #632