### PR TITLE
Fix #71

### DIFF
--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -810,12 +810,12 @@
   <interface name='SVGFitToViewBox' href='types.html#InterfaceSVGFitToViewBox'/>
   <interface name='SVGNumber' href='types.html#InterfaceSVGNumber'/>
   <interface name='SVGAngle' href='types.html#InterfaceSVGAngle'/>
-  <interface name='DOMMatrix' href='https://www.w3.org/TR/2014/CR-geometry-1-20141125/#dom-dommatrix'/>
-  <interface name='DOMMatrixReadOnly' href='https://www.w3.org/TR/2014/CR-geometry-1-20141125/#dom-dommatrixreadonly'/>
-  <interface name='SVGMatrix' href='https://www.w3.org/TR/2014/CR-geometry-1-20141125/#dom-dommatrix'/>
-  <interface name='DOMRect' href='https://www.w3.org/TR/2014/CR-geometry-1-20141125/#dom-domrect'/>
-  <interface name='DOMRectReadOnly' href='https://www.w3.org/TR/2014/CR-geometry-1-20141125/#dom-domrectreadonly'/>
-  <interface name='SVGRect' href='https://www.w3.org/TR/2014/CR-geometry-1-20141125/#dom-domrect'/>
+  <interface name='DOMMatrix' href='https://www.w3.org/TR/geometry-1/#DOMMatrix'/>
+  <interface name='DOMMatrixReadOnly' href='https://www.w3.org/TR/geometry-1/#dommatrixreadonly'/>
+  <interface name='SVGMatrix' href='https://www.w3.org/TR/geometry-1/#dommatrix'/>
+  <interface name='DOMRect' href='https://www.w3.org/TR/geometry-1/#DOMRect'/>
+  <interface name='DOMRectReadOnly' href='https://www.w3.org/TR/geometry-1/#domrectreadonly'/>
+  <interface name='SVGRect' href='https://www.w3.org/TR/geometry-1/#DOMRect'/>
   <interface name='DOMMatrix2DInit' href='https://drafts.fxtf.org/geometry/#dictdef-dommatrix2dinit'/>
   <interface name='SVGAnimatedRect' href='types.html#InterfaceSVGAnimatedRect'/>
   <interface name='SVGLength' href='types.html#InterfaceSVGLength'/>
@@ -889,7 +889,7 @@
   <symbol name='points' href='shapes.html#DataTypePoints'/>
   <symbol name='position' href='https://www.w3.org/TR/css3-background/#ltpositiongt'/>
   <symbol name='repeat-style' href='https://www.w3.org/TR/css3-background/#ltrepeat-stylegt'/>
-  <symbol name='shape-box' href='https://www.w3.org/TR/2014/WD-css-shapes-1-20140211/#typedef-shape-box'/>
+  <symbol name='shape-box' href='https://www.w3.org/TR/css-shapes-1/#typedef-shape-box'/>
   <symbol name='time' href='https://www.w3.org/TR/css3-values/#time'/>
   <symbol name='transform-list' href='http://dev.w3.org/csswg/css-transforms/#typedef-transform-list'/>
   <symbol name='url' href='https://www.w3.org/TR/css3-values/#url-value'/>
@@ -967,7 +967,7 @@
   <term name='direction at the end of the path segment' href='paths.html#TermPathSegmentEndDirection'/>
   <term name='segment-completing close path' href='paths.html#TermSegment-CompletingClosePath'/>
   <term name='initial coordinate system' href='coords.html#InitialCoordinateSystem'/>
-  <term name='inherit' href='https://www.w3.org/TR/2008/REC-CSS2-20080411/cascade.html#value-def-inherit'/>
+  <term name='inherit' href='https://www.w3.org/TR/css-cascade-4/#valdef-all-inherit'/>
   <term name='object bounding box units' href='coords.html#ObjectBoundingBoxUnits'/>
 
   <term name='conforming SVG DOM subtree' href='conform.html#ConformingSVGDOMSubtrees'/>
@@ -1240,7 +1240,9 @@
   <term name='throw' href='https://heycam.github.io/webidl/#dfn-throw'/>
   <term name='thrown' href='https://heycam.github.io/webidl/#dfn-throw'/>
 
-  <term name='illegal value' href='https://www.w3.org/TR/2011/REC-CSS2-20110607/syndata.html#illegalvalues'/>
+  <!--
+  CSS does not define an illegal value anymore
+   <term name='illegal value' href='https://www.w3.org/TR/2011/REC-CSS2-20110607/syndata.html#illegalvalues'/> -->
   <term name='3d rendering context' href='https://drafts.csswg.org/css-transforms-2/#3d-rendering-contexts'/>
 
   <term name='processing mode' href='conform.html#processing-modes'/>
@@ -1274,25 +1276,26 @@
   <term name='forced line break' href='http://dev.w3.org/csswg/css-text/#forced-line-break'/>
 
   <!-- ... grammar symbols ................................................ -->
-  <symbol name='angle' href='https://www.w3.org/TR/2012/WD-css3-values-20120308/#angles'/>
-  <symbol name='identifier' href='https://www.w3.org/TR/2012/WD-css3-values-20120308/#identifier'/>
-  <symbol name='transform-function' href='http://dev.w3.org/csswg/css3-transforms/#transform-functions'/>
+  <symbol name='angle' href='https://www.w3.org/TR/css-values/#angles'/>
+  <symbol name='identifier' href='https://www.w3.org/TR/css-syntax-3/#identifier'/>
+  <symbol name='transform-function' href='https://www.w3.org/TR/css-transforms-1/#transform-functions'/>
 
   <!-- ... properties ..................................................... -->
-  <property name='outline' href='https://www.w3.org/TR/CSS21/ui.html#propdef-outline'/>
-  <property name='position' href='https://www.w3.org/TR/CSS21/visuren.html#propdef-position'/>
-  <property name='text-transform' href='https://www.w3.org/TR/CSS21/text.html#propdef-text-transform'/>
-  <property name='border-top-style' href='https://www.w3.org/TR/CSS21/box.html#propdef-border-top-style'/>
-  <property name='border-style' href='https://www.w3.org/TR/CSS21/box.html#propdef-border-style'/>
+  <property name='outline' href='https://www.w3.org/TR/css-ui-4/#propdef-outline'/>
+  <property name='position' href='https://www.w3.org/TR/css-position-3/#propdef-position'/>
+  <property name='text-transform' href='https://www.w3.org/TR/css-text-3/#propdef-text-transform'/>
+  <property name='border-top-style' href='https://www.w3.org/TR/css-backgrounds-3/#propdef-border-top-style'/>
+  <property name='border-style' href='https://www.w3.org/TR/css-backgrounds-3/#propdef-border-style'/>
+  <!-- really? we need to reference CSS2 for floats, in SVG2?  -->
   <property name='float' href='https://www.w3.org/TR/CSS21/visuren.html#propdef-float'/>
-  <property name='margin-top' href='https://www.w3.org/TR/CSS21/box.html#propdef-margin-top'/>
-  <property name='content' href='https://www.w3.org/TR/CSS21/generate.html#propdef-content'/>
+  <property name='margin-top' href='https://www.w3.org/TR/css-box-3/#propdef-margin-top'/>
+  <property name='content' href='https://www.w3.org/TR/css-content-3/#propdef-content'/>
   <property name='transform-box' href='https://drafts.csswg.org/css-transforms/#transform-box'/>
   <property name='transform-origin' href='https://drafts.csswg.org/css-transforms/#transform-origin-property'/>
   <property name='will-change' href='https://drafts.csswg.org/css-will-change/#will-change'/>
   <property name='background' href='https://drafts.csswg.org/css-backgrounds-3/#background'/>
-  <property name='min-width' href='https://www.w3.org/TR/CSS21/visudet.html#propdef-min-width'/>
-  <property name='max-width' href='https://www.w3.org/TR/CSS21/visudet.html#propdef-max-width'/>
+  <property name='min-width' href='https://www.w3.org/TR/css-sizing-3/#propdef-min-width'/>
+  <property name='max-width' href='https://www.w3.org/TR/css-sizing-3/#propdef-max-width'/>
   <property name='block-size' href='http://dev.w3.org/csswg/css-writing-modes/#block-size'/>
   <property name='shape-outside' href='https://www.w3.org/TR/css-shapes/#shape-outside-property'/>
 

--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -1177,17 +1177,15 @@
 
   <!-- ... interfaces ..................................................... -->
 
-  <interface name='AbstractView' href='https://www.w3.org/TR/DOM-Level-2-Views/views.html#Views-AbstractView'/>
+
   <interface name='CharacterData' href='https://dom.spec.whatwg.org/#interface-characterdata'/>
   <interface name='Comment' href='https://dom.spec.whatwg.org/#interface-comment'/>
   <interface name='CSSStyleDeclaration' href='https://www.w3.org/TR/cssom-1/#the-cssstyledeclaration-interface'/>
-  <interface name='CSSPrimitiveValue' href='https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-CSSPrimitiveValue'/>
   <interface name='CSSRule' href='https://www.w3.org/TR/cssom-1/#the-cssrule-interface'/>
   <interface name='Document' href='https://dom.spec.whatwg.org/#interface-document'/>
   <interface name='DocumentAndElementEventHandlers' href='https://html.spec.whatwg.org/multipage/webappapis.html#documentandelementeventhandlers'/>
   <interface name='DocumentFragment' href='https://dom.spec.whatwg.org/#interface-documentfragment'/>
   <interface name='ShadowRoot' href='https://dom.spec.whatwg.org/#interface-shadowroot'/>
-  <interface name='DocumentCSS' href='https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-DocumentCSS'/>
   <interface name='DOMImplementation' href='https://dom.spec.whatwg.org/#interface-domimplementation'/>
   <interface name='DOMException' href='https://heycam.github.io/webidl/#idl-DOMException'/>
   <interface name='DOMStringMap' href='https://html.spec.whatwg.org/multipage/dom.html#domstringmap'/>
@@ -1212,8 +1210,6 @@
   <interface name='LinkStyle' href='https://www.w3.org/TR/cssom-1/#the-linkstyle-interface'/>
   <interface name='Node' href='https://dom.spec.whatwg.org/#interface-node'/>
   <interface name='NodeList' href='https://dom.spec.whatwg.org/#interface-nodelist'/>
-  <interface name='RGBColor' href='https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-RGBColor'/>
-  <interface name='ViewCSS' href='https://www.w3.org/TR/2000/REC-DOM-Level-2-Style-20001113/css.html#CSS-ViewCSS'/>
   <interface name='Window' href='https://html.spec.whatwg.org/multipage/window-object.html#window'/>
   <interface name='WindowEventHandlers' href='https://html.spec.whatwg.org/multipage/webappapis.html#windoweventhandlers'/>
   <interface name='Animation' href='https://www.w3.org/TR/web-animations-1/#the-animation-interface' />


### PR DESCRIPTION
Address [review comments](https://github.com/w3c/svgwg/issues/71#issuecomment-385876982) by @dstorey about unused DOM interfaces, and links to dated, obsolete, or incorrect specs. In so doing, remove almost all references to CSS2.