### PR TITLE
No value is illegal

### DIFF
--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -1238,9 +1238,8 @@
   <term name='throw' href='https://heycam.github.io/webidl/#dfn-throw'/>
   <term name='thrown' href='https://heycam.github.io/webidl/#dfn-throw'/>
 
-  <!--
-  CSS does not define an illegal value anymore
-   <term name='illegal value' href='https://www.w3.org/TR/2011/REC-CSS2-20110607/syndata.html#illegalvalues'/> -->
+  <term name='ignore' href='https://drafts.csswg.org/css-syntax/#css-ignored'/>
+  <term name='ignored' href='https://drafts.csswg.org/css-syntax/#css-ignored'/>
   <term name='3d rendering context' href='https://drafts.csswg.org/css-transforms-2/#3d-rendering-contexts'/>
 
   <term name='processing mode' href='conform.html#processing-modes'/>

--- a/master/geometry.html
+++ b/master/geometry.html
@@ -158,7 +158,7 @@ of the position of the element. </p>
 <p>The <a>'r'</a> property describes the radius of the <a>'circle'</a>
 element.</p>
 
-<p>A negative value for <a>'r'</a> must be treated as an <a>illegal value</a>.</p>
+<p>A negative value for <a>'r'</a> is <a>invalid</a> and must be <a>ignored</a>.</p>
 
 <h2 id='RX'>Horizontal radius: The <span class="property">'rx'</span>
 property</h2>
@@ -216,7 +216,7 @@ element.
     matching the behavior for <a>'rect'</a> elements when <a>'rx'</a> was not specified.
 </p>
 
-<p>A negative value for <a>'rx'</a> must be treated as an <a>illegal value</a>.</p>
+<p>A negative value for <a>'rx'</a> is <a>invalid</a> and must be <a>ignored</a>.</p>
 
 <h2 id='RY'>Vertical radius: The <span class="property">'ry'</span>
 property</h2>
@@ -274,7 +274,7 @@ property</h2>
     matching the behavior for <a>'rect'</a> elements when <a>'ry'</a> was not specified.
 </p>
 
-<p>A negative value for <a>'ry'</a> must be treated as an <a>illegal value</a>.</p>
+<p>A negative value for <a>'ry'</a> is <a>invalid</a> and must be <a>ignored</a>.</p>
 
 <h2 id='X'>Horizontal coordinate: The <span class="property">'x'</span> property</h2>
 <table class="propdef def">

--- a/master/painting.html
+++ b/master/painting.html
@@ -1018,7 +1018,7 @@ the <a href="paths.html#PathElementImplementationNotes">path implementation note
     <span class='prop-value'>miter-clip</span>, or
     <span class='prop-value'>arcs</span> line join as a multiple of
     the <a>'stroke-width'</a> value.
-    A negative value for <a>'stroke-miterlimit'</a> must be treated as an <a>illegal value</a>.
+    A negative value for <a>'stroke-miterlimit'</a> is <a>invalid</a> and must be <a>ignored</a>.
   </dd>
 </dl>
 

--- a/master/shapes.html
+++ b/master/shapes.html
@@ -61,14 +61,14 @@ non-zero values for the <a>'rx'</a> and <a>'ry'</a> geometric properties.</p>
 in the current user coordinate system.</p>
 
 <p>The <a>'width'</a> and <a>'height'</a> properties define the overall width and height of the rectangle.
-A negative value for either property is illegal and <a href="https://www.w3.org/TR/CSS21/syndata.html#parsing-errors">must be ignored as a parsing error</a>.
+A negative value for either property is <a>invalid</a> and must be <a>ignored</a>.
 A computed value of zero for either dimension disables rendering of the element.</p>
 
 <p>For rounded rectangles,
 the computed values of the <a>'rx'</a> and <a>'ry'</a> properties define
 the x- and y-axis radii of elliptical arcs used to round off the corners of the rectangle.
 The arc are always symmetrical along both horizontal and vertical axis; to create a rectangle with uneven corner rounding, define the shape explicitly with a <a>'path'</a>.
-A negative value for either property is illegal and <a href="https://www.w3.org/TR/CSS21/syndata.html#parsing-errors">must be ignored as a parsing error</a>.
+A negative value for either property is <a>invalid</a> and must be <a>ignored</a>.
 A computed value of zero for either dimension,
 or a computed value of <code>auto</code> for <em>both</em> dimensions,
 results in a rectangle without corner rounding.
@@ -201,7 +201,7 @@ radius.</p>
 
 <p>
   The <a>'r'</a> attribute defines the radius of the circle.
-  A negative value is illegal and <a href="https://www.w3.org/TR/CSS21/syndata.html#parsing-errors">must be ignored as a parsing error</a>.
+  A negative value is <a>invalid</a> and must be <a>ignored</a>.
   A computed value of zero disables rendering of the element.
 </p>
 
@@ -258,7 +258,7 @@ with the current <a>user coordinate system</a> based on a center point and two r
 <p>
   The <a>'rx'</a> and <a>'ry'</a> properties define the x- and y-axis radii of the
   ellipse.
-  A negative value for either property is illegal and <a href="https://www.w3.org/TR/CSS21/syndata.html#parsing-errors">must be ignored as a parsing error</a>.
+  A negative value for either property is <a>invalid</a> and must be <a>ignored</a>.
   A computed value of zero for either dimension,
   or a computed value of <code>auto</code> for <em>both</em> dimensions,
   disables rendering of the element.

--- a/master/struct.html
+++ b/master/struct.html
@@ -650,7 +650,7 @@ also apply in the scope of the cloned <a>shadow tree</a>.
     of the corresponding geometric property on that element.
     </p>
     <p>A negative value for <a>'width'</a> or <a>'height'</a>
-    must be treated as an illegal value.
+    is <a>invalid</a> and must be <a>ignored</a>.
     If <a>'width'</a> or <a>'height'</a> is zero,
     and the properties have an effect on the <a>referenced element</a>,
     then rendering of that element will be disabled.</p>

--- a/master/types.html
+++ b/master/types.html
@@ -35,8 +35,7 @@
   or a <a>presentation attribute</a>, is one that is either not allowed according
   to the grammar defining the property's values, or is allowed by the grammar but
   subsequently disallowed in prose.  A CSS declaration with an invalid value is
-  ignored; see <a href="https://www.w3.org/TR/2011/REC-CSS2-20110607/syndata.html#declaration">Declarations
-  and properties</a> ([<a href="refs.html#ref-css2">CSS2</a>], section 4.1.8).</dd>
+  <a>ignored</a>.</dd>
 
 </dl>
 


### PR DESCRIPTION
But many values are <a>invalid</a> and must be <a>ignored</a>!

Changes the prose describing non-negative value constraints
to use the CSS 3 terms.

"invalid" is linked to the existing definition of "invalid value"
in the types chapter.

"ignored" links directly to the CSS Syntax definition
(ED version for now; the published CR is out of date.)

Closes #639 and tidies up changes made in #637.