### PR TITLE
Added paragraph about Tiny 1.2 being deprecated (bug #199)

### DIFF
--- a/master/intro.html
+++ b/master/intro.html
@@ -93,6 +93,15 @@ and standards efforts, as described in the following:</p>
   See <a href="access.html">Accessibility Support</a>.</li>
 </ul>
 
+<h2 id="RelationshipToPrevious">Relationship to previous versions of this standard</h2>
+
+This edition of the SVG standard has been developed based on, and built upon, the 1.1 edition released in 2003.
+An intermediate version of SVG - named <a href="https://www.w3.org/TR/SVGTiny12/">Tiny 1.2</a> - was released
+in 2008. However it did not receive wide acceptance and there have been very few implementations of its
+enhanced feature set. However there are some 1.2 features have been implemented by many SVG implementations and
+they have been incorporated as part of this specification. But otherwise, the SVG Working Group consider version
+Tiny 1.2 to be a deprecated branch of the SVG standard.
+
 <h2 id="ConformanceTerms">Normative Terminology</h2>
 
 <p>Within this specification, the key words "MUST", "MUST NOT",


### PR DESCRIPTION
The suggested text I offered in bug #199 seemed to be acceptable to people,. So I have created a PR based on that. The text here has been slightly modified from the original.

Bug #199 has been marked as deferred to 2.1. But I think it would be a good idea to include this in the first release of SVG 2.