### PR TITLE
Fix for #649. Incorrect Unicode code point reference

### DIFF
--- a/master/paths.html
+++ b/master/paths.html
@@ -140,7 +140,7 @@ attempts to minimize the size of path data are as follows:</p>
 <p>The path data syntax is a prefix notation (i.e., commands
 followed by parameters). The only allowable decimal point is a
 Unicode
-U+0046 FULL STOP (".") character (also referred to in Unicode as
+U+002E FULL STOP (".") character (also referred to in Unicode as
 PERIOD, dot and decimal point) and no other delimiter
 characters are allowed [<a href='refs.html#ref-unicode'>UNICODE</a>].
 (For example, the following is an


### PR DESCRIPTION
Period/Full-stop is U+002E, not U+0046 (which is a capital F).

For issue #649.