### PR TITLE
Remove zoomAndPan attribute

### DIFF
--- a/master/Overview.html
+++ b/master/Overview.html
@@ -171,7 +171,6 @@ are encouraged to give feedback to implementers regarding its priority. The
 following features are at risk, and may be dropped during the CR period:</p>
 <ul>
 <li>More than one <a>'title'</a> or <a>'desc'</a> to provide localisation</li>
-<li><a>'zoomAndPan'</a></li>
 <li><a href="linking.html#Links">Nested links</a></li>
 <li><a>'vector-effect'</a> options other than <span class="prop-value">non-scaling-stroke</span></li>
 <li><a>'stroke-linejoin'</a> options <span class="prop-value">miter-clip</span> and <span class="prop-value">arcs</span></li>

--- a/master/changes.html
+++ b/master/changes.html
@@ -289,6 +289,10 @@ have been made.</p>
     to an out-of-range integer or 0 throws a TypeError.
     <a href="https://github.com/w3c/svgwg/issues/547">Issue discussion</a>
   </li>
+  <li>
+    Remove <code>zoomAndPan</code> attribute and related text.
+    <a href="https://github.com/w3c/svgwg/issues/56">Issue discussion</a>
+  </li>
 </ul>
 </div>
 
@@ -440,6 +444,15 @@ have been made.</p>
       is case-insensitive, as required by BCP 47.
     <a href="https://github.com/w3c/svgwg/issues/517">Issue discussion</a>
     <a href="https://github.com/w3c/svgwg/pull/528">Edits</a>
+    </li>
+  </ul>
+</div>
+
+<div class='changed-since-cr1 cr2 cr3'>
+  <ul>
+    <li>
+      Remove <code>zoomAndPan</code> attribute and related text.
+      <a href="https://github.com/w3c/svgwg/issues/56">Issue discussion</a>
     </li>
   </ul>
 </div>
@@ -924,9 +937,6 @@ have been made.</p>
   the 'cursor element' element to take an URL that is not in a CSS-like
   functional form.</li>
   <li>Added the <span class="prop-value">bounding-box</span> keyword to <a>'pointer-events'</a>.</li>
-  <div class='changed-since-cr1 cr2 cr3'>
-    <li>Remove requirements on <a>'pointer-events'</a> for raster images to check individual pixels for transparency.</li>
-  </div>
   <li>Replaced SVGLoad, SVGAbort, SVGError and SVGUnload with load, abort, error and unload respectively.</li>
   <li>Required that only <a>structurally external elements</a> and the <a>outermost svg element</a> must fire load events.</li>
   <li>Replaced SVGResize and SVGScroll with resize and scroll respectively.</li>
@@ -955,6 +965,13 @@ have been made.</p>
         <a href="https://github.com/w3c/svgwg/pull/548">Edits</a>
     </li>
     <li>Added the <span class="prop-value">auto</span> keyword to <a>'pointer-events'</a>.</li>
+  </ul>
+</div>
+
+<div class='changed-since-cr1 cr2 cr3'>
+  <ul>
+    <li>Remove requirements on <a>'pointer-events'</a> for raster images to check individual pixels for transparency.</li>
+    <li>Remove <code>zoomAndPan</code> attribute and related text.</li>
   </ul>
 </div>
 

--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -281,7 +281,7 @@
       elementcategories='animation, descriptive, shape, structural, paint server'
       elements='a, clipPath, filter, foreignObject, image, marker, mask, script, style, switch, text, view'
       attributecategories='aria, conditional processing, core, document event, global event, document element event, graphical event, presentation'
-      attributes='viewBox, preserveAspectRatio, zoomAndPan'
+      attributes='viewBox, preserveAspectRatio'
       geometryproperties='x, y, width, height'
       interfaces='SVGSVGElement'>
       <attribute name='transform' href='coords.html#TransformProperty' animatable='yes'/>
@@ -382,7 +382,7 @@
       elementcategories='animation, descriptive'
       elements='script, style'
       attributecategories='aria, core, global event, document element event'
-      attributes='viewBox, preserveAspectRatio, zoomAndPan'
+      attributes='viewBox, preserveAspectRatio'
       interfaces='SVGViewElement'>
   </element>
 
@@ -425,7 +425,6 @@
   <!-- misc:  Applies to all <element>s that include attribute name in 'attribute'. -->
   <attribute name='viewBox' href='coords.html#ViewBoxAttribute' animatable='yes'/>
   <attribute name='preserveAspectRatio' href='coords.html#PreserveAspectRatioAttribute' animatable='yes'/>
-  <attribute name='zoomAndPan' href='interact.html#ZoomAndPanAttribute'/>
 
   <attribute name='pathLength' href='paths.html#PathLengthAttribute' animatable='yes'/>
   <!-- ... attribute categories .......................................... -->
@@ -751,7 +750,6 @@
   <interface name='SVGAnimatedNumber' href='types.html#InterfaceSVGAnimatedNumber'/>
   <interface name='SVGAnimatedLength' href='types.html#InterfaceSVGAnimatedLength'/>
   <interface name='SVGAnimatedEnumeration' href='types.html#InterfaceSVGAnimatedEnumeration'/>
-  <interface name='SVGZoomAndPan' href='types.html#InterfaceSVGZoomAndPan'/>
   <interface name='SVGFitToViewBox' href='types.html#InterfaceSVGFitToViewBox'/>
   <interface name='SVGNumber' href='types.html#InterfaceSVGNumber'/>
   <interface name='SVGAngle' href='types.html#InterfaceSVGAngle'/>

--- a/master/interact.html
+++ b/master/interact.html
@@ -32,22 +32,11 @@ the SVG language:</p>
   <span class="element-name">'a'</span> element</a>) by actions such
   as mouse clicks when the pointing device is positioned over
   particular graphics elements.</li>
-
-  <li>In many cases, depending on the value of the <a>'zoomAndPan'</a>
-  attribute on the <a>'svg'</a> element and on the
-  characteristics of the user agent, users are able to zoom
-  into and pan around SVG content.</li>
 </ul>
 
-<p>This chapter describes:</p>
-
-<ul>
-  <li>information about <a href="interact.html#SVGEvents">events</a>,
-  including under which circumstances events are triggered</li>
-
-  <li>how to indicate whether a given document can be
-  <a href="interact.html#EnableZoomAndPanControls">zoomed and panned</a></li>
-</ul>
+<p>This chapter describes scripting
+and DOM <a href="interact.html#SVGEvents">event</a> handling in interactive SVG,
+including under which circumstances events are triggered.</p>
 
 <p>Related information can be found in other chapters:</p>
 
@@ -426,8 +415,7 @@ a <a>outermost svg element</a> will never be the target of pointer events,
 though events can bubble to this element.
 If a pointer event does not result in a positive <a>hit-test</a> on a
 <a>graphics element</a>, then it should evoke any user-agent-specific window
-behavior, such as a presenting a context menu or controls to allow zooming
-and panning of an SVG document fragment.</p>
+behavior, such as a presenting a context menu.</p>
 
 <p>This specification does not define the behavior of pointer events on the
 <a>outermost svg element</a> for SVG images which are embedded by reference
@@ -485,8 +473,7 @@ DOM event, is as follows:</p>
   <li>If the event type is one which the user agent associates with the evocation
   of special user-interface controls (e.g., a right-click or command-click
   evoking a context menu), the user agent should evoke such user-agent-specific
-  behavior, such as presenting a context menu or controls to allow zooming and
-  panning of an SVG document fragment.</li>
+  behavior, such as presenting a context menu.</li>
 </ol>
 
 <h2 id="PointerEventsProp">The <span class="property">'pointer-events'</span> property</h2>
@@ -733,91 +720,6 @@ element to be target of hit-testing as well.</p>
 <a>'fill-opacity'</a>, <a>'stroke-opacity'</a>, <a>'fill'</a> and
 <a>'stroke'</a> do not affect event processing.</p>
 
-<h2 id="EnableZoomAndPanControls">Magnification and panning</h2>
-
-<div class="annotation svg2-requirement">
-  <table>
-    <tr>
-      <th>SVG 2 Requirement:</th>
-      <td>Support level of detail control.</td>
-    </tr>
-    <tr>
-      <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/10/28-svg-irc#T00-20-33">We will support Level of Detail control in SVG 2.</a></td>
-    </tr>
-    <tr>
-      <th>Purpose:</th>
-      <td>Control visibility of elements based on zoom level (useful, for example, in mapping).</td>
-    </tr>
-    <tr>
-      <th>Owner:</th>
-      <td>Doug (no action)</td>
-    </tr>
-    <tr>
-      <th>Note:</th>
-      <td>See <a href="http://www.w3.org/Submission/2011/SUBM-SVGTL-20110607/#VisibilityControllingAccordingToZooming">Tiling and Layering Module for SVG 1.2 Tiny</a>.</td>
-    </tr>
-  </table>
-</div>
-
-<p>Magnification represents a complete, uniform
-transformation on an SVG document fragment, where the magnify operation scales
-all graphical elements by the same amount. A magnify operation
-has the effect of a supplemental scale and translate
-transformation placed at the outermost level on the SVG
-document fragment (i.e., outside the <a>outermost svg element</a>).</p>
-
-<p>Panning represents a translation (i.e., a shift)
-transformation on an SVG document fragment in response to a
-user interface action.</p>
-
-<p>SVG user agents that operate in interaction-capable user
-environments are required to support the ability to magnify and pan.</p>
-
-<p>The <a>outermost svg element</a>
-in an SVG document fragment has attribute <a>'svg/zoomAndPan'</a>, which takes the possible
-values of <em>disable</em> and <em>magnify</em>, with the
-default being <em>magnify</em>.</p>
-
-<p class="issue" data-issue="9">The zoomAndPan attribute is at risk, it has no known implementations
-and is unlikely to be implemented. See
-<a href="https://github.com/w3c/svgwg/issues/56">Github issue #56</a>.</p>
-
-<dl class="attrdef-list">
-  <dt>
-    <table class="attrdef def">
-      <tr>
-        <th>Name</th>
-        <th>Value</th>
-        <th>Initial value</th>
-        <th>Animatable</th>
-      </tr>
-      <tr>
-        <td><dfn id="ZoomAndPanAttribute" data-dfn-type="element-attr" data-dfn-for="svg">zoomAndPan</dfn></td>
-        <td>[ disable | magnify ]</td>
-        <td>disable</td>
-        <td>no</td>
-      </tr>
-    </table>
-  </dt>
-  <dd>
-    <p>If <em>disable</em>, the user agent shall disable any
-    magnification and panning controls and not allow the user to
-    magnify or pan on the given document fragment.</p>
-
-    <p>If <em>magnify</em>, in environments that support user
-    interactivity, the user agent shall provide controls to allow
-    the user to perform a "magnify" operation on the document
-    fragment.</p>
-  </dd>
-</dl>
-
-
-<p>If a <a>'svg/zoomAndPan'</a> attribute is
-assigned to an inner <a>'svg'</a>
-element, the <a>'svg/zoomAndPan'</a> setting
-on the inner <a>'svg'</a> element
-will have no effect on the SVG user agent.</p>
 
 <div class='ready-for-wider-review'>
 <h2 id="Focus">Focus</h2>
@@ -852,7 +754,6 @@ will have no effect on the SVG user agent.</p>
 </p>
 <ul>
     <li>the document root element</li>
-    <li>an <a>'svg'</a> element which has <a href="#ZoomAndPanAttribute">zoom and pan</a> controls</li>
     <li>any element (such as within a <a>'foreignObject'</a>)
         that generates a scrollable region
     </li>

--- a/master/linking.html
+++ b/master/linking.html
@@ -1003,12 +1003,10 @@ SVGViewAttributes ::= SVGViewAttribute |
 
 SVGViewAttribute ::= viewBoxSpec |
                      preserveAspectRatioSpec |
-                     transformSpec |
-                     zoomAndPanSpec
+                     transformSpec
 viewBoxSpec ::= 'viewBox(' ViewBoxParams ')'
 preserveAspectRatioSpec = 'preserveAspectRatio(' AspectParams ')'
 transformSpec ::= 'transform(' TransformParams ')'
-zoomAndPanSpec ::= 'zoomAndPan(' ZoomAndPanParams ')'
 </pre>
 
 <p>where:</p>
@@ -1029,10 +1027,6 @@ zoomAndPanSpec ::= 'zoomAndPan(' ZoomAndPanParams ')'
   many elements. For example, <span class="attr-value">transform(scale(5))</span>.
   Currently additional tranform styles and parameters (e.g. transform-origin, perspective) are not supported.
   </li>
-
-  <li><em>ZoomAndPanParams</em> corresponds to the
-  parameter values for the <a>'zoomAndPan'</a> attribute on the <a>'view'</a>
-  element. For example, <span class="attr-value">zoomAndPan(magnify)</span>.</li>
 
 </ul>
 
@@ -1198,8 +1192,7 @@ interface <b>SVGAElement</b> : <a>SVGGraphicsElement</a> {
 <pre class="idl">[Exposed=Window]
 interface <b>SVGViewElement</b> : <a>SVGElement</a> {};
 
-<a>SVGViewElement</a> includes <a>SVGFitToViewBox</a>;
-<a>SVGViewElement</a> includes <a>SVGZoomAndPan</a>;</pre>
+<a>SVGViewElement</a> includes <a>SVGFitToViewBox</a>;</pre>
 
 </edit:with>
 </div>

--- a/master/struct.html
+++ b/master/struct.html
@@ -223,32 +223,6 @@ information, refer to the <a href="https://www.w3.org/TR/2006/REC-xml-names-2006
   is treated equivalent to <span class="prop-value">100%</span>.
 </p>
 
-<p><em>Attribute definitions:</em></p>
-
-<dl class="attrdef-list">
-  <dt>
-    <table class="attrdef def">
-      <tr>
-        <th>Name</th>
-        <th>Value</th>
-        <th>Initial value</th>
-        <th>Animatable</th>
-      </tr>
-      <tr>
-        <td><dfn id="SVGElementZoomAndPanAttribute" data-dfn-type="element-attr" data-dfn-for="svg" data-export="">zoomAndPan</dfn></td>
-        <td>disable | magnify</td>
-        <td>magnify</td>
-        <td>no</td>
-      </tr>
-    </table>
-  </dt>
-  <dd>
-    <p>Specifies whether the user agent should supply a means to zoom
-    and pan the SVG content.  See the definition of <a>'zoomAndPan'</a>
-    for details.</p>
-  </dd>
-</dl>
-
 <p>If an SVG document is likely to be referenced as a component
 of another document, the author will often want to include a
 <a>'viewBox'</a> attribute on the <a>outermost svg element</a> of the
@@ -2694,7 +2668,6 @@ interface <b>SVGSVGElement</b> : <a>SVGGraphicsElement</a> {
 };
 
 <a>SVGSVGElement</a> includes <a>SVGFitToViewBox</a>;
-<a>SVGSVGElement</a> includes <a>SVGZoomAndPan</a>;
 <a>SVGSVGElement</a> includes <a>WindowEventHandlers</a>;</pre>
 
 <p>The
@@ -2708,16 +2681,35 @@ presentation attributes, respectively.</p>
 
 <p>The <b id="__svg__SVGSVGElement__currentScale">currentScale</b> and
 <b id="__svg__SVGSVGElement__currentTranslate">currentTranslate</b> IDL
-attributes represent the transform applied to the document in
-response to user magnification and panning operations, as described under
-<a href="interact.html#ZoomAndPanAttribute">Magnification and panning</a>.</p>
+attributes represent an additional transform applied to the SVG.
+They only have an effect on the <a>outermost svg element</a> of an <a>SVG document fragment</a>.</p>
 
-<p class="note">The document's magnification and panning
+<p>The document's magnification and panning
 transform is a 2x3 matrix of the form
-[currentScale 0 0 currentScale currentTranslate.x currentTranslate.y].
+<code>[currentScale 0 0 currentScale currentTranslate.x currentTranslate.y]</code>.
 The value of the <a>'transform'</a> property does not affect
 <a href="#__svg__SVGSVGElement__currentScale">currentScale</a> or
 <a href="#__svg__SVGSVGElement__currentTranslate">currentTranslate</a>.</p>
+
+<div class="note">
+<p>Previous versions of SVG recommended that user agents implement controls, by default,
+for the user to set the scale (zoom) and translate (pan) of the graphic.
+Transformations from these user actions <em>would</em> be reflected
+in the values of <code>currentScale</code> and <code>currentTranslate</code>.
+These user controls were not well implemented, and are no longer recommended.
+However, authors should be aware that the user agent may update these values.
+</p>
+<p>The obsolete attribute <code>zoomAndPan="disable"</code>, on the outermost SVG element,
+should disable any user agent manipulation of the values based on user action,
+but may have unwanted side effects in some user agents.</p>
+</div>
+
+<p class="issue" data-issue="360">
+The interaction of currentScale and currentTranslate
+with other ways of transforming the document root (transforms and SVG views)
+is poorly defined.
+See the <a href="https://github.com/w3c/svgwg/issues/360">GitHub issue</a> for more.
+</p>
 
 <p>On getting <a href="#__svg__SVGSVGElement__currentScale">currentScale</a>,
 the following steps are run:</p>
@@ -2782,13 +2774,6 @@ the document's magnification and panning transform.</p>
 <p>Whenever an <a>'svg'</a> element is no longer <a>outermost svg element</a>,
 the x and y components of its <a href="#CurrentTranslatePointObject">current
 translate point object</a> must be set to 0.</p>
-
-<p class="note">Note that the value of the <a>'zoomAndPan'</a> attribute
-on the <a>outermost svg element</a> only controls whether the document's
-magnification and panning transform can be updated through user interaction.
-Regardless of the value of that attribute, the current scale and translation
-can be changed by modifying <a href="#__svg__SVGSVGElement__currentScale">currentScale</a>
-and <a href="#__svg__SVGSVGElement__currentTranslate">currentTranslate</a>.</p>
 
 <p>The <b id="__svg__SVGSVGElement__suspendRedraw">suspendRedraw</b>,
 <b id="__svg__SVGSVGElement__unsuspendRedraw">unsuspendRedraw</b>,

--- a/master/types.html
+++ b/master/types.html
@@ -648,10 +648,6 @@ while a <a>DOMRect</a> consists of many <span class="DOMInterfaceName">double</s
   <dd>Initialized as <span class="attr-value">0 in unspecified units</span>
   (<a href="types.html#__svg__SVGAngle__SVG_ANGLETYPE_UNSPECIFIED">SVG_ANGLETYPE_UNSPECIFIED</a>).</dd>
 
-  <dt class="DOMInterfaceName"><a>SVGZoomAndPan</a></dt>
-  <dd>Initialized as <span class="attr-value">0</span>
-  (<a href="types.html#__svg__SVGZoomAndPan__SVG_ZOOMANDPAN_UNKNOWN">SVG_ZOOMANDPAN_UNKNOWN</a>).</dd>
-
   <dt class="DOMInterfaceName"><a>SVGPreserveAspectRatio</a></dt>
   <dd>Initialized as <span class="attr-value">'xMidYMid meet'</span>.</dd>
 </dl>
@@ -2673,61 +2669,6 @@ these two attributes.</p>
 
 <p>The <b id="__svg__SVGFitToViewBox__preserveAspectRatio">preserveAspectRatio</b> IDL attribute
 <a>reflects</a> the <a>'preserveAspectRatio'</a> content attribute.</p>
-
-
-<h3 id="InterfaceSVGZoomAndPan" data-dfn-type="interface" data-lt="SVGZoomAndPan">Mixin SVGZoomAndPan</h3>
-
-<p>The <a>SVGZoomAndPan</a> interface is used to reflect the
-<a>'svg/zoomAndPan'</a> attribute, and is mixed in to other
-interfaces for elements that support this attribute.</p>
-
-<pre class="idl">interface mixin <b>SVGZoomAndPan</b> {
-
-  // Zoom and Pan Types
-  const unsigned short <a href="#__svg__SVGZoomAndPan__SVG_ZOOMANDPAN_UNKNOWN">SVG_ZOOMANDPAN_UNKNOWN</a> = 0;
-  const unsigned short <a href="#__svg__SVGZoomAndPan__SVG_ZOOMANDPAN_DISABLE">SVG_ZOOMANDPAN_DISABLE</a> = 1;
-  const unsigned short <a href="#__svg__SVGZoomAndPan__SVG_ZOOMANDPAN_MAGNIFY">SVG_ZOOMANDPAN_MAGNIFY</a> = 2;
-
-  attribute unsigned short <a href="#__svg__SVGZoomAndPan__zoomAndPan">zoomAndPan</a>;
-};</pre>
-
-<p>The zoom and pan type constants defined on <a>SVGZoomAndPan</a> have the
-following meanings:</p>
-
-<table class='vert'>
-  <tr><th>Constant</th><th>Meaning</th></tr>
-  <tr><td><b id="__svg__SVGZoomAndPan__SVG_ZOOMANDPAN_DISABLE">SVG_ZOOMANDPAN_DISABLE</b></td><td>Corresponds to the <span class='attr-value'>'disable'</span> attribute value.</td></tr>
-  <tr><td><b id="__svg__SVGZoomAndPan__SVG_ZOOMANDPAN_MAGNIFY">SVG_ZOOMANDPAN_MAGNIFY</b></td><td>Corresponds to the <span class='attr-value'>'magnify'</span> attribute value.</td></tr>
-  <tr><td><b id="__svg__SVGZoomAndPan__SVG_ZOOMANDPAN_UNKNOWN">SVG_ZOOMANDPAN_UNKNOWN</b></td><td>Some other type of value.</td></tr>
-</table>
-
-<p>The <b id="__svg__SVGZoomAndPan__zoomAndPan">zoomAndPan</b>
-IDL attribute represents the value of the <a>'zoomAndPan'</a> attribute.
-On getting <a href="#__svg__SVGZoomAndPan__zoomAndPan">zoomAndPan</a>, the
-following steps are run:</p>
-
-<ol class='algorithm'>
-  <li>Let <var>value</var> be the current value of the <a>'zoomAndPan'</a>
-  attribute (using the attribute's <a>initial value</a>
-  if it is not present or invalid).</li>
-  <li>Return the corresponding constant in the zoom and pan type constant
-  table above for <var>value</var>.</li>
-</ol>
-
-<p>On setting <a href="#__svg__SVGZoomAndPan__zoomAndPan">zoomAndPan</a>,
-the following steps are run:</p>
-
-<ol class='algorithm'>
-  <li>Let <var>value</var> be the value being assigned to a
-  <a href="#__svg__SVGZoomAndPan__zoomAndPan">zoomAndPan</a>.</li>
-  <li>If <var>value</var> is
-  <a href="#__svg__SVGZoomAndPan__SVG_ZOOMANDPAN_UNKNOWN">SVG_ZOOMANDPAN_UNKNOWN</a>
-  or does not correspond to an entry in the zoom and pan type constant
-  table above, then return.</li>
-  <li>Set the <a>'zoomAndPan'</a> attribute to the
-  keyword value in the zoom and pan type constant table above
-  that corresponds to <var>value</var>.</li>
-</ol>
 
 
 <h3 id="InterfaceSVGURIReference" data-dfn-type="interface" data-lt="SVGURIReference">Mixin SVGURIReference</h3>


### PR DESCRIPTION
Closes #56.

Adds a note about the legacy spec, in the context of currentScale and currentTranslate.

Remaining ambiguities about these IDL properties are covered in #360.
An inline issue is included.