### PR TITLE
Link to definition of color for stop-color syntax

### DIFF
--- a/master/propidx.html
+++ b/master/propidx.html
@@ -210,9 +210,7 @@
         </tr>
         <tr>
           <th><a>'stop-color'</a></th>
-          <td>currentColor |<br />
-           <a>&lt;color&gt;</a>
-           [<a>&lt;icccolor&gt;</a>]</td>
+          <td>&lt;‘<a>'color'</a>’&gt;</td>
           <td>black</td>
           <td><a>'stop'</a> elements</td>
           <td>no</td>

--- a/master/pservers.html
+++ b/master/pservers.html
@@ -1158,7 +1158,7 @@ colors..." but "ramp" is used nowhere else in this section.</p>
       <p>
       The <a>'stop-color'</a> property indicates what color to use
       at that gradient stop. The keyword
-      <span class="attr-value">currentColor</span> and ICC colors
+      <span class="attr-value">currentColor</span> and other color syntaxes
       can be specified in the same manner as within a
       <a href="painting.html#SpecifyingPaint">&lt;paint&gt;</a>
       specification for the <a>'fill'</a> and <a>'stroke'</a>
@@ -1173,8 +1173,7 @@ colors..." but "ramp" is used nowhere else in this section.</p>
       <a>'stop-opacity'</a> with the value '0'.
       </p>
       <dl class="propdef-svg2">
-    <dt>Value</dt>
-    <dd>currentColor | <a>&lt;color&gt;</a> <a>&lt;icccolor&gt;</a></dd>
+        <dt>Value</dt>              <dd>&lt;‘<a>'color'</a>’&gt;</dd>
         <dt>Initial</dt>            <dd>black</dd>
         <dt>Applies to</dt>         <dd><a>'stop'</a> elements</dd>
         <dt>Inherited</dt>          <dd>no</dd>


### PR DESCRIPTION
We previously defined the stop-color syntax as
`currentColor | <color> <icccolor>`
which would have suggested that `black icc-color(name)` is
a valid stop-color but `black` is not.