### PR TITLE
tweak styling of the header links

### DIFF
--- a/master/style/svg.css
+++ b/master/style/svg.css
@@ -140,7 +140,7 @@ dl.definitions > dd > :first-child,
 dl.definitions > dt > dfn { font-style: normal; font-weight: bold; }
 
 /* header/footer with links to next/previous chapter, etc. */
-.header { font-size: 85%; }
+.header { font-size: 75%; margin-top: 1em; white-space: nowrap; }
 
 /* put more space around the chapter dividers (in the single page version) than
    there is around section headings */

--- a/tools/publish/processing.js
+++ b/tools/publish/processing.js
@@ -143,14 +143,15 @@ exports.addHeaderFooter = function(conf, page, doc) {
   var markup = '<div class="header {{side}}">';
 
   if (conf.toc)            markup += '<a href="Overview.html">Overview</a>';
-  if (previous)            markup += ' . <a href="{{previous}}.html">Previous</a>';
-  if (next)                markup += ' . <a href="{{next}}.html">Next</a>';
-  if (conf.elementIndex)   markup += ' . <a href="{{elementIndex}}">Elements</a>';
-  if (conf.attributeIndex) markup += ' . <a href="{{attributeIndex}}">Attributes</a>';
-  if (conf.propertyIndex)  markup += ' . <a href="{{propertyIndex}}">Properties</a>';
+  if (previous)            markup += ' · <a href="{{previous}}.html">Previous</a>';
+  if (next)                markup += ' · <a href="{{next}}.html">Next</a>';
+  if (conf.elementIndex)   markup += ' · <a href="{{elementIndex}}">Elements</a>';
+  if (conf.attributeIndex) markup += ' · <a href="{{attributeIndex}}">Attributes</a>';
+  if (conf.propertyIndex)  markup += ' · <a href="{{propertyIndex}}">Properties</a>';
+
   markup += "</div>";
 
-  function header(side) {
+  function header() {
     return utils.parse(markup, { shortTitle: conf.shortTitle,
                                  publicationDate: conf.publicationDate,
                                  index: conf.index,
@@ -159,8 +160,7 @@ exports.addHeaderFooter = function(conf, page, doc) {
                                  attributeIndex: conf.attributeIndex,
                                  propertyIndex: conf.propertyIndex,
                                  previous: previous,
-                                 next: next,
-                                 side: side });
+                                 next: next });
   }
 
   function getChildNodeById(parent, id) {
@@ -175,7 +175,7 @@ exports.addHeaderFooter = function(conf, page, doc) {
   if (conf.pages[page].type != 'index') {
     var toc = getChildNodeById(doc.body, 'toc');
     if (toc) {
-        toc.insertBefore(header("top"), toc.firstChild);
+      toc.insertBefore(header(), toc.firstChild);
     }
   }
 }


### PR DESCRIPTION
The middle dot characters got turned into periods at one point.
    
Also make the text a bit smaller so that it fits on one line.