### PR TITLE
Rebase the SVG Native spec on top of SVG 2

### DIFF
--- a/specs/svg-native/index.bs
+++ b/specs/svg-native/index.bs
@@ -54,6 +54,8 @@ There are numerous differences between the SVG Native format and the [[!SVG2]] f
 
 Note: If a document uses parts of SVG that aren't part of SVG Native, then it isn't a conformant SVG Native document. When an SVG Native renderer opens such a file, it should ignore all of those parts. Therefore, all SVG Native renderers should produce the same rendering for the same document. However, there may be renderers which intentionally decide to honor parts of SVG that aren't part of SVG Native. In order to make it more likely that a given document's rendering is predictable, even in these renderers, SVG Native authoring tools are recommended to always emit documents that conform to this specification. The SVG Working Group is considering producing a validator to determine whether a given document is conformant to the SVG Native format.
 
+ISSUE: The file type and mime type is being discussed in <a href="https://github.com/w3c/svgwg/issues/664">this GitHub issue</a>.
+
 SVG Native is a standalone file type, expected to be rendered with a dedicated-purpose renderer. Therefore, SVG Native content must not be present as part of a larger XML (or HTML) document. If it is present as part of a larger XML (or HTML) document, the content should be interpreted as SVG proper.
 
 Note: This means that browsers encounting a SVG Native root element within the DOM must not interpret it as SVG Native, even if it has the 'baseAttribute' attribute set to <code>native</code>. If a Web author desires to use SVG Native on the Web, the <{img}> element may be used instead. This matches other native image formats such as [[!PNG]]. A Web browser should implement SVG Native by linking with the system's SVG Native facilities. This matches the implementation of other native image formats.
@@ -66,7 +68,7 @@ User agents may limit the reference depth of references to implementation-depend
 
 XSL Processing is forbidden.
 
-XML Entities and CDATA sections may be present.
+A valid SVG Native document must not contain any of the external or internal XML DTD subset.
 
 ISSUE: Is it worth mentioning the 'HTML dialect' of SVG?
 

--- a/specs/svg-native/index.bs
+++ b/specs/svg-native/index.bs
@@ -120,10 +120,21 @@ Percentage length values are not supported by SVG Native.
 <a lt="relative length">Relative units</a> are not supported by SVG Native.
 <!-- https://www.w3.org/2019/07/01-svg-minutes.html -->
 
+Geometry Properties {#geometryproperties}
+=========================================
+
+The grammar for the 'cx', 'cy', 'r', 'rx', 'ry', 'x', 'y', 'width', and 'height' properties is:
+
+<code><<number>> | <<length>> | <<percentage>></code>
+
+A bare number behaves as if ''px'' is specified.
+
+Note: The ''auto'' value is not supported in the 'cx', 'cy', 'r', 'rx', 'ry', 'x', 'y', 'width', and 'height' properties.
+
 Coordinate Systems, Transformations, and Units {#coords}
 ========================================================
 
-Only the following units are supported:
+Only the following units are supported by SVG Native:
 - (unitless)
 - ''px''
 - ''pt''
@@ -131,6 +142,28 @@ Only the following units are supported:
 - ''mm''
 - ''cm''
 - ''in''
+
+The 'transform' property is only supported by SVG Native on the following elements:
+- <{svg}>
+- <{g}>
+- <{defs}>
+- <{use}>
+- <{image}>
+- <{path}>
+- <{rect}>
+- <{circle}>
+- <{ellipse}>
+- <{line}>
+- <{polyline}>
+- <{polygon}>
+- <{clipPath}>
+
+The 'viewBox' attribute is only supported by SVG Native on the <{svg}> element.
+
+The 'preserveAspectRatio' attribute is only supported by SVG Native on the following elements:
+- <{svg}>
+- <{image}>
+- <{pattern}>
 
 Paths {#paths}
 ==============

--- a/specs/svg-native/index.bs
+++ b/specs/svg-native/index.bs
@@ -50,9 +50,13 @@ Basics {#basics}
 
 SVG Native is presented as a series of modifications of [[!SVG2]]. These modifications are applied as differences from that specification. Rather than being a strict line-by-line diff, this specification describes the differences directly.
 
-There are numerous differences between the SVG Native format and the [[!SVG2]] format. Currently, all differences are reductive; all functionality in SVG Native is also present in [[!SVG2]]. A conforming SVG Native document must only include functionality present in the SVG Native format. A conforming SVG Native renderer should ignore any functionality requested by a document that is not present in the SVG Native format. If a SVG Native renderer intentionally chooses to honor functionality beyond the SVG Native specification, it must do so in accordance with the [[!SVG2]] specification.
+If functionality present in [[!SVG2]] isn't present in the SVG Native specification, SVG Native includes that functionality.
+<!-- https://www.w3.org/2019/04/15-svg-minutes.html -->
+
+There are numerous differences between the SVG Native format and the [[!SVG2]] format. Currently, all differences are reductive; all functionality in SVG Native is also present in [[!SVG2]]. A conforming SVG Native document must only include functionality present in the SVG Native format. A conforming SVG Native renderer should ignore any functionality requested by a document that is not present in the SVG Native format. If a SVG Native renderer intentionally chooses to honor functionality beyond the SVG Native specification, it must do so in accordance with the [[!SVG2]] specification. There are a few exceptions to this throughout this specification below, where an SVG Native renderer must not include some functionality from [[!SVG2]].
 
 Note: If a document uses parts of SVG that aren't part of SVG Native, then it isn't a conformant SVG Native document. When an SVG Native renderer opens such a file, it should ignore all of those parts. Therefore, all SVG Native renderers should produce the same rendering for the same document. However, there may be renderers which intentionally decide to honor parts of SVG that aren't part of SVG Native. In order to make it more likely that a given document's rendering is predictable, even in these renderers, SVG Native authoring tools are recommended to always emit documents that conform to this specification. The SVG Working Group is considering producing a validator to determine whether a given document is conformant to the SVG Native format.
+<!-- https://www.w3.org/2019/05/06-svg-minutes.html -->
 
 ISSUE: The file type and mime type is being discussed in <a href="https://github.com/w3c/svgwg/issues/664">this GitHub issue</a>.
 
@@ -66,35 +70,24 @@ The file extension for SVG Native is <code>.svn</code>. The UTI for SVG Native i
 
 User agents may limit the reference depth of references to implementation-dependent maximas. However, this limit must be greater than or equal to 1 reference.
 
-XSL Processing is forbidden.
+XSL Processing is not supported by SVG Native.
 
 A valid SVG Native document must not contain any of the external or internal XML DTD subset.
-
-ISSUE: Is it worth mentioning the 'HTML dialect' of SVG?
-
-Concepts {#concepts}
-====================
-
-Chapter is unchanged.
-
-Rendering Model {#render}
-=========================
-
-Chapter is unchanged.
-
-Basic Data Types and Interfaces {#types}
-========================================
-
-Chapter is unchanged.
-
-Note: Because this specification removes some elements and attributes, not all of the syntax productions in this chapter are referenced by other sections of this specification. Therefore, not all of the productions in this chapter need to be implemented.
+<!-- https://www.w3.org/2019/04/29-svg-minutes.html -->
 
 Document Structure {#struct}
 ============================
 
-The root element must be an <{svg}> element, and all other <{svg}> elements are forbidden.
+The root element must be an <{svg}> element, and all other <{svg}> elements are not supported by SVG Native.
+<!-- https://www.w3.org/2019/07/15-svg-minutes.html -->
 
-Section 5.8 "Conditional Processing" is deleted.
+Conditional processesing attributes and elements are not supported in SVG Native. These include the <{switch}> element.
+
+<!-- There are too many things which are unobservable in SVG Native. Don't need to list them all out. -->
+
+The <{meta}> element is not supported in SVG Native.
+
+Elements in foreign namespaces, except the xlink (<code>http://www.w3.org/1999/xlink</code>) namespace, are not supported in SVG Native.
 
 <{image}> elements must only contain base64-encoded <code>data:</code> URLs of [[!JPEG]] or [[!PNG]] images. [[!APNG]] images must be rendered without animation, using standard backward-compatibility with static [[!PNG]] images. All other image formats must be ignored.
 
@@ -103,20 +96,29 @@ All external resource loading is forbidden.
 Styling {#styling}
 ==================
 
-The <{style}> element and the 'style' attribute are forbidden.
+The <{style}> element and the 'style' attribute is not supported in SVG Native.
+<!-- https://www.w3.org/2019/05/06-svg-minutes.html -->
 
-Using ''calc()'', ''env()'', or ''var()'' is forbidden.
+''calc()'' is not supported by SVG Native.
 
-Note: Other environments may relax these rules and allow these functions as necessary. For example, the [[!OPENTYPE]] spec might allow ''env()'' or ''var()'' in color fonts to support font color palettes.
+''env()'' and ''var()'' are supported by SVG Native.
+<!-- https://www.w3.org/2019/05/06-svg-minutes.html -->
+<!-- https://www.w3.org/2019/05/20-svg-minutes.html -->
 
-The CSS 'all' property is forbidden.
+The CSS 'all' property is not supported by SVG Native.
 
-All the global CSS keywords are forbidden. These include:
+All the global CSS keywords are not supported by SVG Native. These include:
 
 1. ''initial''
 2. ''inherit''
 3. ''unset''
 4. ''revert''
+
+Percentage length values are not supported by SVG Native.
+<!-- https://www.w3.org/2019/07/01-svg-minutes.html -->
+
+<a lt="relative length">Relative units</a> are not supported by SVG Native.
+<!-- https://www.w3.org/2019/07/01-svg-minutes.html -->
 
 Coordinate Systems, Transformations, and Units {#coords}
 ========================================================

--- a/specs/svg-native/index.bs
+++ b/specs/svg-native/index.bs
@@ -95,10 +95,29 @@ SVG Modules {#modules}
 
 SVG Native is a subset of the content in the [[!SVG2]] specification, and some associated modules. They are:
 - <a href="https://www.w3.org/TR/2018/REC-css-color-3-20180619/">CSS Color</a>
+- <a href="https://www.w3.org/TR/css-values-3/">CSS Values and Units</a>
+- <a href="https://www.w3.org/TR/css-masking-1/">CSS Masking</a>
 
 No other SVG modules are supported by SVG Native. This includes:
 - <a href="https://www.w3.org/TR/filter-effects-1/">CSS Filter Effects</a>
 - <a href="https://svgwg.org/specs/animations/">SVG Animations</a>
+
+Rendering Model {#render}
+=========================
+
+SVG Native does not support masking.
+
+The following attributes are not supported by SVG Native:
+- 'clipPathUnits'
+- 'clip'
+
+The ''scroll'' value on the 'overflow' property behaves identically to 'hidden'.
+
+The 'clip-path' attribute is not supported on a <{clipPath}> element.
+
+Every <{clipPath}> element must have either exactly zero or exactly one child. Anything more than that is not supported by SVG Native.
+
+The ''scroll'' and the ''auto'' values of the 'overflow' property are not supported by SVG Native.
 
 Document Structure {#struct}
 ============================
@@ -117,6 +136,9 @@ Elements in foreign namespaces, except the xlink (<code>http://www.w3.org/1999/x
 <{image}> elements must only contain base64-encoded <code>data:</code> URLs of [[!JPEG]] or [[!PNG]] images. [[!APNG]] images must be rendered without animation, using standard backward-compatibility with static [[!PNG]] images. All other image formats must be ignored.
 
 All external resource loading is forbidden.
+
+The <{symbol}> element is not supported by SVG Native.
+<!-- https://www.w3.org/2019/07/15-svg-minutes.html -->
 
 Styling {#styling}
 ==================
@@ -215,12 +237,15 @@ The 'display' attribute is not supported by SVG Native.
 Note: Hiding elements can be achieved with the 'visibility' attribute.
 
 The <{marker}> element is not supported by SVG Native, nor are the 'marker', 'marker-start', 'marker-mid', and 'marker-end' properties.
+<!-- https://www.w3.org/2019/07/15-svg-minutes.html -->
 
 The ''context-fill'' and ''context-stroke'' values are not supported by SVG Native.
 
 Note: Authors wishing to use a contextual color from the environment may use ''currentColor''.
+<!-- https://www.w3.org/2019/06/17-svg-minutes.html -->
 
 The <{color}> property is not supported by SVG Native.
+<!-- https://www.w3.org/2019/06/17-svg-minutes.html -->
 
 Note: The absence of <{color}> makes it impossible to change the value of ''currentColor'' from its initial value.
 
@@ -231,28 +256,13 @@ All color interpolation occurs in the sRGB color space.
 Gradients and Patterns {#pservers}
 ==================================
 
-The following attributes are forbidden:
-- 'gradientUnits'
-- 'xlink:href' on <{linearGradient}> or <{radialGradient}>
+Only the ''userSpaceOnUse'' value of 'gradientUnits' is supported. According to [[!SVG2]], the default value of 'gradientUnits' is ''objectBoundingBox'', which isn't supported. This means that all <{gradient}> elements must include <code>gradientUnits="userSpaceOnUse"</code> to be valid.
+<!-- https://www.w3.org/2019/11/04-svg-minutes.html -->
 
-Delete section 13.3: Patterns.
+<!-- href is supported on gradients. https://www.w3.org/2019/07/15-svg-minutes.html -->
 
-Clipping, Masking, and Compositing {#masking}
-=============================================
-
-Delete section 14.4: Masking.
-
-The following attributes are forbidden:
-- 'clipPathUnits'
-- 'clip'
-
-The ''scroll'' value on the 'overflow' property behaves identically to 'hidden'.
-
-The 'clip-path' attribute must not be present on a <{clipPath}> element.
-
-Every <{clipPath}> element must have either exactly zero or exactly one child.
-
-The ''scroll'' and the ''auto'' values of the 'overflow' property are forbidden.
+The <{pattern}> element is not supported by SVG Native.
+<!-- https://www.w3.org/2019/07/15-svg-minutes.html -->
 
 Scripting and Interactivity {#interact}
 =======================================

--- a/specs/svg-native/index.bs
+++ b/specs/svg-native/index.bs
@@ -48,11 +48,11 @@ SVG Native is designed to fit a number of use cases.
 Basics {#basics}
 ----------------
 
-SVG Native is presented as a series of modifications of [[!SVG11]]. These modifications are applied as differences from that specification.
+SVG Native is presented as a series of modifications of [[!SVG2]]. These modifications are applied as differences from that specification. Rather than being a strict line-by-line diff, this specification describes the differences directly.
 
-Note: This spec will likely be rebased on [[!SVG2]] in the near future.
+There are numerous differences between the SVG Native format and the [[!SVG2]] format. Currently, all differences are reductive; all functionality in SVG Native is also present in [[!SVG2]]. A conforming SVG Native document must only include functionality present in the SVG Native format. A conforming SVG Native renderer should ignore any functionality requested by a document that is not present in the SVG Native format. If a SVG Native renderer intentionally chooses to honor functionality beyond the SVG Native specification, it must do so in accordance with the [[!SVG2]] specification.
 
-If the engine encounters an element or attribute that is forbidden, not supported, or not included in this specification, that element or attribute must be disregarded.
+Note: If a document uses parts of SVG that aren't part of SVG Native, then it isn't a conformant SVG Native document. When an SVG Native renderer opens such a file, it should ignore all of those parts. Therefore, all SVG Native renderers should produce the same rendering for the same document. However, there may be renderers which intentionally decide to honor parts of SVG that aren't part of SVG Native. In order to make it more likely that a given document's rendering is predictable, even in these renderers, SVG Native authoring tools are recommended to always emit documents that conform to this specification. The SVG Working Group is considering producing a validator to determine whether a given document is conformant to the SVG Native format.
 
 SVG Native is a standalone file type, expected to be rendered with a dedicated-purpose renderer. Therefore, SVG Native content must not be present as part of a larger XML (or HTML) document. If it is present as part of a larger XML (or HTML) document, the content should be interpreted as SVG proper.
 

--- a/specs/svg-native/index.bs
+++ b/specs/svg-native/index.bs
@@ -48,7 +48,7 @@ SVG Native is designed to fit a number of use cases.
 Basics {#basics}
 ----------------
 
-SVG Native is presented as a series of modifications of [[!SVG2]]. These modifications are applied as differences from that specification. Rather than being a strict line-by-line diff, this specification describes the differences directly.
+SVG Native is presented as a series of modifications of the <a href="https://svgwg.org/svg2-draft/conform.html#secure-static-mode">Secure Static Mode</a> of [[!SVG2]]. These modifications are applied as differences from that specification. Rather than being a strict line-by-line diff, this specification describes the differences directly.
 
 If functionality present in [[!SVG2]] isn't present in the SVG Native specification, SVG Native includes that functionality.
 <!-- https://www.w3.org/2019/04/15-svg-minutes.html -->
@@ -131,9 +131,9 @@ Conditional processesing attributes and elements are not supported in SVG Native
 
 The <{meta}> and <{metadata}> elements are not supported in SVG Native.
 
-Elements in foreign namespaces, except the xlink (<code>http://www.w3.org/1999/xlink</code>) namespace, are not supported in SVG Native.
+Elements in foreign namespaces are not supported in SVG Native. Attributes in foreign namespaces, except the xlink (<code>http://www.w3.org/1999/xlink</code>) namespace, are not supported in SVG Native.
 
-<{image}> elements must only contain base64-encoded <code>data:</code> URLs of [[!JPEG]] or [[!PNG]] images. [[!APNG]] images must be rendered without animation, using standard backward-compatibility with static [[!PNG]] images. All other image formats must be ignored.
+Because SVG Native is a subset of [[!SVG2]]'s Secure Static mode, only <{image}> elements which contain base64-encoded <code>data:</code> URLs of [[!JPEG]] or [[!PNG]] images are supported. [[!APNG]] images are be rendered without animation, using standard backward-compatibility with static [[!PNG]] images. No other image format is supported by SVG Native.
 
 All external resource loading is forbidden.
 
@@ -143,14 +143,18 @@ The <{symbol}> element is not supported by SVG Native.
 Styling {#styling}
 ==================
 
-The <{style}> element and the 'style' attribute is not supported in SVG Native.
+The <{style}> element and the 'style' attribute are not supported in SVG Native.
 <!-- https://www.w3.org/2019/05/06-svg-minutes.html -->
+
+Note: Style properties can be set by presentation attributes, which must be parsed and processed according to the SVG and CSS specifications, other than the specific restrictions outlined in this section.
 
 ''calc()'' is not supported by SVG Native.
 
 ''env()'' and ''var()'' are supported by SVG Native.
 <!-- https://www.w3.org/2019/05/06-svg-minutes.html -->
 <!-- https://www.w3.org/2019/05/20-svg-minutes.html -->
+
+Note: Because of the other restrictions on styling, there is no way to set new values to CSS custom properties inside an SVG Native document. However, some rendering environments (e.g., for SVG fonts) will expose custom property values from an external document, as if they were inherited by the root element of the SVG Native document; the `var()` function can therefore be used similar to the `env()` function, to access this value if it exists and set a fallback value if it doesn't.
 
 The CSS 'all' property is not supported by SVG Native.
 
@@ -170,13 +174,9 @@ Percentage length values are not supported by SVG Native.
 Geometry Properties {#geometryproperties}
 =========================================
 
-The grammar for the 'cx', 'cy', 'r', 'rx', 'ry', 'x', 'y', 'width', and 'height' properties is:
+Keyword values, such as ''auto'', are not supported in the 'cx', 'cy', 'r', 'rx', 'ry', 'x', 'y', 'width', and 'height' attributes.
 
-<code><<number>> | <<length>> | <<percentage>></code>
-
-A bare number behaves as if ''px'' is specified.
-
-Note: The ''auto'' value is not supported in the 'cx', 'cy', 'r', 'rx', 'ry', 'x', 'y', 'width', and 'height' properties.
+Note: Raw numbers are supported by these attributes, in accordance with the [[!SVG2]] rules on parsing presentation attributes.
 
 Coordinate Systems, Transformations, and Units {#coords}
 ========================================================

--- a/specs/svg-native/index.bs
+++ b/specs/svg-native/index.bs
@@ -72,8 +72,33 @@ User agents may limit the reference depth of references to implementation-depend
 
 XSL Processing is not supported by SVG Native.
 
+No namespaces other than <a href="https://www.w3.org/TR/xlink11/">xlink</a> are supported inside an SVG Native document. From the xlink namespace, only 'href' is supported.
+
 A valid SVG Native document must not contain any of the external or internal XML DTD subset.
 <!-- https://www.w3.org/2019/04/29-svg-minutes.html -->
+
+Common Attributes {#commonattributes}
+-------------------------------------
+
+SVG 2.0 defines sets of common attributes wich might apply to multiple elements. These sets of attributes are not supported by SVG Native:
+- aria attributes
+- conditional processing attributes
+- all core attributes except for 'id'
+- global event attributes
+- document element event attributes
+- graphical event attributes
+- deprecated xlink attributes except for 'xlink:href'
+- 'crossorigin'
+
+SVG Modules {#modules}
+----------------------
+
+SVG Native is a subset of the content in the [[!SVG2]] specification, and some associated modules. They are:
+- <a href="https://www.w3.org/TR/2018/REC-css-color-3-20180619/">CSS Color</a>
+
+No other SVG modules are supported by SVG Native. This includes:
+- <a href="https://www.w3.org/TR/filter-effects-1/">CSS Filter Effects</a>
+- <a href="https://svgwg.org/specs/animations/">SVG Animations</a>
 
 Document Structure {#struct}
 ============================
@@ -85,7 +110,7 @@ Conditional processesing attributes and elements are not supported in SVG Native
 
 <!-- There are too many things which are unobservable in SVG Native. Don't need to list them all out. -->
 
-The <{meta}> element is not supported in SVG Native.
+The <{meta}> and <{metadata}> elements are not supported in SVG Native.
 
 Elements in foreign namespaces, except the xlink (<code>http://www.w3.org/1999/xlink</code>) namespace, are not supported in SVG Native.
 
@@ -168,41 +193,40 @@ The 'preserveAspectRatio' attribute is only supported by SVG Native on the follo
 Paths {#paths}
 ==============
 
-The 'pathLength' attribute on the <{path}> element is forbidden.
-
-Basic Shapes {#shapes}
-======================
-
-Chapter is unchanged.
+The 'pathLength' attribute on the <{path}> element is not supported by SVG Native.
 
 Text {#text}
 ============
 
-Entire chapter is deleted.
+All text and fonts facilities are not supported by SVG Native. This includes <{text}>, <{tspan}>, <{textPath}>, <{font}>, <{glyph}>, <{missingGlyph}>, <{hkern}>, <{vkern}>, <{font-face}>, <{font-face-src}>, <{font-face-uri}>, <{font-face-format}>, <{font-face-name}>, 'inline-size', 'shape-inside', 'shape-subtract', 'shape-image-threshold', 'shape-margin', 'shape-padding', 'text-anchor', 'glyph-orientation-horizontal', 'glyph-orientation-vertical', 'kerning', 'text-overflow', 'xml:space', 'text-decoration-fill', 'text-decoration-stroke', 'letter-spacing', 'text-align', 'text-align-last', 'text-indent', 'word-spacing', 'white-space', 'vertical-align', 'dominant-baseline', 'alignment-baseline', 'baseline-shift', 'direction', 'text-orientation', 'writing-mode', 'font', 'font-family', 'font-feature-settings', 'font-kerning', 'font-size', 'font-size-adjust', 'font-stretch', 'font-style', 'font-variant', the subproperties of 'font-variant', 'font-weight', 'text-decoration', 'text-decoration-line', 'text-decoration-style', 'text-decoration-color', and 'text-rendering'.
 
-Note: This means that all text facilities are forbidden in SVG Native.
+Embedded Content {#embedded}
+============================
+
+HTML elements in SVG subtrees are not supported by SVG Native.
+
+<{foreignObject}> is not supported by SVG Native.
 
 Painting: Filling, Stroking, and Marker Symbols {#painting}
 ===========================================================
 
-The 'display' attribute is forbidden. Hiding elements can be achieved with the 'visibility' attribute.
+The 'display' attribute is not supported by SVG Native.
 
-Delete section 11.6.2 The <{marker}> element.
+Note: Hiding elements can be achieved with the 'visibility' attribute.
 
-The 'color-interpolation' attribute is forbidden. All color interpolation occurs in the sRGB color space.
+The <{marker}> element is not supported by SVG Native, nor are the 'marker', 'marker-start', 'marker-mid', and 'marker-end' properties.
 
-Color {#color}
-==============
+The ''context-fill'' and ''context-stroke'' values are not supported by SVG Native.
 
-Delete section 12.2: The 'color' property.
+Note: Authors wishing to use a contextual color from the environment may use ''currentColor''.
 
-Note: In some environments, the ''currentColor'' keyword is used to provide surrounding context to the SVG graphic. For example, in a color font glyph, ''currentColor'' may represent the text color of the surrounding line. Therefore, support of ''currentColor'' is required, but support of the 'color' property to change ''currentColor'' is not supported.
+The <{color}> property is not supported by SVG Native.
 
-Delete section 12.3: Color profile descriptions.
+Note: The absence of <{color}> makes it impossible to change the value of ''currentColor'' from its initial value.
 
-Note: This specification will likely adopt [[!SVG2]]'s syntax for specifying colors outside of sRGB.
+The 'vector-effect', 'paint-order', 'color-interpolation', and 'will-change' attributs are not supported by SVG Native.
 
-ISSUE: What should we do about non-sRGB color spaces?
+All color interpolation occurs in the sRGB color space.
 
 Gradients and Patterns {#pservers}
 ==================================
@@ -230,63 +254,14 @@ Every <{clipPath}> element must have either exactly zero or exactly one child.
 
 The ''scroll'' and the ''auto'' values of the 'overflow' property are forbidden.
 
-Filter Effects {#filters}
-=========================
+Scripting and Interactivity {#interact}
+=======================================
 
-Entire chapter is deleted.
-
-Note: This means that all filter facilities are forbidden in SVG Native.
-
-Interactivity {#interact}
-==============================
-
-Entire chapter is deleted.
-
-Note: This means that all interactivity facilities are forbidden in SVG Native.
+All scripting and interactivity facilities are not supported by SVG Native. This includes the 'pointer-events' and 'zoomAndPan' attributes and the <{script}> element. No contents of the SVG Native document are focusable.
 
 Linking {#linking}
 ==================
 
-All external resource loading is forbidden.
+All external resource loading is forbidden. All URLs must either be a data URL or only consist of a fragment identifier.
 
-Delete section 17.2: Links out of SVG content: the <{a}> element.
-
-Delete section 17.3.3: Predefined views: the <{view}> element.
-
-Scripting {#script}
-===================
-
-Entire chapter is deleted.
-
-Note: This means that all scripting facilities are forbidden in SVG Native.
-
-Animation {#animate}
-====================
-
-Entire chapter is deleted.
-
-Note: This means that all animation facilities are forbidden in SVG Native.
-
-Fonts {#fonts}
-==============
-
-Entire chapter is deleted.
-
-Note: This means that all font facilities are forbidden in SVG Native.
-
-Metadata {#metadata}
-====================
-
-Entire chapter is deleted.
-
-Note: This means that all metadata facilities are forbidden in SVG Native. Because the engine must ignore document constructs that aren't included in this specification, it means metadata is ignored. This may be what the author intends.
-
-Backwards Compatibility {#backward}
-===================================
-
-Entire chapter is deleted.
-
-Extensibility {#extend}
-=======================
-
-Delete section 23.3: The <{foreignObject}> element.
+The <{a}> element and <{view}> elements are not supported by SVG Native.


### PR DESCRIPTION
This reorganizes the SVG Native spec to match SVG 2. I don't believe there are any (meaningful) behavior changes.

While doing this, I also included all the resolutions the SVG WG has made. A link to each resolution is included in a comment in the source.

This should catch the SVG Native spec up with current discussion.