### PR TITLE
Make the .gitignore patterns more robust, and simpler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,3 @@
+*.swp
 build/
-build/specs/integration/build/
-build/specs/template/build/
-master/issue-state.txt
-specs/animations/master/issue-state.txt
-specs/integration/master/issue-state.txt
-specs/markers/master/issue-state.txt
-specs/paths/master/issue-state.txt
-specs/strokes/master/issue-state.txt
-specs/svg-native/index.html
+issue-state.txt


### PR DESCRIPTION
 - We don't need to mention subdirectories of 'build', since we're
   ignoring that already.

 - Ignoring all files with the name 'issue-state.txt' instead of
   having to manually add them each time we add one.

 - Ignore *.swp files.