### PR TITLE
Remove glyph-orientation-horizontal presentation attribute

### DIFF
--- a/master/styling.html
+++ b/master/styling.html
@@ -445,7 +445,6 @@ the presentation attribute name is the same as the property name, in lower-case 
       <a>'font-style'</a>,
       <a>'font-variant'</a>,
       <a>'font-weight'</a>,
-      <a>'glyph-orientation-horizontal'</a>,
       <a>'glyph-orientation-vertical'</a>,
       <a>'image-rendering'</a>,
       <a>'letter-spacing'</a>,


### PR DESCRIPTION
The property itself has already been removed.