### PR TITLE
Fix missing trailing wsp after path commands

### DIFF
--- a/master/paths.html
+++ b/master/paths.html
@@ -800,7 +800,11 @@ SVG arc notation to a format that uses center points and arc sweeps.
 
 <p>SVG path data matches the following EBNF grammar.</p>
 <pre class='grammar ready-for-wider-review'>
-svg_path::= wsp* moveto? (moveto drawto_command*)?
+svg_path::= wsp* (moveto wsp* drawto_command_group*)? wsp*
+
+drawto_command_group::=
+    drawto_command
+    | drawto_command wsp* drawto_command_group
 
 drawto_command::=
     moveto

--- a/master/paths.html
+++ b/master/paths.html
@@ -800,11 +800,7 @@ SVG arc notation to a format that uses center points and arc sweeps.
 
 <p>SVG path data matches the following EBNF grammar.</p>
 <pre class='grammar ready-for-wider-review'>
-svg_path::= wsp* (moveto wsp* drawto_command_group*)? wsp*
-
-drawto_command_group::=
-    drawto_command
-    | drawto_command wsp* drawto_command_group
+svg_path::= wsp* (moveto (wsp* drawto_command)*)? wsp*
 
 drawto_command::=
     moveto


### PR DESCRIPTION
Hello SVG WG.

I'm currently implementing an SVG Path parser and it appears that the SVG2 path grammar is a little inconsistent with SVG 1.1 and with other current implementations (AFAIK those from web browsers).

Many details have been discussed in issue #752 (mostly point 1 and 2 raised by @dalboris)

This PR is a proposed fix for the missing trailing white spaces after commands and at end of path. The intent is to prevent a breaking change to the SVG Path grammar. If the SVG WG think this breaking change should be kept, so it should be clearly stated (exactly like the warn done for numbers with trailing dot). If so, I would be glad to update this PR accordingly.

+@dalboris