### PR TITLE
Fix prose about H and V path commands

### DIFF
--- a/master/paths.html
+++ b/master/paths.html
@@ -484,9 +484,11 @@ current point to a new point:</p>
     absolute coordinates will follow; <strong>v</strong>
     (lowercase) indicates that relative coordinates will
     follow. Multiple y values can be provided (although usually
-    this doesn't make sense).  A <strong>V</strong> or <strong>v</strong>
-    command is equivalent to an <strong>L</strong> or <strong>l</strong>
-    command with 0 specified for the x coordinate.
+    this doesn't make sense). A <strong>v</strong> command is
+    equivalent to an <strong>l</strong> command with 0 specified
+    for the x coordinate. A <strong>V</strong> command is
+    equivalent to an <strong>L</strong> command with the x coordinate
+    being equal to the absolute x coordinate of the current point.
     At the end of the command, the new current point is
     taken from the final coordinate value.</td>
   </tr>

--- a/master/paths.html
+++ b/master/paths.html
@@ -466,9 +466,11 @@ current point to a new point:</p>
     that absolute coordinates will follow; <strong>h</strong>
     (lowercase) indicates that relative coordinates will
     follow. Multiple x values can be provided (although usually
-    this doesn't make sense). An <strong>H</strong> or <strong>h</strong>
-    command is equivalent to an <strong>L</strong> or <strong>l</strong>
-    command with 0 specified for the y coordinate.
+    this doesn't make sense). An <strong>h</strong> command is
+    equivalent to an <strong>l</strong> command with 0 specified
+    for the y coordinate. An <strong>H</strong> command is
+    equivalent to an <strong>L</strong> command with the y coordinate
+    being equal to the absolute y coordinate of the current point.
     At the end of the command, the new current point is
     taken from the final coordinate value.</td>
   </tr>


### PR DESCRIPTION
Hi SVGWG,

The [current wording of the H command](https://svgwg.org/svg2-draft/paths.html#PathDataLinetoCommands) state that: 

> An **H** or **h** command is equivalent to an **L** or **l** command with 0 specified for the y coordinate.

This means that `M1,1 l5,5 H10` is equivalent to `M1,1 l5,5 L10,0` which is not the case.

All browsers (for the lack of other SVG rendering engines) consider that `M1,1 l5,5 H10` is actually equivalent to `M1,1 l5,5 L10,6` which makes more sens.

As a consequence I suggest the following change in prose to fix that spec issue:

> An **h** command is equivalent to an **l** command with 0 specified for the y coordinate. An **H** command is equivalent to an **L** command with the y coordinate being equal to the absolute y coordinate of the current point.

Because V is worded the same way (but for the x coordinate instead of the y coordinate), I'm also suggesting an equivalent change for the V command.