### PR TITLE
Replace AbstractView with WindowProxy/Window

### DIFF
--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -1148,6 +1148,7 @@
   <interface name='Node' href='https://dom.spec.whatwg.org/#interface-node'/>
   <interface name='NodeList' href='https://dom.spec.whatwg.org/#interface-nodelist'/>
   <interface name='Window' href='https://html.spec.whatwg.org/multipage/window-object.html#window'/>
+  <interface name='WindowProxy' href='https://html.spec.whatwg.org/multipage/window-object.html#windowproxy'/>
   <interface name='WindowEventHandlers' href='https://html.spec.whatwg.org/multipage/webappapis.html#windoweventhandlers'/>
   <interface name='Animation' href='https://www.w3.org/TR/web-animations-1/#the-animation-interface' />
   <interface name='isPointInPath' href='https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-ispointinpath' />

--- a/specs/animations/master/Overview.html
+++ b/specs/animations/master/Overview.html
@@ -3294,21 +3294,20 @@ contextual information associated with Time events.</p>
 
 <pre class="idl">interface <b>TimeEvent</b> : <a>Event</a> {
 
-  readonly attribute <a>AbstractView</a> <a href="#__svg__TimeEvent__view">view</a>;
+  readonly attribute <a>WindowProxy</a>? <a href="#__svg__TimeEvent__view">view</a>;
   readonly attribute long <a href="#__svg__TimeEvent__detail">detail</a>;
 
-  void <a href="#__svg__TimeEvent__initTimeEvent">initTimeEvent</a>(DOMString typeArg, <a>AbstractView</a> viewArg, long detailArg);
+  void <a href="#__svg__TimeEvent__initTimeEvent">initTimeEvent</a>(DOMString typeArg, <a>Window</a>? viewArg, long detailArg);
 };</pre>
 
 <dl class="interface">
   <dt class="attributes-header">Attributes:</dt>
   <dd>
     <dl class="attributes">
-      <dt id="__svg__TimeEvent__view" class="attribute first-child"><b>view</b><span class="idl-type-parenthetical"> (readonly <a>AbstractView</a>)</span></dt>
+      <dt id="__svg__TimeEvent__view" class="attribute first-child"><b>view</b><span class="idl-type-parenthetical"> (readonly <a>WindowProxy</a>?)</span></dt>
       <dd class="attribute">
-        <div>The <a>TimeEvent::view</a> attribute identifies the <a>AbstractView</a>
-        [<a href="#ref-DOM2VIEWS">DOM2VIEWS</a>] from which the event
-        was generated.</div>
+        <div>The <a>TimeEvent::view</a> attribute identifies the <a>Window</a>
+        from which the event was generated.</div>
       </dd>
       <dt id="__svg__TimeEvent__detail" class="attribute"><b>detail</b><span class="idl-type-parenthetical"> (readonly long)</span></dt>
       <dd class="attribute">
@@ -3321,7 +3320,7 @@ contextual information associated with Time events.</p>
   <dt class="operations-header">Operations:</dt>
   <dd>
     <dl class="attributes">
-      <dt id="__svg__TimeEvent__initTimeEvent" class="operation first-child">void <b>initTimeEvent</b>(DOMString <var>typeArg</var>, <a>AbstractView</a> <var>viewArg</var>, long <var>detailArg</var>)</dt>
+      <dt id="__svg__TimeEvent__initTimeEvent" class="operation first-child">void <b>initTimeEvent</b>(DOMString <var>typeArg</var>, <a>Window</a>? <var>viewArg</var>, long <var>detailArg</var>)</dt>
       <dd class="operation">
         <div>The <a>TimeEvent::initTimeEvent</a> method is used to initialize the value of a
         <a>TimeEvent</a> created with <code>document.createEvent()</code>. This
@@ -3338,8 +3337,8 @@ contextual information associated with Time events.</p>
                 <div>Specifies the event type.</div>
               </li>
               <li class="parameter">
-                <div><a>AbstractView</a> <var>viewArg</var></div>
-                <div>Specifies the Event's <a>AbstractView</a>.</div>
+                <div><a>Window</a>? <var>viewArg</var></div>
+                <div>Specifies the Event's <a>Window</a>.</div>
               </li>
               <li class="parameter">
                 <div>long <var>detailArg</var></div>


### PR DESCRIPTION
AbstractView is an obsolete term from DOM2\[0\]. The Gecko implementation
of TimeEvent uses WindowProxy and Window instead\[1\], so this change
aligns the spec with that.

Fixes https://github.com/w3c/svgwg/issues/775

[0]: https://www.w3.org/TR/DOM-Level-2-Views/views.html#Views-AbstractView
[1]: https://github.com/mozilla/gecko-dev/blob/cfd1cc461f1efe0d66c2fdc17c024a203d5a2fd8/dom/webidl/TimeEvent.webidl#L17