### PR TITLE
textPath example: Replace `path` attribute with `d`

### DIFF
--- a/master/text.html
+++ b/master/text.html
@@ -4413,7 +4413,7 @@
 style="font-weight:bold; color:red">transform="translate(25,25)"</span>&gt;
     &lt;defs&gt;
       &lt;path id="path1" <span
-style="font-weight:bold; color:green">transform="scale(2)"</span> path="M0,10 L40,20 80,10" fill="none" stroke="red"/&gt;
+style="font-weight:bold; color:green">transform="scale(2)"</span> d="M0,10 L40,20 80,10" fill="none" stroke="red"/&gt;
     &lt;/defs&gt;
   &lt;/g&gt;
   &lt;text <span
@@ -4433,7 +4433,7 @@ style="font-weight:bold; color:blue">transform="rotate(45)"</span>&gt;
 style="font-weight:bold; color:blue">transform="rotate(45)"</span>&gt;
     &lt;defs&gt;
       &lt;path id="path1" <span
-style="font-weight:bold; color:green">transform="scale(2)"</span> path="M0,10 L40,20 80,10" fill="none" stroke="red"/&gt;
+style="font-weight:bold; color:green">transform="scale(2)"</span> d="M0,10 L40,20 80,10" fill="none" stroke="red"/&gt;
     &lt;/defs&gt;
     &lt;text&gt;
       &lt;textPath href="#path1"&gt;Text on a path&lt;/textPath&gt;


### PR DESCRIPTION
No name change for `d` attribute. See ANNOTATION 1:
https://www.w3.org/TR/SVG/paths.html#PathElement