### PR TITLE
Drop the [NoInterfaceObject] for SVGPathSegment

### DIFF
--- a/specs/paths/master/Overview.html
+++ b/specs/paths/master/Overview.html
@@ -1368,7 +1368,7 @@ commands contribute to path length calculations.</p>
 The <a>SVGPathSegment</a> interface is a base interface that corresponds to a
 single command within a path data specification.
 
-<pre class="idl">[NoInterfaceObject]
+<pre class="idl">
 interface <b>SVGPathSegment</b> {
   DOMString type;
   sequence&lt;float> values;

--- a/specs/paths/master/Overview.html
+++ b/specs/paths/master/Overview.html
@@ -1370,8 +1370,8 @@ single command within a path data specification.
 
 <pre class="idl">
 interface <b>SVGPathSegment</b> {
-  DOMString type;
-  sequence&lt;float> values;
+  attribute DOMString type;
+  attribute FrozenArray&lt;float> values;
 };</pre>
 
 <dl class="interface">
@@ -1397,7 +1397,7 @@ The <a>SVGPathData</a> interface provides a way to get and set path data.
 <pre class="idl">
 dictionary <b id="InterfaceSVGPathDataSettings">SVGPathDataSettings</b> {
    boolean normalize = false;
-}
+};
 
 interface mixin <b>SVGPathData</b> {
    sequence&lt;<a>SVGPathSegment</a>> getPathData(optional <a>SVGPathDataSettings</a> settings);


### PR DESCRIPTION
This has been renamed in Web IDL:
https://heycam.github.io/webidl/#LegacyNoInterfaceObject

However, if the interface is implemented, it would be best to expose it for feature detection.