### PR TITLE
Number grammar adjusted

### DIFF
--- a/specs/paths/master/Overview.html
+++ b/specs/paths/master/Overview.html
@@ -1202,7 +1202,7 @@ coordinate_pair::= coordinate comma_wsp? coordinate
 coordinate::= sign? number
 
 sign::= "+"|"-"
-number ::= ([0-9])+
+number ::= ( ([0-9])+ | ([0-9])+ "." | ([0-9])+ "." ([0-9])+ )
 flag::=("0"|"1")
 comma_wsp::=(wsp+ ","? wsp*) | ("," wsp*)
 wsp ::= (#x9 | #x20 | #xA | #xC | #xD)


### PR DESCRIPTION
Number grammar now includes floating-point integers instead of only integers.

Fixes #815 
> This issue concerns a wrong grammar definition in `specs/paths/master/Overview.html` in the section on _The grammar for path data_. The link to which can be found [here](https://www.w3.org/TR/SVG/paths.html#PathDataBNF).
> 
> One will find the grammar definition for a _number_ given as:
> 
> ```
> number ::= ([0-9])+
> ```
> 
> This is a fault because it does not include floating-point integers.
> 
> Probably this should be:
> 
> ```
> number ::= ( ([0-9])+ | ([0-9])+ "." | ([0-9])+ "." ([0-9])+ )
> ```