### PR TITLE
[color] Double link wraps in Bikeshed

### DIFF
--- a/specs/color/Overview.bs
+++ b/specs/color/Overview.bs
@@ -75,7 +75,7 @@ If ICC-based colors are provided,
 then the ICC-based color takes precedence over the sRGB color specification;
 otherwise, the sRGB fallback colors will be used.
 Note that, in this specification, by default color interpolation occurs in sRGB color space even if an
-ICC-based color specification is provided, but this can be changed (see <a>'color-interpolation'</a>).</p>
+ICC-based color specification is provided, but this can be changed (see 'color-interpolation').</p>
   
   <div class="ready-for-wider-review">
     <h2 id="color-managed-images">Color-managed images</h2>
@@ -217,7 +217,7 @@ ICC-based color specification is provided, but this can be changed (see <a>'colo
       name descriptor matches &lt;name&gt; and uses the last matching entry that is found;
       painting shall be done using the given ICC color, where the comma-separated list
       (with optional white space) of <strong>&lt;icccolorvalue&gt;</strong>'s is a set
-      of ICC-profile-specific color values, expressed as <a>&lt;number&gt;</a>s
+      of ICC-profile-specific color values, expressed as <<number>>'s
       (see <a href="#icc-colors">ICC colors</a>). If no match is
       found, then the fallback sRGB color is used.
     </p>
@@ -370,18 +370,18 @@ ICC-based color specification is provided, but this can be changed (see <a>'colo
 <h2 id="ColorProperty">The effect of the <span class="property">'color'</span> property</h2>
 
 <p class="note">See the CSS Color Module Level 3 specification for the
-definition of <a>'color'</a>.
+definition of 'color'.
 [<a href="refs.html#ref-CSS3COLOR">CSS3COLOR</a>]</p>
 
-<p>The <a>'color'</a> property is used to provide a potential indirect value,
-<span class="prop-value">currentColor</span>, for the <a>'fill'</a>,
-<a>'stroke'</a>, <a>'solid-color'</a>, <a>'stop-color'</a>, <a>'flood-color'</a> and
-<a>'lighting-color'</a> properties.  The property has no other effect
+<p>The 'color' property is used to provide a potential indirect value,
+<span class="prop-value">currentColor</span>, for the 'fill',
+'stroke', 'solid-color', 'stop-color', 'flood-color' and
+'lighting-color' properties.  The property has no other effect
 on SVG elements.</p>
 
 <div class="example">
   <p>The following example shows how the inherited value of the
-  <a>'color'</a> property from an HTML document can be used to
+  'color' property from an HTML document can be used to
   set the color of SVG text in an inline SVG fragment.</p>
 
   <pre>
@@ -412,7 +412,7 @@ svg { border: 1px solid #888; background-color: #eee }
       </svg>
     </div>
     <p class="caption">The text and arrow in the SVG fragment are filled
-    with the same color as the inherited <a>'color'</a> property.</p>
+    with the same color as the inherited 'color' property.</p>
   </div>
 </div>
 </div>
@@ -553,8 +553,8 @@ child elements.</p>
   <dt><span class='prop-value'><a>&lt;identifier&gt;</a></span></dt>
   <dd>The name which is used as the first parameter for <span
   class="prop-value">icc-color</span> specifications within
-  <a>'fill'</a>, <a>'stroke'</a>, <a>'stop-color'</a>,
-  <a>'flood-color'</a> and <a>'lighting-color'</a> property
+  'fill', 'stroke', 'stop-color',
+  'flood-color' and 'lighting-color' property
   values to identify the color profile to use for the ICC
   color specification.  Note that if 'name' is not
   provided, it will be impossible to reference the given @color-profile


### PR DESCRIPTION
The plain `<a>` wrapping was making a nested link with the `'` linking.

/cc @tabatkins in case there was a better wrapping to use here