### PR TITLE
Use constructor operation for ShadowAnimation

### DIFF
--- a/master/struct.html
+++ b/master/struct.html
@@ -3209,8 +3209,9 @@ or is null otherwise.</p>
 </p>
 
 
-<pre class="idl">[<i>Constructor</i>(<a>Animation</a> source, <a>Animatable</a> newTarget), Exposed=Window]
+<pre class="idl">[Exposed=Window]
 interface <b>ShadowAnimation</b> : <a>Animation</a> {
+  constructor(<a>Animation</a> source, <a>Animatable</a> newTarget);
   [SameObject] readonly attribute <a>Animation</a> <a href="#__svg__ShadowAnimation__sourceAnimation">sourceAnimation</a>;
 };</pre>
 


### PR DESCRIPTION
The Constructor extended attribute has been removed from Web IDL.