### PR TITLE
[svg-paths] Add default value {} to getPathData argument

### DIFF
--- a/specs/paths/master/Overview.html
+++ b/specs/paths/master/Overview.html
@@ -1400,7 +1400,7 @@ dictionary <b id="InterfaceSVGPathDataSettings">SVGPathDataSettings</b> {
 }
 
 interface mixin <b>SVGPathData</b> {
-   sequence&lt;<a>SVGPathSegment</a>> getPathData(optional <a>SVGPathDataSettings</a> settings);
+   sequence&lt;<a>SVGPathSegment</a>> getPathData(optional <a>SVGPathDataSettings</a> settings = {});
    void setPathData(sequence&lt;<a>SVGPathSegment</a>> pathData);
 };</pre>
 


### PR DESCRIPTION
This is required by Web IDL.