### PR TITLE
Add remaining [Exposed=Window] where still missing

### DIFF
--- a/master/types.html
+++ b/master/types.html
@@ -759,6 +759,7 @@ is to directly render graphics into a group.</p>
   boolean clipped = false;
 };
 
+[Exposed=Window]
 interface <b>SVGGraphicsElement</b> : <a>SVGElement</a> {
   [SameObject] readonly attribute <a>SVGAnimatedTransformList</a> <a href="types.html#__svg__SVGGraphicsElement__transform">transform</a>;
 

--- a/specs/animations/master/Overview.html
+++ b/specs/animations/master/Overview.html
@@ -3292,7 +3292,8 @@ contextual information associated with Time events.</p>
   </dd>
 </dl>
 
-<pre class="idl">interface <b>TimeEvent</b> : <a>Event</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>TimeEvent</b> : <a>Event</a> {
 
   readonly attribute <a>WindowProxy</a>? <a href="#__svg__TimeEvent__view">view</a>;
   readonly attribute long <a href="#__svg__TimeEvent__detail">detail</a>;
@@ -3401,7 +3402,8 @@ times, as described in
   ([<a href="#ref-SMILANIM">SMILANIM</a>], section 3.3.7).</li>
 </ul>
 
-<pre class="idl">interface <b>SVGAnimationElement</b> : <a>SVGElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGAnimationElement</b> : <a>SVGElement</a> {
 
   readonly attribute <a>SVGElement</a>? <a href="#__svg__SVGAnimationElement__targetElement">targetElement</a>;
 
@@ -3562,7 +3564,8 @@ element.</p>
 <p>Object-oriented access to the attributes of the <a>'animate'</a> element
 via the SVG DOM is not available.</p>
 
-<pre class="idl">interface <b>SVGAnimateElement</b> : <a>SVGAnimationElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGAnimateElement</b> : <a>SVGAnimationElement</a> {
 };</pre>
 
 </edit:with>
@@ -3577,7 +3580,8 @@ element.</p>
 <p>Object-oriented access to the attributes of the <a>'set'</a> element
 via the SVG DOM is not available.</p>
 
-<pre class="idl">interface <b>SVGSetElement</b> : <a>SVGAnimationElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGSetElement</b> : <a>SVGAnimationElement</a> {
 };</pre>
 
 </edit:with>
@@ -3592,7 +3596,8 @@ via the SVG DOM is not available.</p>
 <p>Object-oriented access to the attributes of the <a>'animateMotion'</a>
 element via the SVG DOM is not available.</p>
 
-<pre class="idl">interface <b>SVGAnimateMotionElement</b> : <a>SVGAnimationElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGAnimateMotionElement</b> : <a>SVGAnimationElement</a> {
 };</pre>
 
 </edit:with>
@@ -3604,7 +3609,8 @@ element via the SVG DOM is not available.</p>
 <p>The <a>SVGMPathElement</a> interface corresponds to the <a>'mpath'</a>
 element.</p>
 
-<pre class="idl">interface <b>SVGMPathElement</b> : <a>SVGElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGMPathElement</b> : <a>SVGElement</a> {
 };
 
 <a>SVGMPathElement</a> includes <a>SVGURIReference</a>;</pre>
@@ -3621,7 +3627,8 @@ element.</p>
 <p>Object-oriented access to the attributes of the
 <a>'animateTransform'</a> element via the SVG DOM is not available.</p>
 
-<pre class="idl">interface <b>SVGAnimateTransformElement</b> : <a>SVGAnimationElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGAnimateTransformElement</b> : <a>SVGAnimationElement</a> {
 };</pre>
 
 </edit:with>
@@ -3636,7 +3643,8 @@ element.</p>
 <p>Object-oriented access to the attributes of the <a>'discard'</a> element
 via the SVG DOM is not available.</p>
 
-<pre class="idl">interface <b>SVGDiscardElement</b> : <a>SVGAnimationElement</a> {
+<pre class="idl">[Exposed=Window]
+interface <b>SVGDiscardElement</b> : <a>SVGAnimationElement</a> {
 };</pre>
 
 </edit:with>


### PR DESCRIPTION
These were missed in https://github.com/w3c/svgwg/pull/387 and should be
the last cases of missing [Exposed] in SVG.