### PR TITLE
Avoid the use of Animatable as a Web IDL type

### DIFF
--- a/master/struct.html
+++ b/master/struct.html
@@ -3211,7 +3211,7 @@ or is null otherwise.</p>
 
 <pre class="idl">[Exposed=Window]
 interface <b>ShadowAnimation</b> : <a>Animation</a> {
-  constructor(<a>Animation</a> source, <a>Animatable</a> newTarget);
+  constructor(<a>Animation</a> source, (<a>Element</a> or <a>CSSPseudoElement</a>) newTarget);
   [SameObject] readonly attribute <a>Animation</a> <a href="#__svg__ShadowAnimation__sourceAnimation">sourceAnimation</a>;
 };</pre>
 


### PR DESCRIPTION
As an interface mixin, Animatable can't be used as a type per Web IDL:
https://heycam.github.io/webidl/#idl-types

Expand it to (Element or CSSPseudoElement), the two interfaces that include Animatable.