### PR TITLE
Add default value {} for optional DOMMatrix2DInit arguments

### DIFF
--- a/master/coords.html
+++ b/master/coords.html
@@ -3206,7 +3206,7 @@ interface <b>SVGTransform</b> {
   [SameObject] readonly attribute <a>DOMMatrix</a> <a href="coords.html#__svg__SVGTransform__matrix">matrix</a>;
   readonly attribute float <a href="coords.html#__svg__SVGTransform__angle">angle</a>;
 
-  undefined <a href="coords.html#__svg__SVGTransform__setMatrix">setMatrix</a>(optional <a>DOMMatrix2DInit</a> matrix);
+  undefined <a href="coords.html#__svg__SVGTransform__setMatrix">setMatrix</a>(optional <a>DOMMatrix2DInit</a> matrix = {});
   undefined <a href="coords.html#__svg__SVGTransform__setTranslate">setTranslate</a>(float tx, float ty);
   undefined <a href="coords.html#__svg__SVGTransform__setScale">setScale</a>(float sx, float sy);
   undefined <a href="coords.html#__svg__SVGTransform__setRotate">setRotate</a>(float angle, float cx, float cy);
@@ -3428,7 +3428,7 @@ interface <b>SVGTransformList</b> {
   <a href="types.html#__svg__SVGNameList__setter">setter</a> undefined (unsigned long index, <a>SVGTransform</a> newItem);
 
   <span class='comment'>// Additional methods not common to other list interfaces.</span>
-  <a>SVGTransform</a> <a href="coords.html#__svg__SVGTransformList__createSVGTransformFromMatrix">createSVGTransformFromMatrix</a>(optional <a>DOMMatrix2DInit</a> matrix);
+  <a>SVGTransform</a> <a href="coords.html#__svg__SVGTransformList__createSVGTransformFromMatrix">createSVGTransformFromMatrix</a>(optional <a>DOMMatrix2DInit</a> matrix = {});
   <a>SVGTransform</a>? <a href="coords.html#__svg__SVGTransformList__consolidate">consolidate</a>();
 };</pre>
 

--- a/master/struct.html
+++ b/master/struct.html
@@ -2685,7 +2685,7 @@ interface <b>SVGSVGElement</b> : <a>SVGGraphicsElement</a> {
   <a>DOMMatrix</a> <a href="struct.html#__svg__SVGSVGElement__createSVGMatrix">createSVGMatrix</a>();
   <a>DOMRect</a> <a href="struct.html#__svg__SVGSVGElement__createSVGRect">createSVGRect</a>();
   <a>SVGTransform</a> <a href="struct.html#__svg__SVGSVGElement__createSVGTransform">createSVGTransform</a>();
-  <a>SVGTransform</a> <a href="struct.html#__svg__SVGSVGElement__createSVGTransformFromMatrix">createSVGTransformFromMatrix</a>(optional <a>DOMMatrix2DInit</a> matrix);
+  <a>SVGTransform</a> <a href="struct.html#__svg__SVGSVGElement__createSVGTransformFromMatrix">createSVGTransformFromMatrix</a>(optional <a>DOMMatrix2DInit</a> matrix = {});
 
   <a>Element</a> <a href="struct.html#__svg__SVGSVGElement__getElementById">getElementById</a>(DOMString elementId);
 


### PR DESCRIPTION
This is required by Web IDL, but because DOMMatrix2DInit is defined in
another spec wasn't noticed until all spec IDL was validated together.

See https://github.com/w3c/webidl2.js/issues/407 for a discussion about
the underlying validation problem.