### PR TITLE
Default some arguments of initTimeEvent

### DIFF
--- a/specs/animations/master/Overview.html
+++ b/specs/animations/master/Overview.html
@@ -3298,7 +3298,7 @@ interface <b>TimeEvent</b> : <a>Event</a> {
   readonly attribute <a>WindowProxy</a>? <a href="#__svg__TimeEvent__view">view</a>;
   readonly attribute long <a href="#__svg__TimeEvent__detail">detail</a>;
 
-  undefined <a href="#__svg__TimeEvent__initTimeEvent">initTimeEvent</a>(DOMString typeArg, <a>Window</a>? viewArg, long detailArg);
+  undefined <a href="#__svg__TimeEvent__initTimeEvent">initTimeEvent</a>(DOMString typeArg, optional <a>Window</a>? viewArg = null, optional long detailArg = 0);
 };</pre>
 
 <dl class="interface">
@@ -3321,7 +3321,7 @@ interface <b>TimeEvent</b> : <a>Event</a> {
   <dt class="operations-header">Operations:</dt>
   <dd>
     <dl class="attributes">
-      <dt id="__svg__TimeEvent__initTimeEvent" class="operation first-child">undefined <b>initTimeEvent</b>(DOMString <var>typeArg</var>, <a>Window</a>? <var>viewArg</var>, long <var>detailArg</var>)</dt>
+      <dt id="__svg__TimeEvent__initTimeEvent" class="operation first-child">undefined <b>initTimeEvent</b>(DOMString <var>typeArg</var>, optional <a>Window</a>? <var>viewArg</var> = null, optional long <var>detailArg</var> = 0)</dt>
       <dd class="operation">
         <div>The <a>TimeEvent::initTimeEvent</a> method is used to initialize the value of a
         <a>TimeEvent</a> created with <code>document.createEvent()</code>. This


### PR DESCRIPTION
See  https://github.com/whatwg/dom/pull/417 and https://github.com/whatwg/html/pull/2410

This fix landed in Firefox as part of https://bugzilla.mozilla.org/show_bug.cgi?id=1345044 and already has a test in https://wpt.fyi/results/svg/idlharness.window.html?label=experimental&label=master&aligned