### PR TITLE
Add SVGStyleElement#disabled attribute

### DIFF
--- a/master/styling.html
+++ b/master/styling.html
@@ -730,6 +730,7 @@ interface <b>SVGStyleElement</b> : <a>SVGElement</a> {
   attribute DOMString <a href="styling.html#__svg__SVGStyleElement__type">type</a>;
   attribute DOMString <a href="styling.html#__svg__SVGStyleElement__media">media</a>;
   attribute DOMString <a href="styling.html#__svg__SVGStyleElement__title">title</a>;
+  attribute boolean <a href="styling.html#__svg__SVGStyleElement__disabled">disabled</a>;
 };
 
 <a>SVGStyleElement</a> includes <a>LinkStyle</a>;</pre>


### PR DESCRIPTION
This PR is meant to mirror https://github.com/whatwg/html/pull/7779 by giving SVGStyleElement a `disabled` IDL attribute that does not mirror any content attribute. Furthermore, this PR is so small because I believe just adding the attribute is enough to piggy-back on the semantics in the WHATWG PR above, given the [following text](https://svgwg.org/svg2-draft/styling.html#:~:text=The%20semantics%20and%20processing%20of%20a%20%E2%80%98style%E2%80%99%20and%20its%20attributes%20must%20be%20the%20same%20as%20is%20defined%20for%20the%20HTML%20%E2%80%98style%E2%80%99%20element.) in the SVG styling spec:

> The semantics and processing of a ‘[style](https://svgwg.org/svg2-draft/styling.html#StyleElement)’ and its attributes must be the same as is defined for the [HTML ‘style’ element](https://html.spec.whatwg.org/multipage/semantics.html#the-style-element).