### PR TITLE
Stop using the DocumentAndElementEventHandlers interface mixin

### DIFF
--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -541,7 +541,9 @@
     <attribute name='onchange' href='interact.html#EventAttributes'/>
     <attribute name='onclick' href='interact.html#EventAttributes'/>
     <attribute name='onclose' href='interact.html#EventAttributes'/>
+    <attribute name='oncopy' href='interact.html#EventAttributes'/>
     <attribute name='oncuechange' href='interact.html#EventAttributes'/>
+    <attribute name='oncut' href='interact.html#EventAttributes'/>
     <attribute name='ondblclick' href='interact.html#EventAttributes'/>
     <attribute name='ondrag' href='interact.html#EventAttributes'/>
     <attribute name='ondragend' href='interact.html#EventAttributes'/>
@@ -572,6 +574,7 @@
     <attribute name='onmouseout' href='interact.html#EventAttributes'/>
     <attribute name='onmouseover' href='interact.html#EventAttributes'/>
     <attribute name='onmouseup' href='interact.html#EventAttributes'/>
+    <attribute name='onpaste' href='interact.html#EventAttributes'/>
     <attribute name='onpause' href='interact.html#EventAttributes'/>
     <attribute name='onplay' href='interact.html#EventAttributes'/>
     <attribute name='onplaying' href='interact.html#EventAttributes'/>
@@ -592,14 +595,6 @@
     <attribute name='onvolumechange' href='interact.html#EventAttributes'/>
     <attribute name='onwaiting' href='interact.html#EventAttributes'/>
     <attribute name='onwheel' href='interact.html#EventAttributes'/>
-  </attributecategory>
-
-  <attributecategory
-      name='document element event'
-      href='https://html.spec.whatwg.org/multipage/webappapis.html#documentandelementeventhandlers'>
-    <attribute name='oncopy' href='interact.html#EventAttributes'/>
-    <attribute name='oncut' href='interact.html#EventAttributes'/>
-    <attribute name='onpaste' href='interact.html#EventAttributes'/>
   </attributecategory>
 
   <attributecategory
@@ -1121,7 +1116,6 @@
   <interface name='CSSStyleDeclaration' href='https://www.w3.org/TR/cssom-1/#the-cssstyledeclaration-interface'/>
   <interface name='CSSRule' href='https://www.w3.org/TR/cssom-1/#the-cssrule-interface'/>
   <interface name='Document' href='https://dom.spec.whatwg.org/#interface-document'/>
-  <interface name='DocumentAndElementEventHandlers' href='https://html.spec.whatwg.org/multipage/webappapis.html#documentandelementeventhandlers'/>
   <interface name='DocumentFragment' href='https://dom.spec.whatwg.org/#interface-documentfragment'/>
   <interface name='ShadowRoot' href='https://dom.spec.whatwg.org/#interface-shadowroot'/>
   <interface name='DOMImplementation' href='https://dom.spec.whatwg.org/#interface-domimplementation'/>

--- a/master/interact.html
+++ b/master/interact.html
@@ -294,8 +294,7 @@ and the event types defined in
 All elements in the SVG namespace support
 <a>event attributes</a> for these events;
 matching IDL properties are included in the base <a>SVGElement</a> interface
-via the <a>GlobalEventHandlers</a> and
-<a>DocumentAndElementEventHandlers</a> mixins, respectively.
+via the <a>GlobalEventHandlers</a> mixin.
 </p>
 
 <p>

--- a/master/types.html
+++ b/master/types.html
@@ -703,7 +703,6 @@ interface <b>SVGElement</b> : <a>Element</a> {
 };
 
 <a>SVGElement</a> includes <a>GlobalEventHandlers</a>;
-<a>SVGElement</a> includes <a>DocumentAndElementEventHandlers</a>;
 <a>SVGElement</a> includes <a>SVGElementInstance</a>;
 <a>SVGElement</a> includes <a>HTMLOrSVGElement</a>;</pre>
 


### PR DESCRIPTION
This mixin will be removed from HTML, and the 3 event handler attributes
will be added to GlobalEventHandlers instead:
https://github.com/whatwg/html/pull/8096
https://github.com/web-platform-tests/wpt/pull/36398
