### PR TITLE
Remove support for data: URL in SVGUseElement

### DIFF
--- a/master/struct.html
+++ b/master/struct.html
@@ -599,7 +599,7 @@ without having to ensure that it has an ID on its root element.</p>
 
 <p>
 User agents may restrict external resource documents for security
-reasons. In particular, this specification does not allow cross-origin resource requests in <a>'use'</a>.
+reasons. In particular, this specification does not allow cross-origin and <a href="linking.html#TermDataURL">data URL</a> resource requests in <a>'use'</a>.
 A future version of this or another specification may provide a method of securely enabling cross-origin re-use
 of assets.
 </p>

--- a/master/struct.html
+++ b/master/struct.html
@@ -600,8 +600,6 @@ without having to ensure that it has an ID on its root element.</p>
 <p>
 User agents may restrict external resource documents for security
 reasons. In particular, this specification does not allow cross-origin and <a href="linking.html#TermDataURL">data URL</a> resource requests in <a>'use'</a>.
-A future version of this or another specification may provide a method of securely enabling cross-origin re-use
-of assets.
 </p>
 
 <p>When the <a>'href'</a> attribute is set


### PR DESCRIPTION
### Motivation
Assigning an attacker controlled string to `SVGUseElement.href` causes XSS due to data: URLs. This also led to a [bypass of Trusted Types](https://github.com/w3c/trusted-types/issues/357) in Blink.

Additionally, data: URLs can only trigger script execution in script loaders such as HTMLScriptElement.src or [dynamic import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import). However, SVGUseElement is an exception to this, which also caused a [bypass](https://bugs.chromium.org/p/chromium/issues/detail?id=1306450#c10) in the Sanitizer API. We believe that this also led to several other bugs in sanitizers and linters missing a check for this special case.

Since Webkit does not support data: URLs in SVGUseElement, Blink is planning to remove support for it. And therefore, we'd like to update the spec.

We have also [requested Mozilla's position](https://github.com/mozilla/standards-positions/issues/718) on this.

Currently, the [usage](https://chromestatus.com/metrics/feature/timeline/popularity/4356) of data: URLs in SVGUseElement is about 0.0056% of page load in Chrome.