### PR TITLE
Fix vertical inline-size example

### DIFF
--- a/master/images/text/text-wrap-vertical.svg
+++ b/master/images/text/text-wrap-vertical.svg
@@ -3,7 +3,7 @@
 <svg xmlns="http://www.w3.org/2000/svg"
    width="100" height="300" viewBox="0 0 100 300">
 
-  <text x="62.5" y="25" inline-size="200"
+  <text x="62.5" y="25" inline-size="250"
 	writing-mode="tb-rl"
 	font-family="IPAMincho"
 	font-size="25px">テキストは１０文字の<tspan x="37.5" y="25">後に折り返されます。</tspan></text>

--- a/master/text.html
+++ b/master/text.html
@@ -2126,8 +2126,8 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      width="100" height="300" viewBox="0 0 100 300">
 
-  <text x="62.5" y="25" inline-size="200"
-	style="font: 25px IPAMincho; inline-size: 200px; writing-mode: vertical-rl;">
+  <text x="62.5" y="25" inline-size="250"
+	style="font: 25px IPAMincho; inline-size: 250px; writing-mode: vertical-rl;">
     テキストは１０文字後に折り返されます。</text>
 
 </svg>


### PR DESCRIPTION
The text should actually wrap at 250px, but the property has been incorrectly set to 200.