### PR TITLE
Add missing whitespace before combinator in value definition

### DIFF
--- a/master/text.html
+++ b/master/text.html
@@ -2384,7 +2384,7 @@
     </tr>
     <tr>
       <th>Value:</th>
-      <td>none | [ &lt;basic-shape&gt;| &lt;uri&gt; ]+</td>
+      <td>none | [ &lt;basic-shape&gt; | &lt;uri&gt; ]+</td>
     </tr>
     <tr>
       <th>Initial:</th>


### PR DESCRIPTION
Cf. w3c/fxtf-drafts#523 and https://github.com/w3c/csswg-drafts/pull/9132 for why it may be required.