### PR TITLE
Update painting.html stroke-width

### DIFF
--- a/master/painting.html
+++ b/master/painting.html
@@ -762,7 +762,8 @@ property</h3>
 
 <p>This property specifies the width of the stroke on the current object.
 A zero value causes no stroke to be painted. A negative value
-is <a>invalid</a>. A <a>&lt;number&gt;</a> value represents a value in <a>user units</a>.</p>
+is <a>invalid</a>. A <a>&lt;number&gt;</a> value represents a value in <a>user units</a>.
+By default, the stroke is centered on the border, and therefore paints beyond the shape by half of the stroke-width.</p>
 
 <h3 id="LineCaps">Drawing caps at the ends of strokes: the <span class="property">'stroke-linecap'</span>
 property</h3>
@@ -1446,7 +1447,7 @@ The ideal stroke shape is determined as follows:
               <li>Let <var>dash</var> be the shape that includes, for all distances
               between <var>start</var> and <var>end</var> along the subpath, all
               points that lie on the line perpendicular to the subpath at that
-              distance and which are within distance <a>'stroke-width'</a> of
+              distance and which are within distance <a>'stroke-width'</a> / 2 of
               the point on the subpath at that position.</li>
 
               <li>Set <var>dash</var> to be the union of <var>dash</var> and the


### PR DESCRIPTION
(1)  Specify that the stroke-width is centered on the path, rather than inside or outside the shape. (2)  Correct(?) the stroke-width of a dash.

(A)  It is expected that the location of the stroke's own paint will be controllable in the next SVG edition, but the default/initial position will still need to be defined.

(B)  The algorithm for painting a dash collects all points on a line perpendicular to the path that are within a distance of stroke-width.  Because the path has two sides, this effectively doubles the stroke-width.  Either that should be corrected (as I proposed here) or it should be made explicit that dashes are double-thick.