### PR TITLE
Update paths.html H and V not equiv to 0

### DIFF
--- a/master/paths.html
+++ b/master/paths.html
@@ -466,11 +466,13 @@ current point to a new point:</p>
     that absolute coordinates will follow; <strong>h</strong>
     (lowercase) indicates that relative coordinates will
     follow. Multiple x values can be provided (although usually
-    this doesn't make sense). An <strong>H</strong> or <strong>h</strong>
-    command is equivalent to an <strong>L</strong> or <strong>l</strong>
-    command with 0 specified for the y coordinate.
-    At the end of the command, the new current point is
-    taken from the final coordinate value.</td>
+    this doesn't make sense). 
+    An <strong>H</strong> command is equivalent to 
+    an <strong>L</strong> command with the y coordinate equal 
+    to the current y coordinate. An <strong>h</strong> command is 
+    equivalent to an <strong>l</strong> command with 0 specified 
+    for the y coordinate. At the end of the command, the new 
+    current point is taken from the final coordinate value.</td>
   </tr>
   <tr>
     <td><strong>V</strong> (absolute)<br />
@@ -482,9 +484,12 @@ current point to a new point:</p>
     absolute coordinates will follow; <strong>v</strong>
     (lowercase) indicates that relative coordinates will
     follow. Multiple y values can be provided (although usually
-    this doesn't make sense).  A <strong>V</strong> or <strong>v</strong>
-    command is equivalent to an <strong>L</strong> or <strong>l</strong>
-    command with 0 specified for the x coordinate.
+    this doesn't make sense).  
+    A <strong>V</strong> command is equivalent to 
+    an <strong>L</strong> command with the x coordinate equal 
+    to the current x coordinate. A <strong>v</strong> command is 
+    equivalent to an <strong>l</strong> command with 0 specified 
+    for the x coordinate.
     At the end of the command, the new current point is
     taken from the final coordinate value.</td>
   </tr>


### PR DESCRIPTION
The existing text claimed that line commands H and h (and V and v) were equivalent; the capitalized versions should still be in absolute terms.  If, for backwards compatibility reasons, the existing text is correct, this should be called out explicitly.