### PR TITLE
Fix equation 6.1 in implnote.html

### DIFF
--- a/master/implnote.html
+++ b/master/implnote.html
@@ -1491,13 +1491,13 @@ steps:</p>
       <mtd>
         <msub>
           <mi>r</mi>
-          <mi>y</mi>
+          <mi>x</mi>
         </msub>
         <mo lspace='3px' rspace='3px'>&#8592;</mo>
         <mfenced open = '&#124;' close = '&#124;'>
           <msub>
             <mi>r</mi>
-            <mi>y</mi>
+            <mi>x</mi>
           </msub>
         </mfenced>
       </mtd>


### PR DESCRIPTION
Equation 6.1 on [this page](https://www.w3.org/TR/SVG/implnote.html#ArcCorrectionOutOfRangeRadii) has two identical lines, both showing $r_y \leftarrow |r_y|$. The two lines should be different, where the first would be changed to $r_x \leftarrow |r_x|$. It's a small inaccuracy that doesn't really make the page any harder to understand, but it's still probably worth fixing 🙂