### PR TITLE
Correct link for SVGAElement.relList

### DIFF
--- a/master/linking.html
+++ b/master/linking.html
@@ -1149,7 +1149,7 @@ interface <b>SVGAElement</b> : <a>SVGGraphicsElement</a> {
   attribute DOMString <a href="linking.html#__svg__SVGAElement__download">download</a>;
   attribute USVString <a href="linking.html#__svg__SVGAElement__ping">ping</a>;
   attribute DOMString <a href="linking.html#__svg__SVGAElement__rel">rel</a>;
-  [SameObject, PutForwards=value] readonly attribute <a>DOMTokenList</a> <a href="linking.html#__svg__SVGAElement__rel">relList</a>;
+  [SameObject, PutForwards=value] readonly attribute <a>DOMTokenList</a> <a href="linking.html#__svg__SVGAElement__relList">relList</a>;
   attribute DOMString <a href="linking.html#__svg__SVGAElement__hreflang">hreflang</a>;
   attribute DOMString <a href="linking.html#__svg__SVGAElement__type">type</a>;
 


### PR DESCRIPTION
This corrects the link from .rel to .relList.