### PR TITLE
Remove SVGAElement.text attribute

### DIFF
--- a/master/linking.html
+++ b/master/linking.html
@@ -1153,8 +1153,6 @@ interface <b>SVGAElement</b> : <a>SVGGraphicsElement</a> {
   attribute DOMString <a href="linking.html#__svg__SVGAElement__hreflang">hreflang</a>;
   attribute DOMString <a href="linking.html#__svg__SVGAElement__type">type</a>;
 
-  attribute DOMString <a href="linking.html#__svg__SVGAElement__text">text</a>;
-
   attribute DOMString <a href="linking.html#__svg__SVGAElement__referrerPolicy">referrerPolicy</a>;
 };
 
@@ -1176,10 +1174,6 @@ interface <b>SVGAElement</b> : <a>SVGGraphicsElement</a> {
   IDL attribute
 <a>reflects</a> the <a>'referrerpolicy'</a> content attribute,
  <a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#limited-to-only-known-values">limited to only known values</a>.</p>
-<p>The <b id="__svg__SVGAElement__text">text</b> IDL attribute,
- on getting, must return the same value as the <a href="https://dom.spec.whatwg.org/#dom-node-textcontent">textContent</a> IDL attribute
- on the element, and on setting, must act as if the <a href="https://dom.spec.whatwg.org/#dom-node-textcontent">textContent</a> IDL attribute
- on the element had been set to the new value.</p>
 </edit:with>
 
 


### PR DESCRIPTION
This was only implemented by Firefox, where it has now been removed (https://bugzilla.mozilla.org/show_bug.cgi?id=1880689).

Discussion in GH-931 indicated that this attribute is desired to be removed from the spec.

Closes GH-931.