### PR TITLE
Use white-space-collapse property instead of old name for it

### DIFF
--- a/master/styling.html
+++ b/master/styling.html
@@ -602,7 +602,7 @@ svg:not(:root), image, marker, pattern, symbol { overflow: hidden; }
 }
 
 *[xml|space=preserve] {
-  text-space-collapse: preserve-spaces;
+  white-space-collapse: preserve-spaces;
 }
 
 defs,


### PR DESCRIPTION
`text-space-collapse` was renamed `white-space-collapse` in 2023: https://github.com/w3c/csswg-drafts/issues/8273