### PR TITLE
Fix #706 - Revert SVGRect/SVGPoint/SVGMatrix

### DIFF
--- a/master/shapes.html
+++ b/master/shapes.html
@@ -667,22 +667,26 @@ a <a>'polygon/points'</a> attribute on a <a>'polygon'</a> or <a>'polyline'</a>
 element.  It is mixed in to the <a>SVGPolygonElement</a> and <a>SVGPolylineElement</a>
 interfaces.</p>
 
-<p class='note'>Note: In SVG 1.1 SE, the <a href="#__svg__SVGAnimatedPoints__animatedPoints">animatedPoints</a>
-attribute represented the current animated value. In this version of SVG, it is
-simply an alias for <a href="#__svg__SVGAnimatedPoints__points">points</a>.</p>
-
 <pre class="idl">interface mixin <b>SVGAnimatedPoints</b> {
   [<a>SameObject</a>] readonly attribute <a>SVGPointList</a> <a href="shapes.html#__svg__SVGAnimatedPoints__points">points</a>;
   [<a>SameObject</a>] readonly attribute <a>SVGPointList</a> <a href="shapes.html#__svg__SVGAnimatedPoints__animatedPoints">animatedPoints</a>;
 };</pre>
 
-<p class='ready-for-wider-review'>The <b id="__svg__SVGAnimatedPoints__points">points</b> and
-<b id="__svg__SVGAnimatedPoints__animatedPoints">animatedPoints</b> IDL
-attributes represent the current non-animated value of the reflected attribute.
-On getting <a href="#__svg__SVGAnimatedPoints__points">points</a> or
-<a href="#__svg__SVGAnimatedPoints__animatedPoints">animatedPoints</a>,
+<p class='ready-for-wider-review'>The <b id="__svg__SVGAnimatedPoints__points">points</b> IDL attribute
+represents the current non-animated value of the reflected attribute.
+On getting <a href="#__svg__SVGAnimatedPoints__points">points</a>,
 an <a>SVGPointList</a> object is returned that reflects the base
 value of the reflected attribute.</p>
+
+<p>The <b id="__svg__SVGAnimatedPoints__animatedPoints">animatedPoints</b> IDL attribute
+represents the current non-animated value of the reflected attribute.
+On getting <a href="#__svg__SVGAnimatedPoints__animatedPoints">animatedPoints</a>,
+an <a>SVGPointList</a> object is returned that reflects the animated
+value of the reflected attribute.</p>
+
+<p>The objects returned from <a href="#__svg__SVGAnimatedPoints__points">points</a>
+and <a href="#__svg__SVGAnimatedPoints__animatedPoints">animatedPoints</a> must be distinct, even
+if there is no animation currently affecting the attribute.</p>
 
 <h3 id="InterfaceSVGPointList">Interface SVGPointList</h3>
 
@@ -714,14 +718,18 @@ objects beyond those described in the
 <a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/">Geometry Interfaces</a>
 specification, so that they can be used to reflect <a>'polygon/points'</a> attributes.</p>
 
-<div class='ready-for-wider-review'>
-<p id="PointMode">Every <a>DOMPoint</a> object operates in one of three modes.
-It can:</p>
+<p id="PointMode">Every <a>DOMPoint</a> object operates in one of four modes. It
+can:</p>
 
+<div class='ready-for-wg-review'>
 <ol>
   <li><em>reflect an element of the base value</em> of a <a>reflected</a> animatable
   attribute (being exposed through the methods on the
   <a href="#__svg__SVGAnimatedPoints__points">points</a> member of
+  an <a>SVGAnimatedPoints</a>),</li>
+  <li><em>reflect an element of the animated value</em> of a <a>reflected</a> animatable
+  attribute (being exposed through the methods on the
+  <a href="#__svg__SVGAnimatedPoints__animatedPoints">animatedPoints</a> member of
   an <a>SVGAnimatedPoints</a>),</li>
   <li><em>represent the current translation</em> of a given <a>'svg'</a> element
   (being exposed through the


### PR DESCRIPTION
This revert the spec to what is currently implemented by all rendering engines and to what was previously described in SVG 1.1 specification.