### PR TITLE
Fix #993: Add SVG_MARKER_ORIENT_AUTO_START_REVERSE to the IDL.

### DIFF
--- a/master/painting.html
+++ b/master/painting.html
@@ -3488,6 +3488,7 @@ interface <b>SVGMarkerElement</b> : <a>SVGElement</a> {
   const unsigned short <a href="painting.html#__svg__SVGMarkerElement__SVG_MARKER_ORIENT_UNKNOWN">SVG_MARKER_ORIENT_UNKNOWN</a> = 0;
   const unsigned short <a href="painting.html#__svg__SVGMarkerElement__SVG_MARKER_ORIENT_AUTO">SVG_MARKER_ORIENT_AUTO</a> = 1;
   const unsigned short <a href="painting.html#__svg__SVGMarkerElement__SVG_MARKER_ORIENT_ANGLE">SVG_MARKER_ORIENT_ANGLE</a> = 2;
+  const unsigned short <a href="painting.html#__svg__SVGMarkerElement__SVG_MARKER_ORIENT__AUTO_START_REVERSE"></a>SVG_MARKER_ORIENT_AUTO_START_REVERSE</a> = 3;
 
   [<a>SameObject</a>] readonly attribute <a>SVGAnimatedLength</a> <a href="painting.html#__svg__SVGMarkerElement__refX">refX</a>;
   [<a>SameObject</a>] readonly attribute <a>SVGAnimatedLength</a> <a href="painting.html#__svg__SVGMarkerElement__refY">refY</a>;
@@ -3522,6 +3523,7 @@ attribute can take.  Their meanings are as follows:</p>
 <table class='vert'>
   <tr><th>Constant</th><th>Meaning</th></tr>
   <tr><td><b id="__svg__SVGMarkerElement__SVG_MARKER_ORIENT_AUTO">SVG_MARKER_ORIENT_AUTO</b></td><td>The <span class="attr-value">auto</span> keyword.</td></tr>
+  <tr><td><b id="__svg__SVGMarkerElement__SVG_MARKER_ORIENT_AUTO_START_REVERSE">SVG_MARKER_ORIENT_AUTO_START_REVERSE</b></td><td>The <span class="attr-value">auto-start-reverse</span> keyword.</td></tr>
   <tr><td><b id="__svg__SVGMarkerElement__SVG_MARKER_ORIENT_ANGLE">SVG_MARKER_ORIENT_ANGLE</b></td><td>An <a>&lt;angle&gt;</a> or <a>&lt;number&gt;</a> value indicating the orientation angle.</td></tr>
   <tr><td><b id="__svg__SVGMarkerElement__SVG_MARKER_ORIENT_UNKNOWN">SVG_MARKER_ORIENT_UNKNOWN</b></td><td>Some other value.</td></tr>
 </table>
@@ -3545,7 +3547,7 @@ The <a>numeric type values</a> for <a>'orient'</a> are as follows:</p>
   </tr>
   <tr>
     <td><span class='attr-value'>auto-start-reverse</span></td>
-    <td><a href='painting.html#__svg__SVGMarkerElement__SVG_MARKER_ORIENT_UNKNOWN'>SVG_MARKER_ORIENT_UNKNOWN</a></td>
+    <td><a href='painting.html#__svg__SVGMarkerElement__SVG_MARKER_ORIENT_AUTO_START_REVERSE'>SVG_MARKER_ORIENT_AUTO_START_REVERSE</a></td>
   </tr>
   <tr>
     <td><a>&lt;angle&gt;</a> | <a>&lt;number&gt;</a></td>

--- a/specs/markers/master/Overview.html
+++ b/specs/markers/master/Overview.html
@@ -1540,6 +1540,7 @@ The <a>SVGMarkerElement</a> interface corresponds to the
   const unsigned short <a href="#__svg__SVGMarkerElement__SVG_MARKER_ORIENT_UNKNOWN">SVG_MARKER_ORIENT_UNKNOWN</a> = 0;
   const unsigned short <a href="#__svg__SVGMarkerElement__SVG_MARKER_ORIENT_AUTO">SVG_MARKER_ORIENT_AUTO</a> = 1;
   const unsigned short <a href="#__svg__SVGMarkerElement__SVG_MARKER_ORIENT_ANGLE">SVG_MARKER_ORIENT_ANGLE</a> = 2;
+  const unsigned short <a href="#__svg__SVGMarkerElement__SVG_MARKER_ORIENT_AUTO_START_REVERSE">SVG_MARKER_ORIENT_AUTO_START_REVERSE</a> = 3;
 
   readonly attribute <a>SVGAnimatedLength</a> <a href="#__svg__SVGMarkerElement__refX">refX</a>;
   readonly attribute <a>SVGAnimatedLength</a> <a href="#__svg__SVGMarkerElement__refY">refY</a>;
@@ -1583,8 +1584,7 @@ The <a>SVGMarkerElement</a> interface corresponds to the
     <dl class="constants">
       <dt id="__svg__SVGMarkerElement__SVG_MARKER_ORIENT_UNKNOWN" class="constant first-child"><b>SVG_MARKER_ORIENT_UNKNOWN</b><span class="idl-type-parenthetical"> (unsigned short)</span></dt>
       <dd class="constant">
-        <div>The marker orientation is <span class="attr-value">'auto-start-rotate'</span> or
-        is not one of the predefined types. It is invalid to
+        <div>The marker orientation is not one of the predefined types. It is invalid to
         attempt to define a new value of this type or to attempt to switch an
         existing value to this type.</div>
       </dd>
@@ -1592,6 +1592,11 @@ The <a>SVGMarkerElement</a> interface corresponds to the
       <dd class="constant">
         <div>Attribute <a>'orient'</a> has value
         <span class="attr-value">'auto'</span>.</div>
+      </dd>
+      <dt id="__svg__SVGMarkerElement__SVG_MARKER_ORIENT_AUTO_START_REVERSE" class="constant"><b>SVG_MARKER_ORIENT_AUTO_START_REVERSE</b><span class="idl-type-parenthetical"> (unsigned short)</span></dt>
+      <dd class="constant">
+        <div>Attribute <a>'orient'</a> has value
+        <span class="attr-value">'auto-start-reverse'</span>.</div>
       </dd>
       <dt id="__svg__SVGMarkerElement__SVG_MARKER_ORIENT_ANGLE" class="constant"><b>SVG_MARKER_ORIENT_ANGLE</b><span class="idl-type-parenthetical"> (unsigned short)</span></dt>
       <dd class="constant">


### PR DESCRIPTION
Firefox is implementing the value auto-start-reverse as an IDL. 
The context for the decision was made in #424

where only 
* `SVG_LENGTHTYPE_*` 
* `SVG_ANGLETYPE_*` constants
* enumeration for new CSS units 

**should NOT** be extended. 

but this is not the case for `SVG_MARKER_ORIENT_*`. 
Hence the extension with this PR to align with Firefox.

FIXME: `SVGFECompositeElement` will be done in a separate PR. 