### PR TITLE
Adding resolution of content dependent units used in sizing properties for inner SVG elements

### DIFF
--- a/master/geometry.html
+++ b/master/geometry.html
@@ -371,6 +371,31 @@ the position of the element.</p>
 <span class='property'>'width'</span> and <span class='property'>'height'</span>
 properties</h2>
 
+<div class="annotation svg2-requirement">
+  <table>
+    <tr>
+      <th>SVG 2 Requirement:</th>
+      <td>Define <a>'width'</a> and <a>'height'</a> CSS values for SVG Elements</td>
+    </tr>
+    <tr>
+      <th>Resolution:</th>
+      <td><a href="https://logs.csswg.org/irc.w3.org/css/2025-08-21/#e1716969">content dependent units used in 'width' and 'height' for inner SVG elements resolve to SVG's definition of <span class='prop-value'>auto</span></a></td>
+    </tr>
+    <tr>
+      <th>Purpose:</th>
+      <td>To resolve the ambiguity when units that depend on the CSS box model are used as CSS values in <a>'width'</a> and <a>'height'</a> properties for inner SVG elements.</td>
+    </tr>
+    <tr>
+      <th>Owner:</th>
+      <td>Divyansh (no action)</td>
+    </tr>
+    <tr>
+      <th>Status:</th>
+      <td>Done</td>
+    </tr>
+  </table>
+</div>
+
 <p class='note'>See the CSS 2.1 specification for the definitions of
 <a href="https://www.w3.org/TR/CSS21/visudet.html#propdef-width"><span class="prop-name">width</span></a> and
 <a href="https://www.w3.org/TR/CSS21/visudet.html#propdef-height"><span class="prop-name">height</span></a>.</p>


### PR DESCRIPTION
This PR adds the CSS WG Resolution in [w3c/csswg-drafts#12376 (comment)](https://github.com/w3c/csswg-drafts/issues/12376#issuecomment-3210998345) for SVG elements.

 > The CSS Working Group just discussed `` [css-sizing-3][css-values-4] Define `width` and `height` CSS values for SVG Elements in a mapping ``, and agreed to the following:
 > 
 > * `RESOLVED: content dependent units used in width and height for inner SVG elements resolve to SVG's definition of auto`