### PR TITLE
Adding resolution of content dependent units used in sizing properties for inner SVG elements

### DIFF
--- a/master/geometry.html
+++ b/master/geometry.html
@@ -399,7 +399,7 @@ and <a>'height'</a> on the <a>'svg'</a> element is treated as 100%.</p>
 <p>The value <span class='prop-value'>auto</span> for <a>'width'</a>
 and <a>'height'</a> on the <a>'image'</a> element is calculated from the referenced image's intrinsic dimensions and aspect ratio, according to the CSS <a>Default Sizing Algorithm</a>.</p>
 
-<p>Content dependent units used in 'width' and 'height' for inner SVG elements resolve to SVG's definition of <span class='prop-value'>auto</span></a>. These content dependent units include 
+<p>Content dependent units used in 'width' and 'height' for inner SVG elements resolve to SVG's definition of <a><span class='prop-value'>auto</span></a>. These content dependent units include 
 <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content">'min-content'</a>, <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">'max-content'</a>, 
 <a href="https://drafts.csswg.org/css-sizing-3/#funcdef-width-fit-content">'fit-content()'</a> and <a href="https://drafts.csswg.org/css-sizing-3/#funcdef-width-calc-size">'calc-size()'</a>.</p>
 


### PR DESCRIPTION
This PR adds the CSS WG Resolution in [w3c/csswg-drafts#12376 (comment)](https://github.com/w3c/csswg-drafts/issues/12376#issuecomment-3210998345) for SVG.
 
> The CSS Working Group just discussed `` [css-sizing-3][css-values-4] Define `width` and `height` CSS values for SVG Elements in a mapping ``, and agreed to the following:
> 
> * `RESOLVED: content dependent units used in width and height for inner SVG elements resolve to SVG's definition of auto`

