### PR TITLE
Align type and media attributes from SVGStyleElement with HTMLStyleElement

### DIFF
--- a/master/styling.html
+++ b/master/styling.html
@@ -81,7 +81,7 @@ element in HTML</a>.</p>
       <tr>
         <td><dfn id="StyleElementTypeAttribute" data-dfn-type="element-attr" data-dfn-for="style" data-export="">type</dfn></td>
         <td>(see below)</td>
-        <td>text/css</td>
+        <td>(none)</td>
         <td>no</td>
       </tr>
     </table>
@@ -91,7 +91,8 @@ element in HTML</a>.</p>
     the element's contents, as a <a href="http://www.ietf.org/rfc/rfc2046.txt">media type</a>.
     [<a href="refs.html#ref-rfc2046">rfc2046</a>].
     If the attribute is not specified, then the
-    style sheet language is assumed to be CSS.</p>
+    style sheet language is assumed to be CSS.
+    This attribute is obsoleted and should not be used.</p>
   </dd>
   <dt>
     <table class="attrdef def">
@@ -104,7 +105,7 @@ element in HTML</a>.</p>
       <tr>
         <td><dfn id="StyleElementMediaAttribute" data-dfn-type="element-attr" data-dfn-for="style" data-export="">media</dfn></td>
         <td>(see below)</td>
-        <td>all</td>
+        <td>(none)</td>
         <td>no</td>
       </tr>
     </table>
@@ -726,10 +727,12 @@ in the DOM.</p>
 
 <pre class="idl">[<a>Exposed</a>=Window]
 interface <b>SVGStyleElement</b> : <a>SVGElement</a> {
-  attribute DOMString <a href="styling.html#__svg__SVGStyleElement__type">type</a>;
   attribute DOMString <a href="styling.html#__svg__SVGStyleElement__media">media</a>;
   attribute DOMString <a href="styling.html#__svg__SVGStyleElement__title">title</a>;
   attribute boolean <a href="styling.html#__svg__SVGStyleElement__disabled">disabled</a>;
+
+  // obsolete members
+  attribute DOMString <a href="styling.html#__svg__SVGStyleElement__type">type</a>;
 };
 
 <a>SVGStyleElement</a> includes <a>LinkStyle</a>;</pre>

--- a/master/styling.html
+++ b/master/styling.html
@@ -92,7 +92,7 @@ element in HTML</a>.</p>
     [<a href="refs.html#ref-rfc2046">rfc2046</a>].
     If the attribute is not specified, then the
     style sheet language is assumed to be CSS.
-    This attribute is obsoleted and should not be used.</p>
+    This attribute is obsolete and should not be used.</p>
   </dd>
   <dt>
     <table class="attrdef def">


### PR DESCRIPTION
Align type and media
attributes from
SVGStyleElement with HTMLStyleElement

- type and media no longer have an initial value
- type is obsoleted

This aligns the behaviour with Firefox and with the HTMLStyleElement.

WebKit Bug: ~~https://bugs.webkit.org/show_bug.cgi?id=297909~~ (Fixed to match this behaviour)
Firefox Bug: N/A (Current behaviour)
Chromium Bug: https://issues.chromium.org/u/1/issues/441253575

WPT Changes: https://github.com/web-platform-tests/wpt/pull/54529

Fixes #996 and #995