### PR TITLE
Replace spec prose with IDL extended attribute for simple reflection

### DIFF
--- a/master/interact.html
+++ b/master/interact.html
@@ -1155,14 +1155,11 @@ myElement.addEventListener("click", myAction1, false)
 
 <pre class="idl">[<a>Exposed</a>=Window]
 interface <b>SVGScriptElement</b> : <a>SVGElement</a> {
-  attribute DOMString <a href="interact.html#__svg__SVGScriptElement__type">type</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="interact.html#__svg__SVGScriptElement__type">type</a>;
   attribute DOMString? <a href="interact.html#__svg__SVGScriptElement__crossOrigin">crossOrigin</a>;
 };
 
 <a>SVGScriptElement</a> includes <a>SVGURIReference</a>;</pre>
-
-<p>The <b id="__svg__SVGScriptElement__type">type</b> IDL attribute
-<a>reflects</a> the <a>'type'</a> content attribute.</p>
 
 <p>The <b id="__svg__SVGScriptElement__crossOrigin">crossOrigin</b> IDL
 attribute <a>reflects</a> the <a>'crossorigin'</a> content attribute.</p>

--- a/master/linking.html
+++ b/master/linking.html
@@ -1148,13 +1148,13 @@ as follows:</p>
 
 <pre class="idl">[<a>Exposed</a>=Window]
 interface <b>SVGAElement</b> : <a>SVGGraphicsElement</a> {
-  [<a>SameObject</a>] readonly attribute <a>SVGAnimatedString</a> <a href="linking.html#__svg__SVGAElement__target">target</a>;
-  attribute DOMString <a href="linking.html#__svg__SVGAElement__download">download</a>;
-  attribute USVString <a href="linking.html#__svg__SVGAElement__ping">ping</a>;
-  attribute DOMString <a href="linking.html#__svg__SVGAElement__rel">rel</a>;
-  [<a>SameObject</a>, <a>PutForwards</a>=value] readonly attribute <a>DOMTokenList</a> <a href="linking.html#__svg__SVGAElement__relList">relList</a>;
-  attribute DOMString <a href="linking.html#__svg__SVGAElement__hreflang">hreflang</a>;
-  attribute DOMString <a href="linking.html#__svg__SVGAElement__type">type</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>, <a>SameObject</a>] readonly attribute <a>SVGAnimatedString</a> <a href="linking.html#__svg__SVGAElement__target">target</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="linking.html#__svg__SVGAElement__download">download</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute USVString <a href="linking.html#__svg__SVGAElement__ping">ping</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="linking.html#__svg__SVGAElement__rel">rel</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>="rel", <a>SameObject</a>, <a>PutForwards</a>=value] readonly attribute <a>DOMTokenList</a> <a href="linking.html#__svg__SVGAElement__relList">relList</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="linking.html#__svg__SVGAElement__hreflang">hreflang</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="linking.html#__svg__SVGAElement__type">type</a>;
 
   attribute DOMString <a href="linking.html#__svg__SVGAElement__referrerPolicy">referrerPolicy</a>;
 };
@@ -1162,17 +1162,6 @@ interface <b>SVGAElement</b> : <a>SVGGraphicsElement</a> {
 <a>SVGAElement</a> includes <a>SVGURIReference</a>;
 <a>SVGAElement</a> includes <a>HTMLHyperlinkElementUtils</a>;</pre>
 
-<p>The <b id="__svg__SVGAElement__target">target</b>,
-  <b id="__svg__SVGAElement__download">download</b>,
-  <b id="__svg__SVGAElement__ping">ping</b>,
-  <b id="__svg__SVGAElement__rel">rel</b>,
-  <b id="__svg__SVGAElement__hreflang">hreflang</b>,
-  <b id="__svg__SVGAElement__type">type</b>,
-  IDL attributes
-<a>reflect</a> the content attributes of the same name.</p>
-<p>The <b id="__svg__SVGAElement__relList">relList</b>
-  IDL attribute
-<a>reflects</a> the <a>'rel'</a> content attribute.</p>
 <p>The <b id="__svg__SVGAElement__referrerPolicy">referrerPolicy</b>
   IDL attribute
 <a>reflects</a> the <a>'referrerpolicy'</a> content attribute,

--- a/master/styling.html
+++ b/master/styling.html
@@ -703,8 +703,9 @@ in the DOM.</p>
 
 <pre class="idl">[<a>Exposed</a>=Window]
 interface <b>SVGStyleElement</b> : <a>SVGElement</a> {
-  attribute DOMString <a href="styling.html#__svg__SVGStyleElement__media">media</a>;
-  attribute DOMString <a href="styling.html#__svg__SVGStyleElement__title">title</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="styling.html#__svg__SVGStyleElement__type">type</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="styling.html#__svg__SVGStyleElement__media">media</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="styling.html#__svg__SVGStyleElement__title">title</a>;
   attribute boolean <a href="styling.html#__svg__SVGStyleElement__disabled">disabled</a>;
 
   // obsolete members
@@ -712,12 +713,6 @@ interface <b>SVGStyleElement</b> : <a>SVGElement</a> {
 };
 
 <a>SVGStyleElement</a> includes <a>LinkStyle</a>;</pre>
-
-<p>The <b id="__svg__SVGStyleElement__type">type</b>,
-<b id="__svg__SVGStyleElement__media">media</b> and
-<b id="__svg__SVGStyleElement__title">title</b> IDL attributes
-<a>reflect</a> the <a>'type'</a>, <a>'media'</a> and <a>'title'</a>
-content attributes, respectively.</p>
 
 </edit:with>
 


### PR DESCRIPTION
This aligns with the HTML spec in using [Reflect] rather than spec prose for the simple HTML-like attribute reflection cases.

Closes #991 