### PR TITLE
Use constructor operation for ShadowAnimation

### DIFF
--- a/master/struct.html
+++ b/master/struct.html
@@ -3207,8 +3207,9 @@ or is null otherwise.</p>
 </p>
 
 
-<pre class="idl">[<i>Constructor</i>(<a>Animation</a> source, <a>Animatable</a> newTarget), Exposed=Window]
+<pre class="idl">[Exposed=Window]
 interface <b>ShadowAnimation</b> : <a>Animation</a> {
+  constructor(<a>Animation</a> source, <a>Animatable</a> newTarget);
   [<a>SameObject</a>] readonly attribute <a>Animation</a> <a href="#__svg__ShadowAnimation__sourceAnimation">sourceAnimation</a>;
 };</pre>
 


### PR DESCRIPTION
The Constructor extended attribute has been removed from Web IDL. This update had been made against the `master` branch in #825 but not ported back to the `main` branch, which is now the one that gets published to https://svgwg.org