### PR TITLE
(Re-)Add default value for optional `DOMMatrix2DInit` args

### DIFF
--- a/master/struct.html
+++ b/master/struct.html
@@ -2683,7 +2683,7 @@ interface <b>SVGSVGElement</b> : <a>SVGGraphicsElement</a> {
   [<a>NewObject</a>] <a>DOMMatrix</a> <a href="struct.html#__svg__SVGSVGElement__createSVGMatrix">createSVGMatrix</a>();
   [<a>NewObject</a>] <a>DOMRect</a> <a href="struct.html#__svg__SVGSVGElement__createSVGRect">createSVGRect</a>();
   [<a>NewObject</a>] <a>SVGTransform</a> <a href="struct.html#__svg__SVGSVGElement__createSVGTransform">createSVGTransform</a>();
-  [<a>NewObject</a>] <a>SVGTransform</a> <a href="struct.html#__svg__SVGSVGElement__createSVGTransformFromMatrix">createSVGTransformFromMatrix</a>(optional <a>DOMMatrix2DInit</a> matrix);
+  [<a>NewObject</a>] <a>SVGTransform</a> <a href="struct.html#__svg__SVGSVGElement__createSVGTransformFromMatrix">createSVGTransformFromMatrix</a>(optional <a>DOMMatrix2DInit</a> matrix = {});
 
   <a>Element</a>? <a href="struct.html#__svg__SVGSVGElement__getElementById">getElementById</a>(DOMString elementId);
 


### PR DESCRIPTION
Required by Web IDL. This had been fixed in #844 but dropped by mistake when #783 was merged.