### PR TITLE
Use relative paths in main index file

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,16 +9,16 @@ li { margin-top: 1em; }
 <h1>SVG Working Group document repository</h1>
 <p>This site hosts a number of documents produced by the SVG Working Group:</p>
 <ul>
-  <li><a href="/svg2-draft/">SVG 2 Editor's Draft</a> &#xb7; <a href="https://github.com/w3c/svgwg/tree/main/master">source</a> &#xb7; <a href="https://github.com/w3c/svgwg/commits/master/master">changelog</a></li>
-  <!--li><a href="/specs/animation-elements/">Animation Elements Editor's Draft</a> &#xb7; <a href="https://github.com/w3c/svgwg/tree/main/specs/animation-elements">source</a> &#xb7; <a href="https://github.com/w3c/svgwg/commits/master/specs/animation-elements">changelog</a></li-->
-  <li><a href="/specs/animations/">SVG Animations Editor's Draft</a> &#xb7; <a href="https://github.com/w3c/svgwg/tree/main/specs/animations">source</a> &#xb7; <a href="https://github.com/w3c/svgwg/commits/master/specs/animations">changelog</a></li>
-  <li><a href="/specs/integration/">SVG Integration Editor's Draft</a> &#xb7; <a href="https://github.com/w3c/svgwg/tree/main/specs/integration">source</a> &#xb7; <a href="https://github.com/w3c/svgwg/commits/master/specs/integration">changelog</a></li>
-  <li><a href="/specs/streaming/">SVG Streaming Editor's Draft</a> &#xb7; <a href="https://github.com/w3c/svgwg/tree/main/specs/streaming">source</a> &#xb7; <a href="https://github.com/w3c/svgwg/commits/master/specs/streaming">changelog</a></li>
-  <li><a href="/specs/transform/">svg:transform for Mapping Editor's Draft</a> &#xb7; <a href="https://github.com/w3c/svgwg/tree/main/specs/transform">source</a> &#xb7; <a href="https://github.com/w3c/svgwg/commits/master/specs/transform">changelog</a></li>
-  <li><a href="/specs/markers/">SVG Markers Editor's Draft</a> &#xb7; <a href="https://github.com/w3c/svgwg/tree/main/specs/markers">source</a> &#xb7; <a href="https://github.com/w3c/svgwg/commits/master/specs/markers">changelog</a></li>
-  <li><a href="/specs/paths/">SVG Paths Editor's Draft</a> &#xb7; <a href="https://github.com/w3c/svgwg/tree/main/specs/paths">source</a> &#xb7; <a href="https://github.com/w3c/svgwg/commits/master/specs/paths">changelog</a></li>
-  <li><a href="/specs/strokes/">SVG Strokes Editor's Draft</a> &#xb7; <a href="https://github.com/w3c/svgwg/tree/main/specs/strokes">source</a> &#xb7; <a href="https://github.com/w3c/svgwg/commits/master/specs/strokes">changelog</a></li>
-  <li><a href="/specs/svg-native/">SVG Native Editor's Draft</a> &#xb7; <a href="https://github.com/w3c/svgwg/tree/main/specs/svg-native">source</a> &#xb7; <a href="https://github.com/w3c/svgwg/commits/master/specs/svg-native">changelog</a></li>
+  <li><a href="./svg2-draft/">SVG 2 Editor's Draft</a> &#xb7; <a href="https://github.com/w3c/svgwg/tree/main/master">source</a> &#xb7; <a href="https://github.com/w3c/svgwg/commits/master/master">changelog</a></li>
+  <!--li><a href="./specs/animation-elements/">Animation Elements Editor's Draft</a> &#xb7; <a href="https://github.com/w3c/svgwg/tree/main/specs/animation-elements">source</a> &#xb7; <a href="https://github.com/w3c/svgwg/commits/master/specs/animation-elements">changelog</a></li-->
+  <li><a href="./specs/animations/">SVG Animations Editor's Draft</a> &#xb7; <a href="https://github.com/w3c/svgwg/tree/main/specs/animations">source</a> &#xb7; <a href="https://github.com/w3c/svgwg/commits/master/specs/animations">changelog</a></li>
+  <li><a href="./specs/integration/">SVG Integration Editor's Draft</a> &#xb7; <a href="https://github.com/w3c/svgwg/tree/main/specs/integration">source</a> &#xb7; <a href="https://github.com/w3c/svgwg/commits/master/specs/integration">changelog</a></li>
+  <li><a href="./specs/streaming/">SVG Streaming Editor's Draft</a> &#xb7; <a href="https://github.com/w3c/svgwg/tree/main/specs/streaming">source</a> &#xb7; <a href="https://github.com/w3c/svgwg/commits/master/specs/streaming">changelog</a></li>
+  <li><a href="./specs/transform/">svg:transform for Mapping Editor's Draft</a> &#xb7; <a href="https://github.com/w3c/svgwg/tree/main/specs/transform">source</a> &#xb7; <a href="https://github.com/w3c/svgwg/commits/master/specs/transform">changelog</a></li>
+  <li><a href="./specs/markers/">SVG Markers Editor's Draft</a> &#xb7; <a href="https://github.com/w3c/svgwg/tree/main/specs/markers">source</a> &#xb7; <a href="https://github.com/w3c/svgwg/commits/master/specs/markers">changelog</a></li>
+  <li><a href="./specs/paths/">SVG Paths Editor's Draft</a> &#xb7; <a href="https://github.com/w3c/svgwg/tree/main/specs/paths">source</a> &#xb7; <a href="https://github.com/w3c/svgwg/commits/master/specs/paths">changelog</a></li>
+  <li><a href="./specs/strokes/">SVG Strokes Editor's Draft</a> &#xb7; <a href="https://github.com/w3c/svgwg/tree/main/specs/strokes">source</a> &#xb7; <a href="https://github.com/w3c/svgwg/commits/master/specs/strokes">changelog</a></li>
+  <li><a href="./specs/svg-native/">SVG Native Editor's Draft</a> &#xb7; <a href="https://github.com/w3c/svgwg/tree/main/specs/svg-native">source</a> &#xb7; <a href="https://github.com/w3c/svgwg/commits/master/specs/svg-native">changelog</a></li>
 </ul>
 
 <p>For more information see the wiki pages for the <a href="http://www.w3.org/Graphics/SVG/WG/">SVG Working Group</a> and <a href="http://www.w3.org/Graphics/fx/wiki/Main_Page">FX Taskforce</a>.


### PR DESCRIPTION
The index file assumed that it would be published at the root of the server. That does not work when content is published to https://w3c.github.io/svgwg/