### PR TITLE
Avoid the use of `Animatable` in `ShadowAnimation` constructor

### DIFF
--- a/master/struct.html
+++ b/master/struct.html
@@ -3209,7 +3209,7 @@ or is null otherwise.</p>
 
 <pre class="idl">[Exposed=Window]
 interface <b>ShadowAnimation</b> : <a>Animation</a> {
-  constructor(<a>Animation</a> source, <a>Animatable</a> newTarget);
+  constructor(<a>Animation</a> source, (<a>Element</a> or <a>CSSPseudoElement</a>) newTarget);
   [<a>SameObject</a>] readonly attribute <a>Animation</a> <a href="#__svg__ShadowAnimation__sourceAnimation">sourceAnimation</a>;
 };</pre>
 


### PR DESCRIPTION
Re-apply #840 to the `main` branch. As an interface mixin, `Animatable` can't be used as a type per Web IDL.
(I had missed that second update in #1010)