### PR TITLE
[Editorial] fix #1034. Adds .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 build/
 issue-state.txt
+.DS_Store


### PR DESCRIPTION
This will fix an annoyance for people working on macOS. 