### PR TITLE
Adding the note for SVGAElement regarding processing model and algorithms

### DIFF
--- a/master/linking.html
+++ b/master/linking.html
@@ -920,6 +920,13 @@ or frame to be replaced by the W3C home page.</p>
     These attributes further describe the targetted resource
     and its relationship to the current document.
     Allowed values and meaning are <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element">as defined for the <code>a</code> element in HTML</a>.
+    
+    <div class="note">
+        <p>The SVG Working Group is waiting on the HTML specification to clarify the processing model and algorithms for these attributes.
+        The attributes should follow the definitions and algorithms <a href="https://html.spec.whatwg.org/multipage/links.html#following-hyperlinks-2">as specified in the HTML specification</a>.</p>
+        For more details on the ongoing clarification effort, see the
+        <p><a href="https://github.com/whatwg/html/issues/11936">HTML specification issue on processing model and algorithms for the HTML A element</a>.</p>
+    </div>
   </dd>
 </dl>
 


### PR DESCRIPTION
As per the discussion in [Specifying processing model and algorithm for ping and referrerPolicy in SVG a element](https://github.com/w3c/svgwg/issues/1029), SVGAElement should also follow the processing model and algorithm as defined for HTMLAElement https://html.spec.whatwg.org/multipage/links.html#following-hyperlinks-2.

However, the corresponding change should ideally be done/referred in the HTML spec, as per the resolution in [Specifying processing model and algorithm for ping and referrerPolicy in SVG a element](https://github.com/w3c/svgwg/issues/1029):
`RESOLUTION: let's create a note in the SVG spec mentioning that we are waiting on the HTML spec to clarify the processing model for these attributes.`

This PR tracks the work done for adding the above note