### PR TITLE
Swap SVGAElement to the new HyperlinkElementUtils

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -1067,6 +1067,11 @@ have been made.</p>
     <a href="https://github.com/w3c/svgwg/issues/315">Issue discussion</a>
     <a href="https://github.com/w3c/svgwg/pull/409">Edits</a>
     </li>
+    <li>Replaced <a>'a'</a> element's mixin with one that avoids conflicting IDL definitions
+      between the main interface and the mixin.
+    <a href="https://github.com/w3c/svgwg/issues/312">Issue discussion</a>
+    <a href="https://github.com/w3c/svgwg/pull/1052">Edits</a>
+    </li>
   </ul>
 </div>
 

--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -795,7 +795,7 @@
   <interface name='SVGForeignObjectElement' href='embedded.html#InterfaceSVGForeignObjectElement'/>
   <interface name='SVGBoundingBoxOptions' href='types.html#SVGBoundingBoxOptions'/>
   <interface name='SVGNameList' href='types.html#ListInterfaces'/> <!-- not a real interface -->
-  <interface name='HTMLHyperlinkElementUtils' href='https://html.spec.whatwg.org/multipage/links.html#htmlhyperlinkelementutils'/>
+  <interface name='HyperlinkElementUtils' href='https://html.spec.whatwg.org/multipage/links.html#hyperlinkelementutils'/>
 
   <!-- ... grammar symbols ................................................ -->
   <symbol name='align' href='coords.html#DataTypeAlign'/>
@@ -1169,6 +1169,11 @@
   <term name='same origin' href='https://html.spec.whatwg.org/multipage/origin.html#same-origin'/>
   <term name='throw' href='https://webidl.spec.whatwg.org/#dfn-throw'/>
   <term name='thrown' href='https://webidl.spec.whatwg.org/#dfn-throw'/>
+  <term name='set the url' href='https://html.spec.whatwg.org/multipage/links.html#concept-hyperlink-url-set'/>
+  <term name='update href' href='https://html.spec.whatwg.org/multipage/links.html#update-href'/>
+  <term name='encoding-parsing a URL' href='https://html.spec.whatwg.org/multipage/urls-and-fetching.html#encoding-parsing-a-url'/>
+  <term name='node document' href='https://dom.spec.whatwg.org/#concept-node-document'/>
+  <term name='serialized' href='https://url.spec.whatwg.org/#concept-url-serializer'/>
 
   <term name='ignore' href='https://drafts.csswg.org/css-syntax/#css-ignored'/>
   <term name='ignored' href='https://drafts.csswg.org/css-syntax/#css-ignored'/>

--- a/master/linking.html
+++ b/master/linking.html
@@ -1160,7 +1160,48 @@ interface <b>SVGAElement</b> : <a>SVGGraphicsElement</a> {
 };
 
 <a>SVGAElement</a> includes <a>SVGURIReference</a>;
-<a>SVGAElement</a> includes <a>HTMLHyperlinkElementUtils</a>;</pre>
+<a>SVGAElement</a> includes <a>HyperlinkElementUtils</a>;</pre>
+
+<p>The <a>set the url</a> algorithm for an <a>SVGAElement</a>:
+  <ol>
+    <li>Set this element's <a href="https://html.spec.whatwg.org/multipage/links.html#concept-hyperlink-url">url</a> to null.</li>
+
+    <li>Let <var>url</var> be failure.</li>
+
+    <li>If this element's <span class="attr-name">'href'</span> content attribute is present:
+      <ol>
+        <li>Set <var>url</var> to the result of <a>encoding-parsing a URL</a> given this element's <span class="attr-name">'href'</span> content attribute's value,
+        relative to this element's <a>node document</a>.</li>
+      </ol>
+    </li>
+
+    <li>Otherwise, if this element's <span class="attr-name">'xlink:href'</span> content attribute is present:
+      <ol>
+        <li>Set <var>url</var> to the result of <a>encoding-parsing a URL</a> given this element's <span class="attr-name">'xlink:href'</span> content attribute's value,
+        relative to this element's <a>node document</a>.</li>
+      </ol>
+    </li>
+
+    <li>If <var>url</var> is not failure, then set this element's <a href="https://html.spec.whatwg.org/multipage/links.html#concept-hyperlink-url">url</a> to url.</li>
+  </ol>
+</p>
+
+<p>To <a>update href</a> for an <a>SVGAElement</a>:
+  <ol>
+    <li>If this element's <span class="attr-name">'xlink:href'</span> content attribute is present:
+      <ol>
+        <li>
+          Set the element's <span class="attr-name">'xlink:href'</span> content attribute's value to the element's
+          <a href="https://html.spec.whatwg.org/multipage/links.html#concept-hyperlink-url">url</a>, <a>serialized</a>.
+        </li>
+      </ol>
+    </li>
+    <li>
+      Otherwise, set the element's <span class="attr-name">'href'</span> content attribute's value to the element's
+      <a href="https://html.spec.whatwg.org/multipage/links.html#concept-hyperlink-url">url</a>, <a>serialized</a>.
+    </li>
+  </ol>
+</p>
 
 <p>The <b id="__svg__SVGAElement__referrerPolicy">referrerPolicy</b>
   IDL attribute

--- a/master/linking.html
+++ b/master/linking.html
@@ -1162,46 +1162,44 @@ interface <b>SVGAElement</b> : <a>SVGGraphicsElement</a> {
 <a>SVGAElement</a> includes <a>SVGURIReference</a>;
 <a>SVGAElement</a> includes <a>HyperlinkElementUtils</a>;</pre>
 
-<p>The <a>set the url</a> algorithm for an <a>SVGAElement</a>:
-  <ol>
-    <li>Set this element's <a href="https://html.spec.whatwg.org/multipage/links.html#concept-hyperlink-url">url</a> to null.</li>
+<p>The <a>set the url</a> algorithm for an <a>SVGAElement</a>:</p>
+<ol>
+  <li>Set this element's <a href="https://html.spec.whatwg.org/multipage/links.html#concept-hyperlink-url">url</a> to null.</li>
 
-    <li>Let <var>url</var> be failure.</li>
+  <li>Let <var>url</var> be failure.</li>
 
-    <li>If this element's <span class="attr-name">'href'</span> content attribute is present:
-      <ol>
-        <li>Set <var>url</var> to the result of <a>encoding-parsing a URL</a> given this element's <span class="attr-name">'href'</span> content attribute's value,
-        relative to this element's <a>node document</a>.</li>
-      </ol>
-    </li>
+  <li>If this element's <span class="attr-name">'href'</span> content attribute is present:
+    <ol>
+      <li>Set <var>url</var> to the result of <a>encoding-parsing a URL</a> given this element's <span class="attr-name">'href'</span> content attribute's value,
+      relative to this element's <a>node document</a>.</li>
+    </ol>
+  </li>
 
-    <li>Otherwise, if this element's <span class="attr-name">'xlink:href'</span> content attribute is present:
-      <ol>
-        <li>Set <var>url</var> to the result of <a>encoding-parsing a URL</a> given this element's <span class="attr-name">'xlink:href'</span> content attribute's value,
-        relative to this element's <a>node document</a>.</li>
-      </ol>
-    </li>
+  <li>Otherwise, if this element's <span class="attr-name">'xlink:href'</span> content attribute is present:
+    <ol>
+      <li>Set <var>url</var> to the result of <a>encoding-parsing a URL</a> given this element's <span class="attr-name">'xlink:href'</span> content attribute's value,
+      relative to this element's <a>node document</a>.</li>
+    </ol>
+  </li>
 
-    <li>If <var>url</var> is not failure, then set this element's <a href="https://html.spec.whatwg.org/multipage/links.html#concept-hyperlink-url">url</a> to url.</li>
-  </ol>
-</p>
+  <li>If <var>url</var> is not failure, then set this element's <a href="https://html.spec.whatwg.org/multipage/links.html#concept-hyperlink-url">url</a> to url.</li>
+</ol>
 
-<p>To <a>update href</a> for an <a>SVGAElement</a>:
-  <ol>
-    <li>If this element's <span class="attr-name">'xlink:href'</span> content attribute is present:
-      <ol>
-        <li>
-          Set the element's <span class="attr-name">'xlink:href'</span> content attribute's value to the element's
-          <a href="https://html.spec.whatwg.org/multipage/links.html#concept-hyperlink-url">url</a>, <a>serialized</a>.
-        </li>
-      </ol>
-    </li>
-    <li>
-      Otherwise, set the element's <span class="attr-name">'href'</span> content attribute's value to the element's
-      <a href="https://html.spec.whatwg.org/multipage/links.html#concept-hyperlink-url">url</a>, <a>serialized</a>.
-    </li>
-  </ol>
-</p>
+<p>To <a>update href</a> for an <a>SVGAElement</a>:</p>
+<ol>
+  <li>If this element's <span class="attr-name">'xlink:href'</span> content attribute is present:
+    <ol>
+      <li>
+        Set the element's <span class="attr-name">'xlink:href'</span> content attribute's value to the element's
+        <a href="https://html.spec.whatwg.org/multipage/links.html#concept-hyperlink-url">url</a>, <a>serialized</a>.
+      </li>
+    </ol>
+  </li>
+  <li>
+    Otherwise, set the element's <span class="attr-name">'href'</span> content attribute's value to the element's
+    <a href="https://html.spec.whatwg.org/multipage/links.html#concept-hyperlink-url">url</a>, <a>serialized</a>.
+  </li>
+</ol>
 
 <p>The <b id="__svg__SVGAElement__referrerPolicy">referrerPolicy</b>
   IDL attribute


### PR DESCRIPTION
See https://github.com/whatwg/html/pull/12066 for context

Implementation Bugs:
- Chromium: https://issues.chromium.org/u/1/issues/512726601
- Firefox: ...
- WebKit: https://bugs.webkit.org/show_bug.cgi?id=314728

Tests:
- https://github.com/web-platform-tests/wpt/pull/59852
- https://github.com/web-platform-tests/wpt/commit/c2f97b77c80140864c172df829e50164c345e583

Fixes https://github.com/w3c/svgwg/issues/312