### PR TITLE
Clarify that CSS width/height properties only apply to outer svg elements

### DIFF
--- a/master/geometry.html
+++ b/master/geometry.html
@@ -401,22 +401,41 @@ may be constrained by the value of the
 <a href="https://www.w3.org/TR/CSS21/visudet.html#propdef-max-height"><span class="prop-name">min-height</span></a> properties.
 </p>
 
-<p>The value <span class='prop-value'>auto</span> for <a>'width'</a>
-and <a>'height'</a> on the <a>'svg'</a> element is treated as 100%.</p>
+<p>The following table summarizes how the value
+<span class='prop-value'>auto</span> for <a>'width'</a> and <a>'height'</a>
+is treated on different elements:</p>
 
-<p>The value <span class='prop-value'>auto</span> for <a>'width'</a>
-and <a>'height'</a> on the <a>'image'</a> element is calculated from the referenced image's intrinsic dimensions and aspect ratio, according to the CSS <a>Default Sizing Algorithm</a>.</p>
-
-<p>Content dependent units used in 'width' and 'height' for inner SVG elements resolve to SVG's definition of <a><span class='prop-value'>auto</span></a>. These content dependent units include 
-<a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-min-content">'min-content'</a>, <a href="https://drafts.csswg.org/css-sizing-3/#valdef-width-max-content">'max-content'</a>, 
-<a href="https://drafts.csswg.org/css-sizing-3/#funcdef-width-fit-content">'fit-content()'</a> and <a href="https://drafts.csswg.org/css-sizing-3/#funcdef-width-calc-size">'calc-size()'</a>.</p>
+<table class="data">
+  <thead>
+    <tr>
+      <th>Element</th>
+      <th>Value</th>
+      <th>Treated as</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a>'svg'</a></td>
+      <td><span class='prop-value'>auto</span></td>
+      <td><span class='prop-value'>100%</span></td>
+    </tr>
+    <tr>
+      <td><a>'image'</a></td>
+      <td><span class='prop-value'>auto</span></td>
+      <td>Calculated from the referenced image's intrinsic dimensions and aspect ratio,
+        according to the CSS <a>Default Sizing Algorithm</a></td>
+    </tr>
+    <tr>
+      <td>All other elements</td>
+      <td><span class='prop-value'>auto</span></td>
+      <td><span class='prop-value'>0</span></td>
+    </tr>
+  </tbody>
+</table>
 
 <p class="note">
     New in SVG 2.  Images embedded in SVG can now be auto-sized to the intrinsic size, or scaled to a fixed height or width according to the intrinsic aspect ratio.  This matches the behavior of embedded images in HTML.
 </p>
-
-<p>The value <span class='prop-value'>auto</span> for <a>'width'</a>
-and <a>'height'</a> on other elements is treated as 0.</p>
 
 <p class='note'>This means that, for example, a <a>'foreignObject'</a>
 object element will not shrink-wrap to its contents if


### PR DESCRIPTION
Per the [SVG WG resolution from 2026-02-05](https://www.w3.org/2026/02/05-svg-minutes.html#cba7):

> The CSS width/height properties are honored as presentation attributes for rect, image, foreignObject and outer-SVG elements and ignored by all other elements with the width/height attributes.

This change updates Section 7.8 (Sizing properties) to:

- Clarify that CSS `width` and `height` properties apply only to the **outermost** `<svg>` element, not nested ones
- Add a note explicitly stating that nested `<svg>`, `<use>`, and `<symbol>` elements have width/height attributes but do **not** accept them as CSS properties—they must be specified as XML attributes