### PR TITLE
Clarify path d animation mismatch handling for from/by and additive animations

### DIFF
--- a/master/paths.html
+++ b/master/paths.html
@@ -245,11 +245,19 @@ is the same as the <span class='prop-value'>none</span> value.</p>
 </p>
 <p>
   For <a href="https://svgwg.org/specs/animations/#FromAttribute">from</a>/<a href="https://svgwg.org/specs/animations/#ByAttribute">by</a> animations
-  or additive animations, if the specified animation values are
+  or <a href="https://svgwg.org/specs/animations/#AdditiveAttribute">additive</a> animations, if the specified animation values are
   incompatible (i.e. the path data command lists do not have the same
-  structure), then the animation has no effect and the
-  element must render using the base value during and after the
-  animation.
+  structure), then the animation must not produce an effect value.
+  The element must render using the base value for the duration of the
+  animation and after the animation ends. In particular, when
+  <span class='attr-name'>'fill'</span>=<span class='attr-value'>'freeze'</span>
+  is specified, the frozen value must be the base value.
+</p>
+<p class="note">
+  A <a href="https://svgwg.org/specs/animations/#ByAttribute">by</a> animation is additive by definition, so when the base value's
+  path data command list is incompatible with the <a href="https://svgwg.org/specs/animations/#ByAttribute">by</a> value, additive
+  composition is undefined; see
+  <a href="https://www.w3.org/TR/2001/REC-smil-animation-20010904/#FromToByAndAdditive">SMIL Animation: from, to, by and additive behavior</a>.
 </p>
 <p>
   If the list of path data commands have the same structure, then each


### PR DESCRIPTION
This change adds more clarification about explicit handling for from/by and additive animations when there are mismatched commands. If they are incompatible, the animation has no effect and the base value is used during and after the animation.

https://github.com/w3c/svgwg/issues/1056