### PR TITLE
[editorial] Replace instances of svgwg.org by w3c.github.io/svgwg. Fix #1060

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Editor's drafts:
 * [SVG 2](https://w3c.github.io/svgwg/svg2-draft/)
 * [SVG-AAM](https://w3c.github.io/svg-aam/)
 <!--
-* [SVG Animations](https://svgwg.org/specs/animations/)
-* [SVG Integration](https://svgwg.org/specs/integration/)
-* [SVG Streaming](https://svgwg.org/specs/streaming/)
-* [svg:transform for Mapping](https://svgwg.org/specs/transform/)
-* [SVG Markers](https://svgwg.org/specs/markers/)
-* [SVG Paths](https://svgwg.org/specs/paths/)
-* [SVG Strokes](https://svgwg.org/specs/strokes/)
+* [SVG Animations](https://w3c.github.io/svgwg/specs/animations/)
+* [SVG Integration](https://w3c.github.io/svgwg/specs/integration/)
+* [SVG Streaming](https://w3c.github.io/svgwg/specs/streaming/)
+* [svg:transform for Mapping](https://w3c.github.io/svgwg/specs/transform/)
+* [SVG Markers](https://w3c.github.io/svgwg/specs/markers/)
+* [SVG Paths](https://w3c.github.io/svgwg/specs/paths/)
+* [SVG Strokes](https://w3c.github.io/svgwg/specs/strokes/)
 -->
 
 The SVG2 spec draft is automatically rebuilt on pushes to this repository.

--- a/master/animate.html
+++ b/master/animate.html
@@ -22,7 +22,7 @@ to create animated effects.
 SVG content can be animated in the following ways:</p>
 
 <ul>
-  <li>Using SVG's <a href="https://svgwg.org/specs/animations/">animation elements</a>
+  <li>Using SVG's <a href="https://w3c.github.io/svgwg/specs/animations/">animation elements</a>
   [<a href="refs.html#ref-svg-animation">svg-animation</a>].
   SVG document fragments can describe time-based modifications
   to the document's elements. Using the various animation

--- a/master/changes.html
+++ b/master/changes.html
@@ -1039,7 +1039,7 @@ have been made.</p>
 
 <ul>
   <li>Moved this chapter to a separate
-  <a href="https://svgwg.org/specs/animations/">SVG Animations</a> module.</li>
+  <a href="https://w3c.github.io/svgwg/specs/animations/">SVG Animations</a> module.</li>
   <li>Some informative text moved to a new Animation appendix.</li>
 </ul>
 

--- a/master/conform.html
+++ b/master/conform.html
@@ -693,7 +693,7 @@ is technically <em>in error</em>:</p>
 
 <p>A dynamic document can go in and out of error over time. For
 example, document changes from the <a href="types.html#SVGDOMOverview">SVG DOM</a>
-or from <a href="https://svgwg.org/specs/animations/">animation</a> can cause
+or from <a href="https://w3c.github.io/svgwg/specs/animations/">animation</a> can cause
 a document to become <em>in error</em> and a further change can
 cause the document to become correct again.</p>
 

--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -808,7 +808,7 @@
   <symbol name='color' href='https://www.w3.org/TR/css3-values/#colors'/>
   <symbol name='dasharray' href='painting.html#DataTypeDasharray'/>
   <symbol name='frequency' href='https://www.w3.org/TR/css3-values/#frequency'/>
-  <symbol name='icccolor' href='https://svgwg.org/specs/color/#DataTypeICCColor'/>
+  <symbol name='icccolor' href='https://w3c.github.io/svgwg/specs/color/#DataTypeICCColor'/>
   <symbol name='image' href='https://www.w3.org/TR/css3-values/#images'/>
   <symbol name='integer' href='https://www.w3.org/TR/css3-values/#integers'/>
   <symbol name='length' href='https://www.w3.org/TR/css3-values/#lengths'/>

--- a/master/interact.html
+++ b/master/interact.html
@@ -24,7 +24,7 @@ the SVG language:</p>
 
 <ul>
   <li>User-initiated actions such as button presses on the
-  pointing device (e.g., a mouse) can cause <a href="https://svgwg.org/specs/animations/">animations</a>
+  pointing device (e.g., a mouse) can cause <a href="https://w3c.github.io/svgwg/specs/animations/">animations</a>
   or <a href="interact.html">scripts</a> to execute.</li>
 
   <li>The user can initiate hyperlinks to new Web pages (see
@@ -275,7 +275,7 @@ event types for UI Events can be found in the ([<a href="refs.html#ref-uievents"
 For other event types, the parameters passed to event listeners
 are described elsewhere in this specification.</p>
 
-<p>Likewise, <a href='https://svgwg.org/specs/animations/#EventValueSyntax'>event-value timing specifiers</a>
+<p>Likewise, <a href='https://w3c.github.io/svgwg/specs/animations/#EventValueSyntax'>event-value timing specifiers</a>
 used in <a>animation element</a> <a>'animate/begin'</a> and <a>'animate/end'</a>
 attributes are resolved to concrete times only in response to "bubbling" and
 "at target" phase events dispatched to the relevant element.</p>
@@ -308,7 +308,7 @@ such as <code>load</code> and <code>error</code> events.
 </p>
 
 <p>SVG animation elements
-  (defined in the <a href="https://svgwg.org/specs/animations/">SVG Animations Level 2</a> specification)
+  (defined in the <a href="https://w3c.github.io/svgwg/specs/animations/">SVG Animations Level 2</a> specification)
   support additional events and event attributes.
   The following event types are triggered due to state
   changes in animations.
@@ -452,7 +452,7 @@ DOM event, is as follows:</p>
 
   <li>If the element and the event type are associated with the activation
   or cancelation of declarative animation though the use of
-  <a href="https://svgwg.org/specs/animations/#EventValueSyntax">event-value</a> timing specifiers,
+  <a href="https://w3c.github.io/svgwg/specs/animations/#EventValueSyntax">event-value</a> timing specifiers,
   any corresponding instance times must be resolved, and any consequential
   actions of this instance time resolution (such as immediately starting
   or stopping the animation) must be performed;</li>
@@ -866,7 +866,7 @@ attribute.</p>
   as if processed with the media type <span class="attr-value">'application/ecmascript'</span>.
   [<a href="refs.html#ref-rfc2046">rfc2046</a>][<a href='refs.html#ref-rfc4329'>rfc4329</a>]</p>
 
-  <p>Event attributes are not <a href="https://svgwg.org/specs/animations/#Animatable">animatable</a>.</p>
+  <p>Event attributes are not <a href="https://w3c.github.io/svgwg/specs/animations/#Animatable">animatable</a>.</p>
 
   <p>Implementors may view the setting of event attributes as the
   creation and registration of an <a>EventListener</a> on the

--- a/master/linking.html
+++ b/master/linking.html
@@ -45,7 +45,7 @@ http://example.com/someDrawing.svg#Lamppost
 
 <h4 id="AlteringHref">Altering the <span class="attr-name">'href'</span> attribute</h4>
 
-<p>If the <a href="https://svgwg.org/specs/animations/#HrefAttribute"><span class="attr-name">'href'</span></a>
+<p>If the <a href="https://w3c.github.io/svgwg/specs/animations/#HrefAttribute"><span class="attr-name">'href'</span></a>
 attribute of an element in the tree is altered by any means (e.g. script, declarative
 animation) such that a new resource is referenced, the new resource must replace
 the existing resource, and must be rendered as appropriate.  For specific effects
@@ -508,7 +508,7 @@ in section 3.1 of the <a href="http://www.ietf.org/rfc/rfc3987.txt">URL specific
   <li>
     <p>
       If the URL reference is from
-      the <span class="attr-name">href</span> attribute on <a href="https://svgwg.org/specs/animations/#TargetElement">SVG animation elements</a>,
+      the <span class="attr-name">href</span> attribute on <a href="https://w3c.github.io/svgwg/specs/animations/#TargetElement">SVG animation elements</a>,
       only <a>same-document URL</a> references are allowed
       [<a href="refs.html#ref-svg-animation">svg-animation</a>].
       A URL referring to a different document is invalid

--- a/master/paths.html
+++ b/master/paths.html
@@ -27,7 +27,7 @@
   these functions at the same time. (See
   <a href="painting.html">Filling, Stroking and Paint Servers</a>,
   <a href="render.html#ClippingAndMasking">Clipping and Masking</a>,
-  Animation (<a href="https://svgwg.org/specs/animations/#AnimateMotionElement">'animateMotion'</a>),
+  Animation (<a href="https://w3c.github.io/svgwg/specs/animations/#AnimateMotionElement">'animateMotion'</a>),
   and <a href="text.html#TextLayoutPath">Text on a Path</a>.)
 </p>
 
@@ -1165,7 +1165,7 @@ and will affect rendering in the following cases:</p>
 
 <p>Various operations, including <a
 href="text.html#TextLayoutPath">text on a path</a> and <a
-href="https://svgwg.org/specs/animations/#AnimateMotionElement">motion animation</a>
+href="https://w3c.github.io/svgwg/specs/animations/#AnimateMotionElement">motion animation</a>
 and various <a href="painting.html#StrokeProperties">stroke
 operations</a>, require that the user agent compute the
 distance along the geometry of a graphics element, such as a <a>'path'</a>.</p>
@@ -1214,7 +1214,7 @@ commands contribute to path length calculations.</p>
     of <a>'pathLength'</a> to the user
     agent's own computed value for total path length. <a>'pathLength'</a> potentially affects
     calculations for <a href="text.html#TextLayoutPath">text on a path</a>,
-    <a href="https://svgwg.org/specs/animations/#AnimateMotionElement">motion animation</a> and
+    <a href="https://w3c.github.io/svgwg/specs/animations/#AnimateMotionElement">motion animation</a> and
     various <a href="painting.html#StrokeProperties">stroke operations</a>.</p>
     <p class="ready-for-wider-review">
     A value of zero is valid and must be treated as a scaling factor of infinity.

--- a/master/publish.xml
+++ b/master/publish.xml
@@ -18,8 +18,8 @@
   -->
 
   <versions>
-    <cvs href='https://svgwg.org/svg2-draft/'/>
-    <cvs-single href='https://svgwg.org/svg2-draft/single-page.html'/>
+    <cvs href='https://w3c.github.io/svgwg/svg2-draft/'/>
+    <cvs-single href='https://w3c.github.io/svgwg/svg2-draft/single-page.html'/>
     <this href='https://www.w3.org/TR/2018/CR-SVG2-20180807/'/>
     <this-single href='https://www.w3.org/TR/2018/CR-SVG2-20180807/single-page.html'/>
     <previous href='https://www.w3.org/TR/2016/CR-SVG2-20160915/'/>
@@ -31,7 +31,7 @@
   <definitions href='definitions-filters.xml' base='https://drafts.fxtf.org/filter-effects/'/>
   <definitions href='definitions-masking.xml' base='https://drafts.fxtf.org/css-masking-1/'/>
   <definitions href='definitions-compositing.xml' base='https://drafts.fxtf.org/compositing-1/'/>
-  <definitions href='../specs/animations/master/definitions.xml' base='https://svgwg.org/specs/animations/'/>
+  <definitions href='../specs/animations/master/definitions.xml' base='https://w3c.github.io/svgwg/specs/animations/'/>
 
   <interfaces idl='../build/svg.idlx'/>
 

--- a/master/refs.html
+++ b/master/refs.html
@@ -295,8 +295,8 @@
   <dd><div>Cameron McCormack; Doug Schepers; Dirk Schulze. <a href="https://www.w3.org/TR/svg-integration/"><cite><strong class="highlight">SVG Integration</strong></cite></a>. 17 April 2014. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/svg-integration/">https://www.w3.org/TR/svg-integration/</a> ED:&nbsp;<a href="https://dvcs.w3.org/hg/svg2/specs/integration">https://dvcs.w3.org/hg/svg2/specs/integration</a></div></dd>
   -->
 
-  <dt id="ref-svg-animation" class="informref">[<a href="https://svgwg.org/specs/animations">svg-animation</a>]</dt>
-  <dd><div>Brian Birtles. <a href="https://svgwg.org/specs/animations"><cite><strong class="highlight">SVG Animations</strong></cite></a>. W3C Editor's Draft. URL:&nbsp;<a href="https://svgwg.org/specs/animations">https://svgwg.org/specs/animations</a></div></dd>
+  <dt id="ref-svg-animation" class="informref">[<a href="https://w3c.github.io/svgwg/specs/animations">svg-animation</a>]</dt>
+  <dd><div>Brian Birtles. <a href="https://w3c.github.io/svgwg/specs/animations"><cite><strong class="highlight">SVG Animations</strong></cite></a>. W3C Editor's Draft. URL:&nbsp;<a href="https://w3c.github.io/svgwg/specs/animations">https://w3c.github.io/svgwg/specs/animations</a></div></dd>
 
   <dt id="ref-uaag20" class="informref">[<a href="https://www.w3.org/TR/UAAG20/">UAAG20</a>]</dt>
   <dd><div>James Allan; Greg Lowney; Kimberly Patch; Jeanne F Spellman. <a href="https://www.w3.org/TR/UAAG20/"><cite>User Agent Accessibility Guidelines (UAAG) 2.0</cite></a>. 15 December 2015. W3C Note. URL:&nbsp;<a href="https://www.w3.org/TR/UAAG20/">https://www.w3.org/TR/UAAG20/</a> ED:&nbsp;<a href="https://www.w3.org/TR/2015/NOTE-UAAG20-20151215/">https://www.w3.org/TR/2015/NOTE-UAAG20-20151215/</a></div></dd>

--- a/master/struct.html
+++ b/master/struct.html
@@ -1068,7 +1068,7 @@ svg:hover .dark, svg:focus .dark {
 <p>
   The <a href="https://www.w3.org/TR/web-animations-1/">Web Animations API</a>
   [<a href="refs.html#ref-web-animations-1">web-animations-1</a>]
-  and the <a href="https://svgwg.org/specs/animations/">SVG Animations</a> specification
+  and the <a href="https://w3c.github.io/svgwg/specs/animations/">SVG Animations</a> specification
   [<a href="refs.html#ref-svg-animation">svg-animation</a>]
   define non-CSS ways to animate attributes and styles
   on targetted elements without directly manipulating DOM properties

--- a/master/text.html
+++ b/master/text.html
@@ -5930,7 +5930,7 @@ the dash pattern at the same positions across different implementations.</p>
     The <a>'xml:space'</a> attribute is:
   </p>
   <p>
-    &nbsp;&nbsp;&nbsp;&nbsp;<span class="anim-target"><a href="https://svgwg.org/specs/animations/#Animatable">Animatable</a>:
+    &nbsp;&nbsp;&nbsp;&nbsp;<span class="anim-target"><a href="https://w3c.github.io/svgwg/specs/animations/#Animatable">Animatable</a>:
     no.</span>
   </p>
 

--- a/master/types.html
+++ b/master/types.html
@@ -25,7 +25,7 @@
       that attribute or property is not specified, or when it has an
       <a>invalid value</a>.
       This value is to be used for the purposes of rendering, calculating
-      <a href="https://svgwg.org/specs/animations/">animation values</a>,
+      <a href="https://w3c.github.io/svgwg/specs/animations/">animation values</a>,
       and when accessing the attribute or property via DOM interfaces.
     </p>
   </dd>
@@ -185,7 +185,7 @@ the attribute is assumed to have been specified as the given <a>initial value</a
 
 <p>The Animatable column indicates whether the attribute can be animated using
 <a>animation elements</a> as defined in the <a
-  href="https://svgwg.org/specs/animations/">SVG Animation</a> module.</p>
+  href="https://w3c.github.io/svgwg/specs/animations/">SVG Animation</a> module.</p>
 
 </div>
 
@@ -906,8 +906,8 @@ an element; and must return false otherwise.
 The outline path must take the stroke properties <a>'stroke-width'</a>,
 <a>'stroke-linecap'</a>, <a>'stroke-linejoin'</a>, <a>'stroke-miterlimit'</a>, <a>'stroke-dasharray'</a>,
 <a>'stroke-dashoffset'</a> and <a>'vector-effect'</a> of an element into account. See sections
-<a href="https://svgwg.org/svg2-draft/painting.html#StrokeShape">Computing the shape of the stroke</a> and
-<a href="https://svgwg.org/svg2-draft/painting.html#PaintingVectorEffects">Vector effects</a> for details.
+<a href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeShape">Computing the shape of the stroke</a> and
+<a href="https://w3c.github.io/svgwg/svg2-draft/painting.html#PaintingVectorEffects">Vector effects</a> for details.
 The returned value is independent of any visual CSS property but the listed stroke properties.
 If either of the <var>x</var> or <var>y</var> properties on <var>point</var> are infinite or NaN,
 then the method must return false. If current element is a <a>
@@ -2709,7 +2709,7 @@ and <a href='#__svg__SVGAnimatedString__animVal'>animVal</a> members, the deprec
 <a>'xlink:href'</a> attribute, if that attribute is
 present and the <span class='attr-name'>'href'</span> is not, and to
 reflect the <span class='attr-name'>'href'</span> attribute in all
-other circumstances. <a href="https://svgwg.org/specs/animations/">Animation elements</a>
+other circumstances. <a href="https://w3c.github.io/svgwg/specs/animations/">Animation elements</a>
 treat <span class='attr-value'>attributeName='xlink:href'</span>
 as being an alias for targeting the <span class='attr-name'>'href'</span> attribute.</p>
 

--- a/specs/animations/master/definitions.xml
+++ b/specs/animations/master/definitions.xml
@@ -83,9 +83,9 @@
   <attributecategory
       name='animation event'
       href='#TermAnimationEventAttribute'>
-    <attribute name='onbegin' href='http://svgwg.org/svg2-draft/interact.html#OnBeginEventAttribute'/>
-    <attribute name='onend' href='http://svgwg.org/svg2-draft/interact.html#OnEndEventAttribute'/>
-    <attribute name='onrepeat' href='http://svgwg.org/svg2-draft/interact.html#OnRepeatEventAttribute'/>
+    <attribute name='onbegin' href='http://w3c.github.io/svgwg/svg2-draft/interact.html#OnBeginEventAttribute'/>
+    <attribute name='onend' href='http://w3c.github.io/svgwg/svg2-draft/interact.html#OnEndEventAttribute'/>
+    <attribute name='onrepeat' href='http://w3c.github.io/svgwg/svg2-draft/interact.html#OnRepeatEventAttribute'/>
   </attributecategory>
 
   <attributecategory

--- a/specs/animations/master/publish.xml
+++ b/specs/animations/master/publish.xml
@@ -18,7 +18,7 @@
   -->
 
   <versions>
-    <cvs href='https://svgwg.org/specs/animations/'/>
+    <cvs href='https://w3c.github.io/svgwg/specs/animations/'/>
     <!--
     <this href='http://www.w3.org/TR/2015/WD-svg-animation-2015xxxx/'/>
     <previous href='http://www.w3.org/TR/2015/WD-svg-animation-2015xxxx/'/>
@@ -27,7 +27,7 @@
   </versions>
 
   <definitions href='definitions.xml' specid='Animation'/>
-  <definitions href='../../../master/definitions.xml' base='https://svgwg.org/svg2-draft/' specid='SVG2'/>
+  <definitions href='../../../master/definitions.xml' base='https://w3c.github.io/svgwg/svg2-draft/' specid='SVG2'/>
   <definitions href='../../../master/definitions-filters.xml' base='http://www.w3.org/TR/2014/WD-filter-effects-1-20141125/' specid='Filters' mainspec='SVG2'/>
   <definitions href='../../../master/definitions-masking.xml' base='https://drafts.fxtf.org/css-masking-1/' specid='Masking' mainspec='SVG2'/>
   <definitions href='../../../master/definitions-compositing.xml' base='http://www.w3.org/TR/2015/CR-compositing-1-20150113/' specid='Compositing' mainspec='SVG2'/>

--- a/specs/color/Overview.html
+++ b/specs/color/Overview.html
@@ -305,7 +305,7 @@ If ICC-based colors are provided,
 then the ICC-based color takes precedence over the sRGB color specification;
 otherwise, the sRGB fallback colors will be used.
 Note that, in this specification, by default color interpolation occurs in sRGB color space even if an
-ICC-based color specification is provided, but this can be changed (see <a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty">color-interpolation</a></a>).</p>
+ICC-based color specification is provided, but this can be changed (see <a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#ColorInterpolationProperty">color-interpolation</a></a>).</p>
 
 
    <div class="ready-for-wider-review">
@@ -777,8 +777,8 @@ definition of <a data-link-type="dfn"><a class="property" data-link-type="propde
 
 
     <p>The <a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="http://dev.w3.org/csswg/css-color-3/#color0">color</a></a> property is used to provide a potential indirect value,
-<span class="prop-value">currentColor</span>, for the <a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="https://svgwg.org/svg2-draft/painting.html#FillProperty">fill</a></a>,
-<a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="https://svgwg.org/svg2-draft/painting.html#StrokeProperty">stroke</a></a>, <a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="https://svgwg.org/svg2-draft/pservers.html#SolidColorProperty">solid-color</a></a>, <a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="https://svgwg.org/svg2-draft/pservers.html#StopColorProperty">stop-color</a></a>, <a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="http://dev.w3.org/fxtf/filters/#propdef-flood-color">flood-color</a></a> and
+<span class="prop-value">currentColor</span>, for the <a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#FillProperty">fill</a></a>,
+<a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeProperty">stroke</a></a>, <a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#SolidColorProperty">solid-color</a></a>, <a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopColorProperty">stop-color</a></a>, <a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="http://dev.w3.org/fxtf/filters/#propdef-flood-color">flood-color</a></a> and
 <a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="http://dev.w3.org/fxtf/filters/#propdef-lighting-color">lighting-color</a></a> properties.  The property has no other effect
 on SVG elements.</p>
 
@@ -1010,7 +1010,7 @@ child elements.</p>
 
     <dl>
 
-     <dt id="ColorProfileNameProperty"><a class="self-link" href="#ColorProfileNameProperty"></a><span class="descdef-title property"><a class="property" data-link-type="propdesc" href="https://svgwg.org/svg2-draft/color.html#ColorProfileNameProperty">name</a></span>
+     <dt id="ColorProfileNameProperty"><a class="self-link" href="#ColorProfileNameProperty"></a><span class="descdef-title property"><a class="property" data-link-type="propdesc" href="https://w3c.github.io/svgwg/svg2-draft/color.html#ColorProfileNameProperty">name</a></span>
 
 
      <dd>
@@ -1064,10 +1064,10 @@ child elements.</p>
     <dt><span class="prop-value"><a class="css" data-link-type="type">&lt;identifier></a></span>
 
     <dd>The name which is used as the first parameter for <span class="prop-value">icc-color</span> specifications within
-  <a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="https://svgwg.org/svg2-draft/painting.html#FillProperty">fill</a></a>, <a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="https://svgwg.org/svg2-draft/painting.html#StrokeProperty">stroke</a></a>, <a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="https://svgwg.org/svg2-draft/pservers.html#StopColorProperty">stop-color</a></a>,
+  <a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#FillProperty">fill</a></a>, <a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeProperty">stroke</a></a>, <a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopColorProperty">stop-color</a></a>,
   <a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="http://dev.w3.org/fxtf/filters/#propdef-flood-color">flood-color</a></a> and <a data-link-type="dfn"><a class="property" data-link-type="propdesc" href="http://dev.w3.org/fxtf/filters/#propdef-lighting-color">lighting-color</a></a> property
   values to identify the color profile to use for the ICC
-  color specification.  Note that if <a class="property" data-link-type="propdesc" href="https://svgwg.org/svg2-draft/color.html#ColorProfileNameProperty">name</a> is not
+  color specification.  Note that if <a class="property" data-link-type="propdesc" href="https://w3c.github.io/svgwg/svg2-draft/color.html#ColorProfileNameProperty">name</a> is not
   provided, it will be impossible to reference the given @color-profile
   definition.
 </dl>
@@ -1077,7 +1077,7 @@ child elements.</p>
 
     <dl>
 
-     <dt id="RenderingIntentProperty"><a class="self-link" href="#RenderingIntentProperty"></a><span class="descdef-title property"><a class="property" data-link-type="propdesc" href="https://svgwg.org/svg2-draft/color.html#RenderingIntentProperty">rendering-intent</a></span>
+     <dt id="RenderingIntentProperty"><a class="self-link" href="#RenderingIntentProperty"></a><span class="descdef-title property"><a class="property" data-link-type="propdesc" href="https://w3c.github.io/svgwg/svg2-draft/color.html#RenderingIntentProperty">rendering-intent</a></span>
 
 
      <dd>
@@ -1610,13 +1610,13 @@ Non-experimental implementations</span><a class="self-link" href="#testing"></a>
     </ul>
    <li><a data-link-type="biblio" href="#biblio-svg2">[svg2]</a> defines the following terms:
     <ul>
-     <li><a href="https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty">color-interpolation</a>
-     <li><a href="https://svgwg.org/svg2-draft/painting.html#FillProperty">fill</a>
-     <li><a href="https://svgwg.org/svg2-draft/color.html#ColorProfileNameProperty">name</a>
-     <li><a href="https://svgwg.org/svg2-draft/color.html#RenderingIntentProperty">rendering-intent</a>
-     <li><a href="https://svgwg.org/svg2-draft/pservers.html#SolidColorProperty">solid-color</a>
-     <li><a href="https://svgwg.org/svg2-draft/pservers.html#StopColorProperty">stop-color</a>
-     <li><a href="https://svgwg.org/svg2-draft/painting.html#StrokeProperty">stroke</a>
+     <li><a href="https://w3c.github.io/svgwg/svg2-draft/painting.html#ColorInterpolationProperty">color-interpolation</a>
+     <li><a href="https://w3c.github.io/svgwg/svg2-draft/painting.html#FillProperty">fill</a>
+     <li><a href="https://w3c.github.io/svgwg/svg2-draft/color.html#ColorProfileNameProperty">name</a>
+     <li><a href="https://w3c.github.io/svgwg/svg2-draft/color.html#RenderingIntentProperty">rendering-intent</a>
+     <li><a href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#SolidColorProperty">solid-color</a>
+     <li><a href="https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopColorProperty">stop-color</a>
+     <li><a href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeProperty">stroke</a>
     </ul>
   </ul>
   <h2 class="no-num heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>

--- a/specs/integration/Overview.html
+++ b/specs/integration/Overview.html
@@ -12,7 +12,7 @@
   <h1 class="p-name no-ref" id=title>SVG Integration Module Level 1</h1>
   <h2 class="no-num no-toc no-ref heading settled heading" id=subtitle><span class=content>Editor’s Draft,
     <span class=dt-updated><span class=value-title title=20131101>1 November 2013</span></span></span></h2>
-  <div data-fill-with=spec-metadata><dl><dt>This version:<dd><a class=u-url href=https://svgwg.org/specs/integration/>https://svgwg.org/specs/integration/</a><dt>Editor’s Draft:<dd><a href=https://svgwg.org/specs/integration/>https://svgwg.org/specs/integration/</a>
+  <div data-fill-with=spec-metadata><dl><dt>This version:<dd><a class=u-url href=https://w3c.github.io/svgwg/specs/integration/>https://w3c.github.io/svgwg/specs/integration/</a><dt>Editor’s Draft:<dd><a href=https://w3c.github.io/svgwg/specs/integration/>https://w3c.github.io/svgwg/specs/integration/</a>
     <dt>Feedback:</dt>
         <dd><a href="mailto:www-svg@w3.org?subject=%5Bsvg-integration%5D%20feedback">www-svg@w3.org</a>
             with subject line

--- a/specs/integration/Overview.src.html
+++ b/specs/integration/Overview.src.html
@@ -3,7 +3,7 @@
 Status: ED
 Group: svg
 Status Text: A document providing guidance how to reference SVG.
-ED: https://svgwg.org/specs/integration/
+ED: https://w3c.github.io/svgwg/specs/integration/
 Shortname: svg-integration
 Level: 1
 Ignored Terms: <circle>, <rect>, <path>, <lineargradient>, <pattern>, <mask>, <filter>, <iframe>, <embed>, <object>, <foreignObject>, nested browsing context, SVG resources

--- a/specs/integration/master/publish.xml
+++ b/specs/integration/master/publish.xml
@@ -18,7 +18,7 @@
   -->
 
   <versions>
-    <cvs href='https://svgwg.org/specs/integration/'/>
+    <cvs href='https://w3c.github.io/svgwg/specs/integration/'/>
     <this href='http://www.w3.org/TR/2014/WD-svg-integration-20140417/'/>
     <!--
     <previous href='http://www.w3.org/TR/2014/WD-svg-integration-2014xxxx/'/>
@@ -27,7 +27,7 @@
   </versions>
 
   <definitions href='definitions.xml' specid='Integration'/>
-  <definitions href='../../../master/definitions.xml' base='https://svgwg.org/svg2-draft/' specid='SVG2'/>
+  <definitions href='../../../master/definitions.xml' base='https://w3c.github.io/svgwg/svg2-draft/' specid='SVG2'/>
   <definitions href='../../../master/definitions-filters.xml' base='http://dev.w3.org/fxtf/filters/' specid='Filters' mainspec='SVG2'/>
   <definitions href='../../../master/definitions-masking.xml' base='http://dev.w3.org/fxtf/css-masking-1/' specid='Masking' mainspec='SVG2'/>
   <definitions href='../../../master/definitions-compositing.xml' base='http://dev.w3.org/fxtf/compositing-1/' specid='Compositing' mainspec='SVG2'/>

--- a/specs/marker/Overview.html
+++ b/specs/marker/Overview.html
@@ -78,7 +78,7 @@ table.attrdef td:first-child + td + td + td { width: 6em; padding-right: 0 !impo
   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
 
   <div class="p-summary" data-fill-with="abstract">
-   <p>Markers are graphical objects that are painted at particular positions along a <a data-link-type="element" href="https://svgwg.org/svg2-draft/paths.html#elementdef-path">path</a>, <a data-link-type="element" href="https://svgwg.org/svg2-draft/shapes.html#elementdef-line">line</a>, <a data-link-type="element" href="https://svgwg.org/svg2-draft/shapes.html#elementdef-polyline">polyline</a> or <a data-link-type="element" href="https://svgwg.org/svg2-draft/shapes.html#elementdef-polygon">polygon</a> element.</p>
+   <p>Markers are graphical objects that are painted at particular positions along a <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#elementdef-path">path</a>, <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#elementdef-line">line</a>, <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#elementdef-polyline">polyline</a> or <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#elementdef-polygon">polygon</a> element.</p>
 
 </div>
 
@@ -185,7 +185,7 @@ Non-experimental implementations</span></a>
 
 
    <p>A marker is a graphical object that is painted at particular positions along
-a <a data-link-type="element" href="https://svgwg.org/svg2-draft/paths.html#elementdef-path">path</a>, <a data-link-type="element" href="https://svgwg.org/svg2-draft/shapes.html#elementdef-line">line</a>, <a data-link-type="element" href="https://svgwg.org/svg2-draft/shapes.html#elementdef-polyline">polyline</a> or <a data-link-type="element" href="https://svgwg.org/svg2-draft/shapes.html#elementdef-polygon">polygon</a>
+a <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#elementdef-path">path</a>, <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#elementdef-line">line</a>, <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#elementdef-polyline">polyline</a> or <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#elementdef-polygon">polygon</a>
 element, together known as the <dfn data-dfn-type="dfn" data-noexport="" external="" id="markable-elements">markable elements<a class="self-link" href="#markable-elements"></a></dfn>.  There are four ways
 markers can be placed on these elements:</p>
 
@@ -230,7 +230,7 @@ as the <dfn data-dfn-type="dfn" data-noexport="" id="marker-properties">marker p
 <a data-link-type="element" href="#elementdef-marker">marker</a> elements.</p>
 
 
-   <p>Markers can be animated, and as with <a data-link-type="element" href="https://svgwg.org/svg2-draft/struct.html#elementdef-use">use</a> elements, the animated
+   <p>Markers can be animated, and as with <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#elementdef-use">use</a> elements, the animated
 effects will show on all current uses of the markers within the document.</p>
 
 
@@ -267,7 +267,7 @@ bottom to top:</p>
       <td><dfn data-dfn-type="element" data-export="" id="elementdef-marker">marker<a class="self-link" href="#elementdef-marker"></a></dfn>
      <tr>
       <th>Categories:
-      <td><a data-link-type="dfn" dfn="" href="https://svgwg.org/svg2-draft/struct.html#container-element">Container element</a>
+      <td><a data-link-type="dfn" dfn="" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#container-element">Container element</a>
      <tr>
       <th>Contexts:
       <td>none
@@ -275,12 +275,12 @@ bottom to top:</p>
       <th>Content model:
       <td>Any number of the following statements, in order:
        <ul>
-        <li><a data-link-type="dfn" href="https://svgwg.org/svg2-draft/animate.html#animation-element">animation elements</a>
+        <li><a data-link-type="dfn" href="https://w3c.github.io/svgwg/svg2-draft/animate.html#animation-element">animation elements</a>
         <li><a data-link-type="dfn">descriptive elements</a>
         <li><a data-link-type="dfn">paint server elements</a>
         <li><a data-link-type="dfn">shape elements</a>
         <li><a data-link-type="dfn">structural elements</a>
-        <li><a data-link-type="element" href="https://svgwg.org/svg2-draft/linking.html#elementdef-a">a</a>, <a data-link-type="element" href="http://dev.w3.org/fxtf/masking/#elementdef-clippath">clipPath</a>, <a data-link-type="element" href="https://svgwg.org/svg2-draft/interact.html#elementdef-cursor">cursor</a>, <a data-link-type="element" href="http://dev.w3.org/fxtf/filters/#elementdef-filter">filter</a>, <a data-link-type="element" href="https://svgwg.org/svg2-draft/embedded.html#ForeignObjectElement">foreignObject</a>, <a data-link-type="element" href="https://svgwg.org/svg2-draft/embedded.html#elementdef-image">image</a>, <a data-link-type="element" href="#elementdef-marker">marker</a>, <a data-link-type="element" href="http://dev.w3.org/fxtf/masking/#elementdef-mask">mask</a>, <a data-link-type="element" href="https://svgwg.org/svg2-draft/interact.html#elementdef-script">script</a>, <a data-link-type="element" href="https://svgwg.org/svg2-draft/styling.html#elementdef-style">style</a>, <a data-link-type="element" href="https://svgwg.org/svg2-draft/struct.html#elementdef-switch">switch</a>, <a data-link-type="element" href="https://svgwg.org/svg2-draft/text.html#elementdef-text">text</a>, <a data-link-type="element" href="https://svgwg.org/svg2-draft/linking.html#elementdef-view">view</a>
+        <li><a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#elementdef-a">a</a>, <a data-link-type="element" href="http://dev.w3.org/fxtf/masking/#elementdef-clippath">clipPath</a>, <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#elementdef-cursor">cursor</a>, <a data-link-type="element" href="http://dev.w3.org/fxtf/filters/#elementdef-filter">filter</a>, <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/embedded.html#ForeignObjectElement">foreignObject</a>, <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/embedded.html#elementdef-image">image</a>, <a data-link-type="element" href="#elementdef-marker">marker</a>, <a data-link-type="element" href="http://dev.w3.org/fxtf/masking/#elementdef-mask">mask</a>, <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/interact.html#elementdef-script">script</a>, <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/styling.html#elementdef-style">style</a>, <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#elementdef-switch">switch</a>, <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/text.html#elementdef-text">text</a>, <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/linking.html#elementdef-view">view</a>
        </ul>
      <tr>
       <th>Attributes:
@@ -299,7 +299,7 @@ bottom to top:</p>
        </ul>
      <tr>
       <th>DOM Interfaces:
-      <td><a class="idl-code" data-link-type="interface" href="https://svgwg.org/svg2-draft/painting.html#InterfaceSVGMarkerElement">SVGMarkerElement</a></table>
+      <td><a class="idl-code" data-link-type="interface" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#InterfaceSVGMarkerElement">SVGMarkerElement</a></table>
 
 
 
@@ -368,7 +368,7 @@ be used for drawing markers on a <a data-link-type="dfn" href="#markable-element
       <dd><a data-link-type="element-attr" href="#element-attrdef-marker-markerwidth">markerWidth</a>, <a data-link-type="element-attr" href="#element-attrdef-marker-markerheight">markerHeight</a> and the contents
     of the <a data-link-type="element" href="#elementdef-marker">marker</a> represent values in a coordinate system
     which has a single unit equal the size in user units of the
-    current stroke width (see the <a class="property" data-link-type="propdesc" href="https://svgwg.org/svg2-draft/painting.html#StrokeWidthProperty">stroke-width</a> property) in
+    current stroke width (see the <a class="property" data-link-type="propdesc" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeWidthProperty">stroke-width</a> property) in
     place for the graphic object referencing the marker.
 
 
@@ -498,7 +498,7 @@ be used for drawing markers on a <a data-link-type="dfn" href="#markable-element
 
     <dd>
 
-     <p class="note" role="note">New in SVG 2: geometric keywords (matches use in <a data-link-type="element" href="https://svgwg.org/svg2-draft/struct.html#elementdef-symbol">symbol</a>).</p>
+     <p class="note" role="note">New in SVG 2: geometric keywords (matches use in <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#elementdef-symbol">symbol</a>).</p>
 
      <p class="annotation">We will add top/center/bottom, left/center/right keywords to
   refX/refY on marker/symbol. Resolved at
@@ -920,7 +920,7 @@ goes outside of the marker’s viewport will be clipped.</p>
 inherit from the element referencing the <a data-link-type="element" href="#elementdef-marker">marker</a> element.</p>
 
 
-   <p class="note" role="note">Note: By using the <span class="css">context-stroke</span> value for the <a class="property" data-link-type="propdesc" href="https://svgwg.org/svg2-draft/painting.html#FillProperty">fill</a> or <a class="property" data-link-type="propdesc" href="https://svgwg.org/svg2-draft/painting.html#StrokeProperty">stroke</a>
+   <p class="note" role="note">Note: By using the <span class="css">context-stroke</span> value for the <a class="property" data-link-type="propdesc" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#FillProperty">fill</a> or <a class="property" data-link-type="propdesc" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeProperty">stroke</a>
 on elements in its definition, a single marker can be designed to match the
 style of the element referencing the marker.</p>
 
@@ -1123,8 +1123,8 @@ Possible values for <a class="property" data-link-type="propdesc" href="#propdef
 </dl>
 
 
-   <p>For <a data-link-type="element" href="https://svgwg.org/svg2-draft/shapes.html#elementdef-polygon">polygon</a> elements, the last vertex is the same as the first
-vertex, and for <a data-link-type="element" href="https://svgwg.org/svg2-draft/paths.html#elementdef-path">path</a> elements that end with a closed subpath, the last
+   <p>For <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/shapes.html#elementdef-polygon">polygon</a> elements, the last vertex is the same as the first
+vertex, and for <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#elementdef-path">path</a> elements that end with a closed subpath, the last
 vertex is the same as the first vertex of that final subpath.
 In this case, if the value of <a class="property" data-link-type="propdesc" href="#propdef-marker-end">marker-end</a> is not
 <a class="css" data-link-type="maybe" href="#valdef-marker-start-none">none</a>, then it is possible that two markers
@@ -1165,7 +1165,7 @@ refer to the first and last vertex of the entire path, not each subpath.</p>
      <p class="caption">The triangle is placed at the end of the path and
     oriented automatically so that it points in the right direction.
     The use of <span class="css">context-stroke</span> ensures
-    the fill of the triangle matches the stroke of each <a data-link-type="element" href="https://svgwg.org/svg2-draft/paths.html#elementdef-path">path</a>.</p>
+    the fill of the triangle matches the stroke of each <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/paths.html#elementdef-path">path</a>.</p>
 
 
     </div>
@@ -1823,7 +1823,7 @@ correctly, as follows:</p>
   <a class="css" data-link-type="maybe" href="#valdef-markerunits-strokewidth">strokeWidth</a>, then the temporary new
   user coordinate system is the result of scaling the current
   user coordinate system by the current value of property
-  <a class="property" data-link-type="propdesc" href="https://svgwg.org/svg2-draft/painting.html#StrokeWidthProperty">stroke-width</a>. If <a data-link-type="element-attr" href="#element-attrdef-marker-markerunits">markerUnits</a> equals
+  <a class="property" data-link-type="propdesc" href="https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeWidthProperty">stroke-width</a>. If <a data-link-type="element-attr" href="#element-attrdef-marker-markerunits">markerUnits</a> equals
   <a class="css" data-link-type="maybe" href="#valdef-markerunits-userspaceonuse">userSpaceOnUse</a>, then no extra scale transformation is applied.
 
 

--- a/specs/markers/master/publish.xml
+++ b/specs/markers/master/publish.xml
@@ -18,7 +18,7 @@
   -->
 
   <versions>
-    <cvs href='https://svgwg.org/specs/markers/'/>
+    <cvs href='https://w3c.github.io/svgwg/specs/markers/'/>
     <this href='http://www.w3.org/TR/2015/WD-svg-markers-20150409/'/>
     <!--
     <previous href='http://www.w3.org/TR/2014/WD-svg-markers-2014xxxx/'/>
@@ -27,11 +27,11 @@
   </versions>
 
   <definitions href='definitions.xml' specid='Markers'/>
-  <definitions href='../../../master/definitions.xml' base='https://svgwg.org/svg2-draft/' specid='SVG2'/>
+  <definitions href='../../../master/definitions.xml' base='https://w3c.github.io/svgwg/svg2-draft/' specid='SVG2'/>
   <definitions href='../../../master/definitions-filters.xml' base='http://www.w3.org/TR/2014/WD-filter-effects-1-20141125/' specid='Filters' mainspec='SVG2'/>
   <definitions href='../../../master/definitions-masking.xml' base='https://drafts.fxtf.org/css-masking-1/' specid='Masking' mainspec='SVG2'/>
   <definitions href='../../../master/definitions-compositing.xml' base='http://www.w3.org/TR/2015/CR-compositing-1-20150113/' specid='Compositing' mainspec='SVG2'/>
-  <definitions href='../../animations/master/definitions.xml' base='https://svgwg.org/specs/animations/' specid='Animations' mainspec='SVG2'/>
+  <definitions href='../../animations/master/definitions.xml' base='https://w3c.github.io/svgwg/specs/animations/' specid='Animations' mainspec='SVG2'/>
 
   <resource href='style'/>
   <resource href='images'/>

--- a/specs/paths/master/publish.xml
+++ b/specs/paths/master/publish.xml
@@ -18,7 +18,7 @@
   -->
 
   <versions>
-    <cvs href='https://svgwg.org/specs/paths/'/>
+    <cvs href='https://w3c.github.io/svgwg/specs/paths/'/>
     <this href='http://www.w3.org/TR/2015/WD-svg-paths-20150709/'/>
     <latest href='http://www.w3.org/TR/svg-paths/'/>
     <!--
@@ -27,9 +27,9 @@
   </versions>
 
   <definitions href='definitions.xml' specid='Paths'/>
-  <definitions href='../../../master/definitions.xml' base='https://svgwg.org/svg2-draft/' specid='SVG2'/>
+  <definitions href='../../../master/definitions.xml' base='https://w3c.github.io/svgwg/svg2-draft/' specid='SVG2'/>
   <definitions href='../../../master/definitions-masking.xml' base='https://drafts.fxtf.org/css-masking-1/' specid='Masking' mainspec='SVG2'/>
-  <definitions href='../../animations/master/definitions.xml' base='https://svgwg.org/specs/animations/' specid='Animations' mainspec='SVG2'/>
+  <definitions href='../../animations/master/definitions.xml' base='https://w3c.github.io/svgwg/specs/animations/' specid='Animations' mainspec='SVG2'/>
 
   <resource href='style'/>
   <resource href='images'/>

--- a/specs/streaming/index.html
+++ b/specs/streaming/index.html
@@ -316,7 +316,7 @@
 	  </pre>
 
 			<p class="note">The same restrictions are applied when referencing an <a title="definition" href="#dfn-svg-stream" class="internalDFN">SVG stream</a> from a <code>video</code> or <code>source</code> element as for referencing an SVG document from an HTML <code>img</code> element, i.e. scripts and external references are not processed.</p>
-			<div class="issue">Should reference the <a href="https://svgwg.org/specs/integration/" SVG integration</a> spec for precise restrictions (probably the "Secure Animated Mode"). What about Cross-Origin Restrictions?</div>
+			<div class="issue">Should reference the <a href="https://w3c.github.io/svgwg/specs/integration/" SVG integration</a> spec for precise restrictions (probably the "Secure Animated Mode"). What about Cross-Origin Restrictions?</div>
 			<div class="issue">Different MIME types will probably be used when SVG streams are delivered as plain SVG or SVG embedded in some multimedia format (WebM, MP4). For instance: "video/mp4; codecs='svg '" ? To be clarified.</div>
 		</section>
 		<section>

--- a/specs/strokes/master/publish.xml
+++ b/specs/strokes/master/publish.xml
@@ -18,7 +18,7 @@
   -->
 
   <versions>
-    <cvs href='https://svgwg.org/specs/strokes/'/>
+    <cvs href='https://w3c.github.io/svgwg/specs/strokes/'/>
     <this href='http://www.w3.org/TR/2015/WD-svg-strokes-20150409/'/>
     <!--
     <previous href='http://www.w3.org/TR/2014/WD-svg-strokes-2014xxxx/'/>
@@ -27,11 +27,11 @@
   </versions>
 
   <definitions href='definitions.xml' specid='Strokes'/>
-  <definitions href='../../../master/definitions.xml' base='https://svgwg.org/svg2-draft/' specid='SVG2'/>
+  <definitions href='../../../master/definitions.xml' base='https://w3c.github.io/svgwg/svg2-draft/' specid='SVG2'/>
   <definitions href='../../../master/definitions-filters.xml' base='http://www.w3.org/TR/2014/WD-filter-effects-1-20141125/' specid='Filters' mainspec='SVG2'/>
   <definitions href='../../../master/definitions-masking.xml' base='https://drafts.fxtf.org/css-masking-1/' specid='Masking' mainspec='SVG2'/>
   <definitions href='../../../master/definitions-compositing.xml' base='http://www.w3.org/TR/2015/CR-compositing-1-20150113/' specid='Compositing' mainspec='SVG2'/>
-  <definitions href='../../animations/master/definitions.xml' base='https://svgwg.org/specs/animations/' specid='Animations' mainspec='SVG2'/>
+  <definitions href='../../animations/master/definitions.xml' base='https://w3c.github.io/svgwg/specs/animations/' specid='Animations' mainspec='SVG2'/>
 
   <resource href='style'/>
   <resource href='images'/>

--- a/specs/svg-native/Makefile
+++ b/specs/svg-native/Makefile
@@ -1,4 +1,4 @@
-# Make the svgwg.org build machine prefer the online version of Bikeshed.
+# Make the w3c.github.io/svgwg build machine prefer the online version of Bikeshed.
 all : $(if $(BUILD_MACHINE),online,local)
 
 local : index.bs

--- a/specs/svg-native/index.bs
+++ b/specs/svg-native/index.bs
@@ -48,7 +48,7 @@ SVG Native is designed to fit a number of use cases.
 Basics {#basics}
 ----------------
 
-SVG Native is presented as a series of modifications of the <a href="https://svgwg.org/svg2-draft/conform.html#secure-static-mode">Secure Static Mode</a> of [[!SVG2]]. These modifications are applied as differences from that specification. Rather than being a strict line-by-line diff, this specification describes the differences directly.
+SVG Native is presented as a series of modifications of the <a href="https://w3c.github.io/svgwg/svg2-draft/conform.html#secure-static-mode">Secure Static Mode</a> of [[!SVG2]]. These modifications are applied as differences from that specification. Rather than being a strict line-by-line diff, this specification describes the differences directly.
 
 If functionality present in [[!SVG2]] isn't present in the SVG Native specification, SVG Native includes that functionality.
 <!-- https://www.w3.org/2019/04/15-svg-minutes.html -->
@@ -100,7 +100,7 @@ SVG Native is a subset of the content in the [[!SVG2]] specification, and some a
 
 No other SVG modules are supported by SVG Native. This includes:
 - <a href="https://www.w3.org/TR/filter-effects-1/">CSS Filter Effects</a>
-- <a href="https://svgwg.org/specs/animations/">SVG Animations</a>
+- <a href="https://w3c.github.io/svgwg/specs/animations/">SVG Animations</a>
 
 Rendering Model {#render}
 =========================

--- a/specs/transform/Overview.html
+++ b/specs/transform/Overview.html
@@ -155,8 +155,8 @@ metadata definition for describing the coordinate system used to
 generate SVG documents is encouraged.</p>
 
 
-   <p>Such metadata must be added under the <a data-link-type="element" href="https://svgwg.org/svg2-draft/metadata.html#elementdef-metadata">metadata</a> element of
-the topmost <a data-link-type="element" href="https://svgwg.org/svg2-draft/struct.html#NewDocument">svg</a> element describing the map, consisting of an
+   <p>Such metadata must be added under the <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/metadata.html#elementdef-metadata">metadata</a> element of
+the topmost <a data-link-type="element" href="https://w3c.github.io/svgwg/svg2-draft/struct.html#NewDocument">svg</a> element describing the map, consisting of an
 RDF description of the Coordinate Reference System definition used to
 generate the SVG map <a data-link-type="biblio" href="#biblio-rdf-primer">[RDF-PRIMER]</a>. Note that
 the presence of this metadata does not affect the rendering of the SVG


### PR DESCRIPTION
This is fixing the dependency of the spec links to the svgwg.org domain names. 
So that it is easier for web implementers to have access to the latest version of the specifications. 
See #1060 