### PR TITLE
#fix 828 - Drop display properties from UA svg CSS.

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -513,6 +513,11 @@ have been made.</p>
     <a href="https://github.com/w3c/svgwg/pull/536">Edits</a></li>
   </ul>
 </div>
+<ul>
+  <li>March 2026: <a href="https://www.w3.org/2026/03/05-svg-minutes.html#c364">Drop 
+    <code>display: inline</code>code> AND <code>display: none</code> from SVG 2 
+    in the UA stylesheet as requirement</a> (<a href="https://github.com/w3c/svgwg/issues/828">Issue #828</a>)</li>
+</ul>
 
 <h3 id="geometry">Geometry Properties chapter (SVG 2 only)</h3>
 

--- a/master/styling.html
+++ b/master/styling.html
@@ -604,17 +604,6 @@ svg:not(:root), image, marker, pattern, symbol { overflow: hidden; }
   white-space-collapse: preserve-spaces;
 }
 
-defs,
-clipPath, mask, marker,
-desc, title, metadata,
-pattern, linearGradient, radialGradient,
-script, style,
-symbol {
-  display: none !important;
-}
-:host(use) > symbol {
-  display: inline !important;
-}
 :link, :visited {
   cursor: pointer;
 }
@@ -629,19 +618,6 @@ symbol {
   and the <code>::selection</code> pseudo-element
   (using an appropriate highlighting technique,
     such as redrawing the selected glyphs with inverse colors).
-</p>
-
-<p class="note">
-An <code>!important</code> rule in a user agent stylesheet
-<a href="https://www.w3.org/TR/css-cascade-4/#importance">over-rides all user and author styles</a>
-[<a href="refs.html#ref-css-cascade-4">css-cascade-4</a>].
-The display value for <a>never-rendered elements</a>
-and for <a>'symbol'</a> elements
-can therefore not be changed.
-A symbol must only be rendered if it is the direct child
-of a shadow root whose host is a <a>'use'</a> element
-(and must always be rendered if the host <a>'use'</a> element is rendered).
-The other elements, and their child content, are never rendered directly.
 </p>
 
 <p class='note'>CSS Transforms defines that the initial value for


### PR DESCRIPTION
This is not currently used by any browsers and these elements are already marked in the spec with their specific behavior. 
https://github.com/w3c/svgwg/issues/828
https://www.w3.org/2026/03/05-svg-minutes.html#c364