### PR TITLE
Add path-length CSS property definition (Section 9.6.2)

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -599,6 +599,14 @@ have been made.</p>
   </li>
 </ul>
 </div>
+<div class='changed-since-cr1 cr2 cr3'>
+<ul>
+  <li>Added the <a>'path-length'</a> CSS property
+    and made <a>'pathLength'</a> a presentation attribute for it.
+    <a href="https://github.com/w3c/svgwg/issues/773">Issue #773</a>
+    <a href="https://github.com/w3c/svgwg/pull/1073">Edits</a></li>
+</ul>
+</div>
 
 <h3 id="shapes">Basic Shapes chapter</h3>
 

--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -426,7 +426,7 @@
   <attribute name='viewBox' href='coords.html#ViewBoxAttribute' animatable='yes'/>
   <attribute name='preserveAspectRatio' href='coords.html#PreserveAspectRatioAttribute' animatable='yes'/>
 
-  <attribute name='pathLength' href='paths.html#PathLengthAttribute' animatable='yes'/>
+  <attribute name='pathLength' href='paths.html#PathLengthAttribute' animatable='yes' presentationattribute='path-length' presentationattributehref='paths.html#PathLengthProperty'/>
   <!-- ... attribute categories .......................................... -->
 
   <attributecategory
@@ -504,7 +504,7 @@
   <attributecategory
     name='presentation'
     href='styling.html#TermPresentationAttribute'
-    presentationattributes='alignment-baseline, baseline-shift, clip, clip-path, clip-rule, color, color-interpolation, color-interpolation-filters, cursor, direction, display, dominant-baseline, fill, fill-opacity, fill-rule, filter, flood-color, flood-opacity, font-family, font-size, font-size-adjust, font-stretch, font-style, font-variant, font-weight, glyph-orientation-horizontal, glyph-orientation-vertical, image-rendering, letter-spacing, lighting-color, marker-end, marker-mid, marker-start, mask, mask-type, opacity, overflow, paint-order, pointer-events, shape-rendering, stop-color, stop-opacity, stroke, stroke-dasharray, stroke-dashoffset, stroke-linecap, stroke-linejoin, stroke-miterlimit, stroke-opacity, stroke-width, text-anchor, text-decoration, text-rendering, transform, transform-origin, unicode-bidi, vector-effect, visibility, word-spacing, writing-mode'/>
+    presentationattributes='alignment-baseline, baseline-shift, clip, clip-path, clip-rule, color, color-interpolation, color-interpolation-filters, cursor, direction, display, dominant-baseline, fill, fill-opacity, fill-rule, filter, flood-color, flood-opacity, font-family, font-size, font-size-adjust, font-stretch, font-style, font-variant, font-weight, glyph-orientation-horizontal, glyph-orientation-vertical, image-rendering, letter-spacing, lighting-color, marker-end, marker-mid, marker-start, mask, mask-type, opacity, overflow, paint-order, path-length, pointer-events, shape-rendering, stop-color, stop-opacity, stroke, stroke-dasharray, stroke-dashoffset, stroke-linecap, stroke-linejoin, stroke-miterlimit, stroke-opacity, stroke-width, text-anchor, text-decoration, text-rendering, transform, transform-origin, unicode-bidi, vector-effect, visibility, word-spacing, writing-mode'/>
 
   <attributecategory
       name='document event'
@@ -625,6 +625,7 @@
   <property name='marker-start' href='painting.html#MarkerStartProperty'/>
   <property name='overflow' href='render.html#OverflowAndClipProperties'/>
   <property name='paint-order' href='painting.html#PaintOrderProperty'/>
+  <property name='path-length' href='paths.html#PathLengthProperty'/>
   <property name='pointer-events' href='interact.html#PointerEventsProperty'/>
   <property name='shape-rendering' href='painting.html#ShapeRenderingProperty'/>
   <property name='stop-color' href='pservers.html#StopColorProperty'/>

--- a/master/paths.html
+++ b/master/paths.html
@@ -1243,6 +1243,87 @@ commands contribute to path length calculations.</p>
   </dd>
 </dl>
 
+<h3 id="PathLengthProperty">The <span class="property">'path-length'</span> property</h3>
+
+<table class="propdef def">
+  <tr>
+    <th>Name:</th>
+    <td><dfn id="PathLengthCSSProperty" data-dfn-type="property" data-export="">path-length</dfn></td>
+  </tr>
+  <tr>
+    <th>Value:</th>
+    <td>none | <a>&lt;number [0,∞]&gt;</a></td>
+  </tr>
+  <tr>
+    <th>Initial:</th>
+    <td>none</td>
+  </tr>
+  <tr>
+    <th>Applies to:</th>
+    <td><a>'path'</a>, <a>'circle'</a>, <a>'ellipse'</a>,
+    <a>'line'</a>, <a>'polygon'</a>, <a>'polyline'</a>, <a>'rect'</a></td>
+  </tr>
+  <tr>
+    <th>Inherited:</th>
+    <td>no</td>
+  </tr>
+  <tr>
+    <th>Percentages:</th>
+    <td>N/A</td>
+  </tr>
+  <tr>
+    <th>Media:</th>
+    <td>visual</td>
+  </tr>
+  <tr>
+    <th>Computed value:</th>
+    <td>the keyword <span class="prop-value">none</span>, or the specified number</td>
+  </tr>
+  <tr>
+    <th><a>Animation type</a>:</th>
+    <td>by computed value</td>
+  </tr>
+</table>
+
+<p>The <a>'path-length'</a> property provides the author's computation of the
+total length of the path, in user units. This value is used to
+calibrate the user agent's own
+<a href="paths.html#DistanceAlongAPath">distance-along-a-path</a>
+calculations with that of the author.</p>
+
+<p>A value of <span class="prop-value">none</span> indicates that no
+author path length is specified and the user agent's own computed
+path length is used.</p>
+
+<p>A <a>&lt;number&gt;</a> value must be zero or greater.
+A value of zero is valid and must be treated as a scaling factor
+of infinity.</p>
+
+<p>The SVG <a>'pathLength'</a> attribute maps to the
+<a>'path-length'</a> CSS property as a
+<a>presentation attribute</a>.
+When the <a>'pathLength'</a> attribute value is absent and
+the <a>'path-length'</a> property computes to
+<span class="prop-value">none</span>, no author scaling is applied.</p>
+
+<p>The <a>'path-length'</a> property affects:</p>
+<ul>
+  <li><a href="text.html#TextLayoutPath">text on a path</a>
+  (<a>'textPath'</a> positioning)</li>
+  <li><a href="https://svgwg.org/specs/animations/#AnimateMotionElement">motion animation</a></li>
+  <li><a href="painting.html#StrokeProperties">stroke operations</a>
+  (<a>'stroke-dasharray'</a>, <a>'stroke-dashoffset'</a>)</li>
+</ul>
+
+<p><a>'path-length'</a> has no effect on percentage
+<a href="paths.html#DistanceAlongAPath">distance-along-a-path</a>
+calculations.</p>
+
+<p class="note">The CSS Working Group resolved to add
+<a>'path-length'</a> as a CSS property and make
+<a>'pathLength'</a> map to it
+(<a href="https://lists.w3.org/Archives/Public/www-style/2020Feb/0009.html">minutes, 22 January 2020</a>).</p>
+
 
 </edit:with>
 

--- a/master/paths.html
+++ b/master/paths.html
@@ -1297,7 +1297,9 @@ path length is used.</p>
 
 <p>A <a>&lt;number&gt;</a> value must be zero or greater.
 A value of zero is valid and must be treated as a scaling factor
-of infinity.</p>
+of infinity.
+A value of zero scaled infinitely must remain zero, while any non-percentage value greater
+than zero must become +Infinity.</p>
 
 <p>The SVG <a>'pathLength'</a> attribute maps to the
 <a>'path-length'</a> CSS property as a


### PR DESCRIPTION
**Summary**

Add a CSS property definition for `path-length` alongside the existing `pathLength` SVG attribute in the Paths chapter (Section 9.6.1), per the [CSS WG resolution from 22 January 2020](https://lists.w3.org/Archives/Public/www-style/2020Feb/0009.html).

**Changes**

[paths.html](https://github.com/w3c/svgwg/blob/c6cc21c4561f626f8acc906c7ed53fc098724896/master/paths.html)

- Added new subsection 9.6.2 The 'path-length' property with:
     - CSS property definition table (`none | <number [0,∞]`>, initial value `none`, applies to shapes and `textPath`, not inherited, not animatable).
     - Prose describing the property's effect on 'distance-along-a-path' calculations ('text-on-path' layout, motion animation, stroke dash operations).
     - Statement that `pathLength` is a presentation attribute for `path-length`.
     - Note referencing the CSS WG resolution.
     
[definitions.xml](https://github.com/w3c/svgwg/blob/c6cc21c4561f626f8acc906c7ed53fc098724896/master/definitions.xml)


- Registered `path-length` in the presentation attributes category.
- Added `<property>` entry for `path-length`.
- Updated the `pathLength` attribute definition with `presentationattribute` mapping.

Addresses #773

**Preview**

<img width="1446" height="1378" alt="image" src="https://github.com/user-attachments/assets/b23ef175-8d34-4bb9-977c-28cedb58b45e" />
