### PR TITLE
Update <textPath> `path`/`href` fallback behavior per WG resolution

### DIFF
--- a/master/text.html
+++ b/master/text.html
@@ -4094,8 +4094,17 @@
     <li><a>'xlink:href'</a> attribute</li>
   </ol>
   <p>
-    If the <a>'path'</a> attribute contains an error, the
-    <a>'href'</a> attribute must be used.
+    If the <a>'path'</a> attribute is specified but
+    the <a href="paths.html#PathDataBNF" class="syntax">path data</a>
+    results in no valid path segments (e.g., the value is an empty
+    string, or an error in the path data occurs before any
+    valid path segments are produced), then the
+    <a>'href'</a> attribute must be used instead.
+    If the <a>'path'</a> attribute contains valid path segments
+    before the first error, the path is used up to the error
+    following the rules in
+    <a href="paths.html#PathDataErrorHandling">Error handling in path data</a>,
+    and the <a>'href'</a> attribute is not used as a fallback.
   </p>
 
 <h3 id="TextPathAttributes">Attributes</h3>
@@ -4351,11 +4360,15 @@
       <p>A <a href="paths.html#PathDataBNF" class="syntax">path data</a>
         string describing the path onto which the <a>typographic characters</a>
 	will be rendered.
-        An empty string indicates that there is no path data for the element.
-        This means that the text within the <a>'textPath'</a> does not render or
-        contribute to the <a>bounding box</a> of the <a>'text'</a> element.
-        If the attribute is not specified,
+        If the attribute is not specified, or if the
+        <a href="paths.html#PathDataBNF" class="syntax">path data</a>
+        results in no valid path segments (e.g., the value is an empty
+        string or an error occurs before any valid path segments),
         the path specified with <a>'href'</a> is used instead.
+        If the path data contains an error but produces at least one valid
+        path segment before the error, the valid portion of the path
+        is used following the rules in
+        <a href="paths.html#PathDataErrorHandling">Error handling in path data</a>.
       </p>
       <dl class="attrdef-svg2">
 	<dt>Value</dt>                  <dd><a href="paths.html#PathDataBNF" class="syntax">path data</a></dd>


### PR DESCRIPTION
Clarifies the fallback behavior when the `path` attribute on a `textPath` element contains errors, per the [March 12, 2026 WG resolution](https://www.w3.org/2026/03/12-svg-minutes.html):

- If the `path` data results in no valid path segments (empty string, or error before any valid segments), fall back to `href`.
- If the `path` data produces at least one valid segment before the error, use the valid portion per [Error handling in path data](https://w3c.github.io/svgwg/svg2-draft/paths.html#PathDataErrorHandling); do not fall back to `href`.

Updated in both the TextPathElement precedence section and the `path` attribute definition.

Resolves [https://github.com/w3c/svgwg/issues/393](https://github.com/w3c/svgwg/issues/393)