### PR TITLE
Update from api.csswg.org/bikeshed to spec-generator

### DIFF
--- a/specs/svg-native/Makefile
+++ b/specs/svg-native/Makefile
@@ -5,7 +5,7 @@ local : index.bs
 	bikeshed -f spec index.bs
 
 online : index.bs
-	curl -s https://api.csswg.org/bikeshed/ -F file=@index.bs -F force=1 > index.html
+	curl -s https://www.w3.org/publications/spec-generator/ -F file=@index.bs -F type=bikeshed-spec -F die-on=nothing > index.html
 
 clean :
 	rm -f index.html


### PR DESCRIPTION
This updates the Makefile to reference spec-generator instead of the discontinued CSSWG Bikeshed service.

I've verified that `make online` runs successfully with output similar to `make local`.