### PR TITLE
Add Virali Purbey as SVG spec editor

### DIFF
--- a/master/Overview.html
+++ b/master/Overview.html
@@ -37,6 +37,7 @@
     <dd>Karl Dubost, Apple, Inc. &lt;<a href="mailto:karlcow@apple.com" class='url'>karlcow@apple.com</a>&gt;</dd>
     <dd>Divyansh Mangal, Microsoft Co. &lt;<a href="mailto:dmangal@microsoft.com" class='url'>dmangal@microsoft.com</a>&gt;</dd>
     <dd>Dirk Schulze, Adobe Systems &lt;<a href="mailto:dschulze@adobe.com" class='url'>dschulze@adobe.com</a>&gt;</dd>
+    <dd>Virali Purbey, Microsoft Co. &lt;<a href="mailto:viralipurbey@microsoft.com" class='url'>viralipurbey@microsoft.com</a>&gt;</dd>
     <dt class="top-editors">Former Editors:</dt>
     <dd>Nikos Andronikos, Canon, Inc. &lt;<a href="mailto:nikos.andronikos@cisra.canon.com.au" class='url'>nikos.andronikos@cisra.canon.com.au</a>&gt;</dd>
     <dd>Rossen Atanassov, Microsoft Co. &lt;<a href="mailto:ratan@microsoft.com" class='url'>ratan@microsoft.com</a>&gt;</dd>


### PR DESCRIPTION
This PR adds Virali Purbey (Microsoft) to the editors list for the SVG specification.

**Changes:**

Added Virali Purbey, Microsoft Co. <viralipurbey@microsoft.com> to the current editors list alongside Karl Dubost (Apple), Divyansh Mangal (Microsoft), and Dirk Schulze (Adobe).
