### PR TITLE
Fix CSS syntax of opacity-related properties

### DIFF
--- a/master/painting.html
+++ b/master/painting.html
@@ -466,7 +466,7 @@ property</h3>
   </tr>
   <tr>
     <th>Value:</th>
-    <td>&lt;‘<a>'opacity'</a>’&gt;</td>
+    <td>&lt;'<a>'opacity'</a>'&gt;</td>
   </tr>
   <tr>
     <th>Initial:</th>
@@ -664,7 +664,7 @@ property</h3>
   </tr>
   <tr>
     <th>Value:</th>
-    <td>&lt;‘<a>'opacity'</a>’&gt;</td>
+    <td>&lt;'<a>'opacity'</a>'&gt;</td>
   </tr>
   <tr>
     <th>Initial:</th>


### PR DESCRIPTION
The spec used curly braces in the property values but only "single quotes" are allowed per the CSS syntax, see:
https://www.w3.org/TR/css-values/#component-types

This replaces curly braces with single quotes in the syntax definitions of `fill-opacity` and `stroke-opacity`.