### PR TITLE
Use `#+` to define `<dasharray>` and `<points>`

### DIFF
--- a/master/painting.html
+++ b/master/painting.html
@@ -1112,7 +1112,7 @@ the <a href="paths.html#PathElementImplementationNotes">path implementation note
 <p>where:</p>
 
 <p class="definition prod"><dfn id="DataTypeDasharray" data-dfn-type="type" data-export="">&lt;dasharray&gt;</dfn> =
-[ [ <a>&lt;length-percentage&gt;</a> | <a>&lt;number&gt;</a> ]+ ]#</p>
+[ <a>&lt;length-percentage&gt;</a> | <a>&lt;number&gt;</a> ]+#</p>
 
 <p>The <a>'stroke-dasharray'</a> property controls
 the pattern of dashes and gaps used to form the shape of

--- a/master/shapes.html
+++ b/master/shapes.html
@@ -445,7 +445,7 @@ shapes.</p>
     <p>where:</p>
     <div class="definition prod">
       <dfn id="DataTypePoints" data-dfn-type="type" data-export="">&lt;points&gt;</dfn> =
-      <div style="margin-left: 4em">[ <a>&lt;number&gt;</a>+ ]#</div>
+      <div style="margin-left: 4em"><a>&lt;number&gt;</a>+#</div>
     </div>
     <p>The points that make up the polyline. All coordinate
     values are in the user coordinate system.</p>


### PR DESCRIPTION
This PR updates the value definition of [`<dasharray>`](https://svgwg.org/svg2-draft/painting.html#DataTypeDasharray) and [`<points>`](https://svgwg.org/svg2-draft/shapes.html#DataTypePoints) to use `[...]+#` instead of `[[...]+]#`. 

[CSS Values and Units](https://drafts.csswg.org/css-values-4/#component-multipliers) defines the valid multiplier stacks for CSS value definitions, which include `+#`.

Not sure what was the intention from defining `<dasharray>` with `#*` in [SVG Strokes](https://svgwg.org/specs/strokes/#StrokeDashing), which is an invalid stack (`#?` is valid though). So I left it unchanged.