### PR TITLE
Exclude negative values using the CSS range notation

### DIFF
--- a/master/geometry.html
+++ b/master/geometry.html
@@ -122,7 +122,7 @@ of the position of the element. </p>
   </tr>
   <tr>
     <th>Value:</th>
-    <td><a>&lt;length-percentage&gt;</a></td>
+    <td><a>&lt;length-percentage [0,&infin;]&gt;</a></td>
   </tr>
   <tr>
     <th>Initial:</th>

--- a/master/painting.html
+++ b/master/painting.html
@@ -728,7 +728,7 @@ property</h3>
   </tr>
   <tr>
     <th>Value:</th>
-    <td><a>&lt;length-percentage&gt;</a> | <a>&lt;number&gt;</a></td>
+    <td><a>&lt;length-percentage [0,&infin;]&gt;</a> | <a>&lt;number [0,&infin;]&gt;</a></td>
   </tr>
   <tr>
     <th>Initial:</th>
@@ -928,7 +928,7 @@ the <a href="paths.html#PathElementImplementationNotes">path implementation note
   </tr>
   <tr>
     <th>Value:</th>
-    <td><a>&lt;number&gt;</a></td>
+    <td><a>&lt;number [0,&infin;]&gt;</a></td>
   </tr>
   <tr>
     <th>Initial:</th>


### PR DESCRIPTION
This PR adds a [bracketed range](https://drafts.csswg.org/css-values-4/#css-bracketed-range-notation) to the CSS types that are used to define [`rx`](https://svgwg.org/svg2-draft/geometry.html#RxProperty), `ry`, [`stroke-miterlimit`](https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty), [`stroke-width`](https://svgwg.org/svg2-draft/painting.html#StrokeWidthProperty), which do not allow negative values.