### PR TITLE
Change SVGPathSegment from [NoInterfaceObject] interface to dictionary

### DIFF
--- a/specs/paths/master/Overview.html
+++ b/specs/paths/master/Overview.html
@@ -1363,26 +1363,25 @@ commands contribute to path length calculations.</p>
 
 <h2 id="DOMInterfaces">DOM interfaces</h2>
 
-<h3 id="InterfaceSVGPathSegment">Interface SVGPathSegment</h3>
+<h3 id="InterfaceSVGPathSegment">Dictionary SVGPathSegment</h3>
 
-The <a>SVGPathSegment</a> interface is a base interface that corresponds to a
+The <a>SVGPathSegment</a> dictionary corresponds to a
 single command within a path data specification.
 
-<pre class="idl">[NoInterfaceObject]
-interface <b>SVGPathSegment</b> {
-  DOMString type;
-  sequence&lt;float> values;
+<pre class="idl">dictionary <b>SVGPathSegment</b> {
+  required DOMString type;
+  required sequence&lt;unrestricted float> values;
 };</pre>
 
 <dl class="interface">
-  <dt class="attributes-header">Attributes:</dt>
+  <dt class="attributes-header">Members:</dt>
   <dd>
     <dl class="attributes">
       <dt id="__svg__SVGPathSegment__type" class="attribute first-child"><b>type</b><span class="idl-type-parenthetical"> (DOMString)</span></dt>
       <dd class="attribute">
         <div>The type of the path segment as specified in the path grammar.</div>
       </dd>
-      <dt id="__svg__SVGPathSeg__pathSegTypeAsLetter" class="attribute"><b>values</b><span class="idl-type-parenthetical"> (sequence&lt;float>)</span></dt>
+      <dt id="__svg__SVGPathSegment__values" class="attribute"><b>values</b><span class="idl-type-parenthetical"> (sequence&lt;unrestricted float>)</span></dt>
       <dd class="attribute">
         <div>The values corresponding to the path segment.</div>
       </dd>

--- a/specs/paths/master/definitions.xml
+++ b/specs/paths/master/definitions.xml
@@ -6,10 +6,11 @@
 
   <term name='equivalent path' href='#TermEquivalentPath'/>
 
-  <!-- ... interfaces ..................................................... -->
+  <!-- ... interfaces and dictionaries ..................................... -->
 
   <interface name='SVGPathData' href='#InterfaceSVGPathData'/>
   <interface name='SVGPathDataSettings' href='#InterfaceSVGPathDataSettings'/>
+  <!-- SVGPathSegment is a dictionary; tooling lacks a <dictionary> element -->
   <interface name='SVGPathSegment' href='#InterfaceSVGPathSegment'/>
 
   <!-- === defined in other specifications ================================ -->


### PR DESCRIPTION
Resolves https://github.com/w3c/svgwg/issues/1082 and https://github.com/w3c/svgwg/issues/974.

Resolution: https://www.w3.org/2026/03/26-svg-minutes.html

- Convert SVGPathSegment from a [NoInterfaceObject] interface to a dictionary
- Mark type and values as required members
- Change values type from sequence<float> to sequence<unrestricted float>