### PR TITLE
Remove hreflang and type IDL from SVGAElement

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -1072,6 +1072,7 @@ have been made.</p>
     <a href="https://github.com/w3c/svgwg/issues/312">Issue discussion</a>
     <a href="https://github.com/w3c/svgwg/pull/1052">Edits</a>
     </li>
+    <li>Removed the <code>hreflang</code> and <code>type</code> IDL properties from <a>'a'</a>, as these are defined in the HTML spec.</li>
   </ul>
 </div>
 

--- a/master/linking.html
+++ b/master/linking.html
@@ -1153,8 +1153,6 @@ interface <b>SVGAElement</b> : <a>SVGGraphicsElement</a> {
   [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute USVString <a href="linking.html#__svg__SVGAElement__ping">ping</a>;
   [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="linking.html#__svg__SVGAElement__rel">rel</a>;
   [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>="rel", <a>SameObject</a>, <a>PutForwards</a>=value] readonly attribute <a>DOMTokenList</a> <a href="linking.html#__svg__SVGAElement__relList">relList</a>;
-  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="linking.html#__svg__SVGAElement__hreflang">hreflang</a>;
-  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="linking.html#__svg__SVGAElement__type">type</a>;
 
   attribute DOMString <a href="linking.html#__svg__SVGAElement__referrerPolicy">referrerPolicy</a>;
 };

--- a/master/linking.html
+++ b/master/linking.html
@@ -1153,8 +1153,6 @@ interface <b>SVGAElement</b> : <a>SVGGraphicsElement</a> {
   [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute USVString <a id="__svg__SVGAElement__ping" href="linking.html#__svg__SVGAElement__ping">ping</a>;
   [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a id="__svg__SVGAElement__rel" href="linking.html#__svg__SVGAElement__rel">rel</a>;
   [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>="rel", <a>SameObject</a>, <a>PutForwards</a>=value] readonly attribute <a>DOMTokenList</a> <a id="__svg__SVGAElement__relList" href="linking.html#__svg__SVGAElement__relList">relList</a>;
-  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a id="__svg__SVGAElement__hreflang" href="linking.html#__svg__SVGAElement__hreflang">hreflang</a>;
-  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a id="__svg__SVGAElement__type" href="linking.html#__svg__SVGAElement__type">type</a>;
 
   attribute DOMString <a href="linking.html#__svg__SVGAElement__referrerPolicy">referrerPolicy</a>;
 };


### PR DESCRIPTION
This is now on the HyperlinkElementUtils mixin

https://html.spec.whatwg.org/multipage/links.html#dom-a-hreflang