### PR TITLE
Clarify that SVG requires well-formed XML, not valid XML

### DIFF
--- a/master/conform.html
+++ b/master/conform.html
@@ -548,7 +548,15 @@ would likely use static mode.
   conformance with this specification is defined by whether
   the content is or can generate a conforming DOM.
   Additional conformance classes depend on whether the content
-  is also valid and well-formed XML [<a href="refs.html#ref-xml">xml</a>].
+  is also well-formed XML [<a href="refs.html#ref-xml">xml</a>].
+</p>
+
+<p class="note">SVG content is not required to be <em>valid</em> XML in the XML 1.0
+  sense (i.e., conforming to a DTD). SVG 2 defines no DTD, and user agents do not
+  perform DTD-based validation. In particular, SVG documents do not need a
+  <code>&lt;!DOCTYPE&gt;</code> declaration or an XML declaration
+  (<code>&lt;?xml …?&gt;</code>); including either is neither necessary nor
+  recommended for SVG content served as <code>image/svg+xml</code>.
 </p>
 
 <h3 id="ConformingSVGDOMSubtrees">Conforming SVG DOM Subtrees</h3>

--- a/master/conform.html
+++ b/master/conform.html
@@ -556,7 +556,8 @@ would likely use static mode.
   perform DTD-based validation. In particular, SVG documents do not need a
   <code>&lt;!DOCTYPE&gt;</code> declaration or an XML declaration
   (<code>&lt;?xml …?&gt;</code>); including either is neither necessary nor
-  recommended for SVG content served as <code>image/svg+xml</code>.
+  recommended for SVG content, whether served as <code>image/svg+xml</code>
+  or embedded inline in HTML.
 </p>
 
 <h3 id="ConformingSVGDOMSubtrees">Conforming SVG DOM Subtrees</h3>

--- a/master/conform.html
+++ b/master/conform.html
@@ -547,7 +547,7 @@ would likely use static mode.
   For SVG content, therefore,
   conformance with this specification is defined by whether
   the content is or can generate a conforming DOM.
-  Additional conformance classes depend on whether the content
+  Some of the following conformance classes depend on whether the content
   is also well-formed XML [<a href="refs.html#ref-xml">xml</a>].
 </p>
 


### PR DESCRIPTION
Addresses #960. cc @real-or-random

## Changes

### Drop "valid and" from the Document Conformance Classes intro

The intro sentence currently reads:

> Additional conformance classes depend on whether the content is also valid and well-formed XML.

None of the conformance classes defined in this section require XML *validity* in the XML 1.0 sense — that is, conformance to a DTD. Only *well-formedness* is required. Removing "valid and" brings the intro into agreement with the conformance classes that follow it.

### Add a clarifying note

Adds a note immediately after the intro paragraph making two things explicit:

- SVG 2 defines no DTD, and user agents do not perform DTD-based validation.
- A `<!DOCTYPE>` declaration and an XML declaration (`<?xml …?>`) are neither required nor recommended for SVG documents served as `image/svg+xml`.

Without this note, a reader could reasonably infer from the surrounding XML-related language that some form of XML validity is expected. The note removes that ambiguity without touching any normative text beyond the one-word fix above.

## Tests

No web-platform-tests PR is needed. This is a purely editorial change: no normative requirements are added or removed.