### PR TITLE
Fix duplicate `type` attribute in `SVGStyleElement` interface

### DIFF
--- a/master/styling.html
+++ b/master/styling.html
@@ -707,9 +707,6 @@ interface <b>SVGStyleElement</b> : <a>SVGElement</a> {
   [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="styling.html#__svg__SVGStyleElement__media">media</a>;
   [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="styling.html#__svg__SVGStyleElement__title">title</a>;
   attribute boolean <a href="styling.html#__svg__SVGStyleElement__disabled">disabled</a>;
-
-  // obsolete members
-  attribute DOMString <a href="styling.html#__svg__SVGStyleElement__type">type</a>;
 };
 
 <a>SVGStyleElement</a> includes <a>LinkStyle</a>;</pre>


### PR DESCRIPTION
Probably an oversight while adding `[Reflect]` attributes in #1003. The former `type` attribute should have been dropped.