### PR TITLE
Fix swapped href targets for open/closed subpath terms in definitions.xml

### DIFF
--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -1023,10 +1023,10 @@
 
   <!-- ... defined in paths.html ... -->
   <term name='initial point' href='paths.html#TermInitialPoint'/>
-  <term name='open subpath' href='paths.html#TermClosedSubpath'/>
-  <term name='open subpaths' href='paths.html#TermClosedSubpath'/>
-  <term name='closed subpath' href='paths.html#TermOpenSubpath'/>
-  <term name='closed subpaths' href='paths.html#TermOpenSubpath'/>
+  <term name='open subpath' href='paths.html#TermOpenSubpath'/>
+  <term name='open subpaths' href='paths.html#TermOpenSubpath'/>
+  <term name='closed subpath' href='paths.html#TermClosedSubpath'/>
+  <term name='closed subpaths' href='paths.html#TermClosedSubpath'/>
 
   <!-- ... defined in painting.html ... -->
   <term name='fill'               href='painting.html#TermFill'/>


### PR DESCRIPTION

The four `<term>` entries for *open subpath* / *closed subpath* in
`master/definitions.xml` have their `href` anchors swapped: each term links to
the **opposite** definition.

### Current (on `main`)

https://github.com/w3c/svgwg/blob/ad280d03e1794513cf31384a89b38f2f8d982925/master/definitions.xml#L1026-L1029

```text
<term name='open subpath' href='paths.html#TermClosedSubpath'/>
<term name='open subpaths' href='paths.html#TermClosedSubpath'/>
<term name='closed subpath' href='paths.html#TermOpenSubpath'/>
<term name='closed subpaths' href='paths.html#TermOpenSubpath'/>
```

### Why these are wrong

The anchor IDs in `paths.html` are correctly named, so the term refs above point
at the opposite definitions:

https://github.com/w3c/svgwg/blob/ad280d03e1794513cf31384a89b38f2f8d982925/master/paths.html#L405-L407

```text
<dfn id="TermClosedSubpath">closed subpath</dfn>
...
<dfn id="TermOpenSubpath">open subpath</dfn>
```

So `name='open subpath'` resolves to the **closed**-subpath definition, and
`name='closed subpath'` resolves to the **open**-subpath definition.

### Fix

Swap the four `href`s so each term points at its matching definition:

```diff
-<term name='open subpath' href='paths.html#TermClosedSubpath'/>
-<term name='open subpaths' href='paths.html#TermClosedSubpath'/>
-<term name='closed subpath' href='paths.html#TermOpenSubpath'/>
-<term name='closed subpaths' href='paths.html#TermOpenSubpath'/>
+<term name='open subpath' href='paths.html#TermOpenSubpath'/>
+<term name='open subpaths' href='paths.html#TermOpenSubpath'/>
+<term name='closed subpath' href='paths.html#TermClosedSubpath'/>
+<term name='closed subpaths' href='paths.html#TermClosedSubpath'/>
```

### Notes

- Editorial / non-normative: this only corrects cross-reference link targets in
  the term index; no spec text or behavior changes, so no web-platform-tests PR
  is needed (per `CONTRIBUTING.md`).
