### PR TITLE
 Change path-length property value type from number to length

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -612,6 +612,11 @@ have been made.</p>
     and made <a>'pathLength'</a> a presentation attribute for it.
     <a href="https://github.com/w3c/svgwg/issues/773">Issue #773</a>
     <a href="https://github.com/w3c/svgwg/pull/1073">Edits</a></li>
+  <li>Changed <a>'path-length'</a> property value type from
+    <code>&lt;number&gt;</code> to <code>&lt;length&gt;</code>
+    per CSSWG resolution.
+    <a href="https://github.com/w3c/csswg-drafts/issues/13901">csswg-drafts#13901</a>
+    (<a href="https://github.com/w3c/csswg-drafts/issues/13901#issuecomment-4500370159">resolution, 20 May 2026</a>)</li>
 </ul>
 </div>
 

--- a/master/paths.html
+++ b/master/paths.html
@@ -1252,7 +1252,7 @@ commands contribute to path length calculations.</p>
   </tr>
   <tr>
     <th>Value:</th>
-    <td>none | <a>&lt;number [0,∞]&gt;</a></td>
+    <td>none | <a>&lt;length [0,∞]&gt;</a></td>
   </tr>
   <tr>
     <th>Initial:</th>
@@ -1277,7 +1277,7 @@ commands contribute to path length calculations.</p>
   </tr>
   <tr>
     <th>Computed value:</th>
-    <td>the keyword <span class="prop-value">none</span>, or the specified number</td>
+    <td>the keyword <span class="prop-value">none</span>, or an absolute length</td>
   </tr>
   <tr>
     <th><a>Animation type</a>:</th>
@@ -1286,8 +1286,7 @@ commands contribute to path length calculations.</p>
 </table>
 
 <p>The <a>'path-length'</a> property provides the author's computation of the
-total length of the path, in user units. This value is used to
-calibrate the user agent's own
+total length of the path. This value is used to calibrate the user agent's own
 <a href="paths.html#DistanceAlongAPath">distance-along-a-path</a>
 calculations with that of the author.</p>
 
@@ -1295,15 +1294,17 @@ calculations with that of the author.</p>
 author path length is specified and the user agent's own computed
 path length is used.</p>
 
-<p>A <a>&lt;number&gt;</a> value must be zero or greater.
+<p>A <a>&lt;length&gt;</a> value must be zero or greater.
 A value of zero is valid and must be treated as a scaling factor
 of infinity.
-A value of zero scaled infinitely must remain zero, while any non-percentage value greater
-than zero must become +Infinity.</p>
+A value of zero scaled infinitely must remain zero, while any
+value greater than zero must become +Infinity.</p>
 
 <p>The SVG <a>'pathLength'</a> attribute maps to the
 <a>'path-length'</a> CSS property as a
 <a>presentation attribute</a>.
+The unitless numeric value of the attribute is interpreted as a
+<a>&lt;length&gt;</a> value in <code>px</code> units.
 When the <a>'pathLength'</a> attribute value is absent and
 the <a>'path-length'</a> property computes to
 <span class="prop-value">none</span>, no author scaling is applied.</p>


### PR DESCRIPTION
Per the CSSWG resolution (resolution, 20 May 2026), change path-length value type from `<number [0,∞]>` to `<length [0,∞]>`, following the standard SVG attribute → CSS property pattern.

Also adds explicit note that unitless pathLength attribute values map to px.

Addresses w3c/csswg-drafts#13901