### PR TITLE
Fix circle r property reference

### DIFF
--- a/master/shapes.html
+++ b/master/shapes.html
@@ -603,7 +603,7 @@ interface <b>SVGCircleElement</b> : <a>SVGGeometryElement</a> {
 <b id="__svg__SVGCircleElement__cy">cy</b> and
 <b id="__svg__SVGCircleElement__r">r</b> IDL attributes
 <a>reflect</a> the computed values of the <a>'cx'</a>, <a>'cy'</a>
-and <a>'y'</a> properties and their corresponding presentation attributes,
+and <a>'r'</a> properties and their corresponding presentation attributes,
 respectively.</p>
 
 </edit:with>


### PR DESCRIPTION
## Summary
- update the `SVGCircleElement` prose so `cx`, `cy`, and `r` reflect the `cx`, `cy`, and `r` properties
- replace the incorrect `y` property reference in the circle element section

Fixes #1119.

## Testing
- `git diff --check`
- `rg -n "and <a>'y'</a> properties|and <a>'r'</a> properties" master/shapes.html`

This is a one-word typo correction in prose, so no web-platform-tests change is needed.

No additional contributors.

AI disclosure: I used OpenAI Codex to help prepare this change.