### PR TITLE
fix #1119 - fix typo in the circle IDL prose.

### DIFF
--- a/master/shapes.html
+++ b/master/shapes.html
@@ -603,7 +603,7 @@ interface <b>SVGCircleElement</b> : <a>SVGGeometryElement</a> {
 <b id="__svg__SVGCircleElement__cy">cy</b> and
 <b id="__svg__SVGCircleElement__r">r</b> IDL attributes
 <a>reflect</a> the computed values of the <a>'cx'</a>, <a>'cy'</a>
-and <a>'y'</a> properties and their corresponding presentation attributes,
+and <a>'r'</a> properties and their corresponding presentation attributes,
 respectively.</p>
 
 </edit:with>


### PR DESCRIPTION
This fixes a simple typo in the prose y used instead of r.