### PR TITLE
Fix #1124 - broken links and warnings in build output

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -261,7 +261,7 @@ have been made.</p>
     specify algorithm used for isPointInFill() and isPointInStroke().
     <a href="https://github.com/w3c/svgwg/issues/416">Issue discussion</a>
     <a href="https://github.com/w3c/svgwg/pull/443">Edits</a></li>
-  <li>Moved dataset, tabIndex, focus(), and blur() to a shared <a>HTMLOrSVGElement</a> mixin defined in the HTML specification.
+  <li>Moved dataset, tabIndex, focus(), and blur() to a shared <a>HTMLOrSVGOrMathMLElement</a> mixin defined in the HTML specification.
     <a href="https://github.com/w3c/svgwg/issues/60">Issue discussion</a>
     <a href="https://github.com/w3c/svgwg/pull/415">Edits</a></li>
   <li>Made <a>SVGElement</a> include the DocumentAndElementEventHandlers interface from HTML.

--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -1082,7 +1082,6 @@
   <term name='current text position'        href='text.html#TermCurrentTextPosition'/>
   <term name='current text positions'       href='text.html#TermCurrentTextPosition'/>
   <term name='content area'                 href='text.html#TermContentArea'/>
-  <term name='wrapping context'             href='text.html#TermWrappingContext'/>
   <term name='wrapping area'                href='text.html#TermWrappingArea'/>
   <term name='wrapping areas'               href='text.html#TermWrappingArea'/>
   <term name='block-flow direction'         href='text.html#TermBlockFlowDirection'/>

--- a/master/interact.html
+++ b/master/interact.html
@@ -1155,7 +1155,7 @@ myElement.addEventListener("click", myAction1, false)
 
 <pre class="idl">[<a>Exposed</a>=Window]
 interface <b>SVGScriptElement</b> : <a>SVGElement</a> {
-  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="interact.html#__svg__SVGScriptElement__type">type</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a id="__svg__SVGScriptElement__type" href="interact.html#__svg__SVGScriptElement__type">type</a>;
   attribute DOMString? <a href="interact.html#__svg__SVGScriptElement__crossOrigin">crossOrigin</a>;
 };
 

--- a/master/linking.html
+++ b/master/linking.html
@@ -1148,13 +1148,13 @@ as follows:</p>
 
 <pre class="idl">[<a>Exposed</a>=Window]
 interface <b>SVGAElement</b> : <a>SVGGraphicsElement</a> {
-  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>, <a>SameObject</a>] readonly attribute <a>SVGAnimatedString</a> <a href="linking.html#__svg__SVGAElement__target">target</a>;
-  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="linking.html#__svg__SVGAElement__download">download</a>;
-  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute USVString <a href="linking.html#__svg__SVGAElement__ping">ping</a>;
-  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="linking.html#__svg__SVGAElement__rel">rel</a>;
-  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>="rel", <a>SameObject</a>, <a>PutForwards</a>=value] readonly attribute <a>DOMTokenList</a> <a href="linking.html#__svg__SVGAElement__relList">relList</a>;
-  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="linking.html#__svg__SVGAElement__hreflang">hreflang</a>;
-  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="linking.html#__svg__SVGAElement__type">type</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>, <a>SameObject</a>] readonly attribute <a>SVGAnimatedString</a> <a id="__svg__SVGAElement__target" href="linking.html#__svg__SVGAElement__target">target</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a id="__svg__SVGAElement__download" href="linking.html#__svg__SVGAElement__download">download</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute USVString <a id="__svg__SVGAElement__ping" href="linking.html#__svg__SVGAElement__ping">ping</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a id="__svg__SVGAElement__rel" href="linking.html#__svg__SVGAElement__rel">rel</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>="rel", <a>SameObject</a>, <a>PutForwards</a>=value] readonly attribute <a>DOMTokenList</a> <a id="__svg__SVGAElement__relList" href="linking.html#__svg__SVGAElement__relList">relList</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a id="__svg__SVGAElement__hreflang" href="linking.html#__svg__SVGAElement__hreflang">hreflang</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a id="__svg__SVGAElement__type" href="linking.html#__svg__SVGAElement__type">type</a>;
 
   attribute DOMString <a href="linking.html#__svg__SVGAElement__referrerPolicy">referrerPolicy</a>;
 };

--- a/master/paths.html
+++ b/master/paths.html
@@ -1252,7 +1252,7 @@ commands contribute to path length calculations.</p>
   </tr>
   <tr>
     <th>Value:</th>
-    <td>none | <a>&lt;length [0,∞]&gt;</a></td>
+    <td>none | <a>&lt;length&gt;</a> [0,∞]</td>
   </tr>
   <tr>
     <th>Initial:</th>

--- a/master/styling.html
+++ b/master/styling.html
@@ -703,10 +703,10 @@ in the DOM.</p>
 
 <pre class="idl">[<a>Exposed</a>=Window]
 interface <b>SVGStyleElement</b> : <a>SVGElement</a> {
-  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="styling.html#__svg__SVGStyleElement__type">type</a>;
-  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="styling.html#__svg__SVGStyleElement__media">media</a>;
-  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a href="styling.html#__svg__SVGStyleElement__title">title</a>;
-  attribute boolean <a href="styling.html#__svg__SVGStyleElement__disabled">disabled</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a id="__svg__SVGStyleElement__type" href="styling.html#__svg__SVGStyleElement__type">type</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a id="__svg__SVGStyleElement__media" href="styling.html#__svg__SVGStyleElement__media">media</a>;
+  [<a href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#xattr-reflect">Reflect</a>] attribute DOMString <a id="__svg__SVGStyleElement__title" href="styling.html#__svg__SVGStyleElement__title">title</a>;
+  attribute boolean <a id="__svg__SVGStyleElement__disabled" href="styling.html#__svg__SVGStyleElement__disabled">disabled</a>;
 };
 
 <a>SVGStyleElement</a> includes <a>LinkStyle</a>;</pre>


### PR DESCRIPTION
The make build emitted broken-link errors and warnings introduced by several recent PRs that left dangling references behind. Each fix is the minimal change needed to silence the build.

- master/styling.html, master/interact.html, master/linking.html: Add id="..." to the IDL `<a>` tags for `SVGStyleElement` (type, media, title, disabled), `SVGScriptElement` (type), and `SVGAElement` (target, download, ping, rel, relList, hreflang, type). PR #1003 (commit 558c06d, "Replace spec prose with IDL extended attribute for simple reflection") deleted the prose paragraphs that held the `<b id="__svg__...">` definitions, but the IDL `<a href="...#__svg__...">` references still pointed at them. Putting the id on the IDL anchor itself restores the link target at the natural definition site.

- master/definitions.xml: Remove the orphan `<term name='wrapping context' href='text.html#TermWrappingContext'/> `entry. PR #1097 (commit 72dbe36, "Remove shape-inside, shape-subtract and related properties from SVG2") deleted the TermWrappingContext `<dfn>` from text.html along with all prose using the term, but the glossary definition file still listed it.

- master/changes.html: Update `HTMLOrSVGElement` to `HTMLOrSVGOrMathMLElement`. PR #1078 (commit fd14001, "Refer to new `HTMLOrSVGOrMathMLElement` mixin") renamed the mixin in definitions.xml and types.html but missed the changelog entry.

- master/paths.html: Move "[0,∞]" outside the` <a><length></a>` symbol link in the path-length property's Value row. The build's symbol table only knows "length"; "length [0,∞]" was treated as an unknown symbol. The range now sits beside the linked type, matching how other property tables express bounds.