### PR TITLE
fix IDL exclusion

### DIFF
--- a/tools/publish/processing.js
+++ b/tools/publish/processing.js
@@ -866,7 +866,7 @@ exports.processReplacements = function(conf, page, doc) {
       var substitutions = { maturity: conf.maturity, date: conf.publicationDateISO, latest: conf.versions.latest };
       var editAttrs = [];
       for (var i = 0; i < n.attributes.length; i++) {
-        if (n.attributes[i].namespaceURI == namespaces.edit) {
+        if (n.attributes[i].namespaceURI == namespaces.edit && !n.hasAttribute("edit:excludefromidl")) {
           editAttrs.push(n.attributes[i]);
         }
       }


### PR DESCRIPTION
#1117 introduced [an unintended side effect](https://github.com/w3c/svgwg/pull/1117#issuecomment-4661192696) where all the elements under the 'edit' namespace are being replaced and thus, overriding the expected behavior from `doCompleteIDL`.
That PR skips the replacement for `edit:excludefromidl`

/cc @tidoust 