### PR TITLE
#1131 - fixing links to the current versions of specifications

### DIFF
--- a/master/Overview.html
+++ b/master/Overview.html
@@ -37,7 +37,7 @@
       <dt>Feedback:</dt>
       <dd><a href="https://github.com/w3c/svgwg/issues/">https://github.com/w3c/svgwg/issues/</a></dd>
       <dt>Public comments:</dt>
-      <dd><a href="mailto:www-svg@w3.org" class='url'>www-svg@w3.org</a> (<a href="http://lists.w3.org/Archives/Public/www-svg/">archive</a>)</dd>
+      <dd><a href="mailto:www-svg@w3.org" class='url'>www-svg@w3.org</a> (<a href="https://lists.w3.org/Archives/Public/www-svg/">archive</a>)</dd>
       <dt class="top-editors">Editors:</dt>
       <dd data-editor-id="14760">Karl Dubost, Apple, Inc. &lt;<a href="mailto:karlcow@apple.com" class='url'>karlcow@apple.com</a>&gt;</dd>
       <dd data-editor-id="165580">Divyansh Mangal, Microsoft Co. &lt;<a href="mailto:dmangal@microsoft.com" class='url'>dmangal@microsoft.com</a>&gt;</dd>
@@ -63,7 +63,7 @@
     </dl>
   </details>
   <!--
-  <p>Please refer to the <a href="http://www.w3.org/2011/08/REC-SVG11-20110802-errata"><strong>errata</strong></a> for this document, which may include some normative corrections.</p>
+  <p>Please refer to the <a href="https://www.w3.org/2011/08/REC-SVG11-20110802-errata"><strong>errata</strong></a> for this document, which may include some normative corrections.</p>
   -->
   <edit:copyright/>
   <hr/>
@@ -97,7 +97,7 @@ against the specification will be published as errata,
 and subsequently will be incorporated into future editions of SVG 2.-->
 Comments can be sent to <a href="mailto:www-svg@w3.org" class='url'>www-svg@w3.org</a>,
 the public email list for issues related to vector graphics on the Web. This list is
-<a href="http://lists.w3.org/Archives/Public/www-svg/">archived</a> and
+<a href="https://lists.w3.org/Archives/Public/www-svg/">archived</a> and
 senders must agree to have their message publicly archived from their
 first posting. To subscribe send an email to
 <a href="mailto:www-svg-request@w3.org" class='url'>www-svg-request@w3.org</a> with
@@ -127,17 +127,6 @@ the word <code>subscribe</code> in the subject line.</p>
   visible.  To view the section maturity background colors and any additional
   annotations, the "All annotations" alternate style sheet can be used.</p></edit:whenpublished>
 </div>
-
-<!--
-XXX At some point we will need to publish the new test suite in Mercurial and
-link to it from here.
-
-<p>The W3C SVG Working Group has released an expanded
-<a href="http://dev.w3.org/SVG/profiles/1.1F2/test/harness/index.html">test suite</a> for SVG 1.1
-along with an
-<a href="http://dev.w3.org/SVG/profiles/1.1F2/test/status/implementation_matrix.html">implementation report</a>.
-This test suite will continue to be updated with new tests to improve interoperability even after Recommendation phase.</p>
--->
 
 <p>This document was published by the <a href="https://www.w3.org/groups/wg/svg/">SVG Working Group</a> as a <edit:maturity/> using the <a href="https://www.w3.org/policies/process/20250818/#recs-and-notes">Recommendation track</a>.</p>
 

--- a/master/animate.html
+++ b/master/animate.html
@@ -30,7 +30,7 @@ SVG content can be animated in the following ways:</p>
   attributes and style properties. These effects can be chained together
   or triggered in response to other events in the document.</li>
 
-  <li>Using <a href="http://www.w3.org/TR/css-animations-1/"><cite>CSS Animations</cite></a>
+  <li>Using <a href="https://www.w3.org/TR/css-animations-1/"><cite>CSS Animations</cite></a>
   [<a href="refs.html#ref-css-animations-1">css-animations-1</a>].
   This CSS module defines a way for authors to animate the values of
   CSS properties over time, using keyframes. The behavior of these

--- a/master/conform.html
+++ b/master/conform.html
@@ -129,7 +129,7 @@
       </p>
       <ul>
         <li><a>same-document URL references</a>, as defined in the <a href="linking.html">Linking chapter</a></li>
-        <li><a>data URL references</a>, as defined by <a href="http://www.ietf.org/rfc/rfc2397.txt">the "data" URL scheme</a>
+        <li><a>data URL references</a>, as defined by <a href="https://www.ietf.org/rfc/rfc2397.txt">the "data" URL scheme</a>
   [<a href="refs.html#ref-rfc2397">rfc2397</a>]</li>
       </ul>
       <p>When external references are disabled in an SVG document, any attempt to
@@ -862,8 +862,8 @@ the server must use the "Content-Encoding:&nbsp;gzip" or
 <div class="note">
 <p>
 In HTTP, compression of stored <em>content</em> (the "entity") is distinct from automatic compression of the <em>message body</em>, as
-defined in HTTP/1.1 <a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.39">TE</a>/
-<a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.41">Transfer Encoding</a>
+defined in HTTP/1.1 <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.39">TE</a>/
+<a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.41">Transfer Encoding</a>
 ([<a href="refs.html#ref-rfc2616">rfc2616</a>], sections 14.39 and 14.41).
 If this is poorly configured,
 and the compression specified in the HTTP headers does not match the used values,
@@ -934,13 +934,13 @@ and in the <a href="linking.html">Linking chapter</a>.
   <table>
     <tr>
       <th>Action:</th>
-      <td><a href="http://www.w3.org/2013/11/14-svg-minutes.html#action01">Look at the performance class requirements and decide whether to remove points or move them into general requirements.</a> (heycam)
+      <td><a href="https://www.w3.org/2013/11/14-svg-minutes.html#action01">Look at the performance class requirements and decide whether to remove points or move them into general requirements.</a> (heycam)
       <br/>
-      <a href="http://www.w3.org/2014/10/31-svg-minutes.html#action02">Spec that calculation of CTMs should use double precision.</a> (stakagi)</td>
+      <a href="https://www.w3.org/2014/10/31-svg-minutes.html#action02">Spec that calculation of CTMs should use double precision.</a> (stakagi)</td>
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2013/11/14-svg-minutes.html#item01">Remove performance class requirements from SVG 2.</a> ( <a href="conform.html#ConformingHighQualitySVGViewers">ConformingHighQualitySVGViewers</a> )</td>
+      <td><a href="https://www.w3.org/2013/11/14-svg-minutes.html#item01">Remove performance class requirements from SVG 2.</a> ( <a href="conform.html#ConformingHighQualitySVGViewers">ConformingHighQualitySVGViewers</a> )</td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -1013,7 +1013,7 @@ definitions from the CSS 2.1 specification</a>
   <li>The viewer must support <a>data URL references</a>
     containing base64-encoded or URL-encoded content,
     in conformance with
-  <a href="http://www.ietf.org/rfc/rfc2397.txt"> the "data:" URL scheme</a>
+  <a href="https://www.ietf.org/rfc/rfc2397.txt"> the "data:" URL scheme</a>
   [<a href="refs.html#ref-rfc2397">rfc2397</a>],
   wherever a URI reference to another document is permitted within
   SVG content.
@@ -1067,21 +1067,21 @@ definitions from the CSS 2.1 specification</a>
   sRGB color component values range from 0 to 255.</li>
 
   <li id="user-agent-compression-requirements">SVG implementations must correctly support
-  <a href="http://www.ietf.org/rfc/rfc1952.txt">gzip-encoded</a>
+  <a href="https://www.ietf.org/rfc/rfc1952.txt">gzip-encoded</a>
   [<a href="refs.html#ref-rfc1952">rfc1952</a>] and
-  <a href="http://www.ietf.org/rfc/rfc1951.txt">deflate-encoded</a>
+  <a href="https://www.ietf.org/rfc/rfc1951.txt">deflate-encoded</a>
   [<a href="refs.html#ref-rfc1951">rfc1951</a>] data streams,
   for any content type (including SVG, script files, images).
   SVG implementations that support HTTP must support these
   encodings according to the
-  <a href="http://www.ietf.org/rfc/rfc2616.txt">HTTP 1.1</a>
+  <a href="https://www.ietf.org/rfc/rfc2616.txt">HTTP 1.1</a>
   specification [<a href="refs.html#ref-rfc2616">rfc2616</a>];
   in particular, the client must specify with an "Accept-Encoding:"
-  request header [<a href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3">HTTP-ACCEPT-ENCODING</a>]
+  request header [<a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.3">HTTP-ACCEPT-ENCODING</a>]
   those encodings that it accepts, including at minimum gzip
   and deflate, and then decompress any
-  <a href="http://www.ietf.org/rfc/rfc1952.txt">gzip-encoded</a> and
-  <a href="http://www.ietf.org/rfc/rfc1951.txt">deflate-encoded</a>
+  <a href="https://www.ietf.org/rfc/rfc1952.txt">gzip-encoded</a> and
+  <a href="https://www.ietf.org/rfc/rfc1951.txt">deflate-encoded</a>
   data streams that are downloaded from the server. When an SVG
   viewer retrieves compressed content (e.g., an <i>.svgz</i> file) over
   HTTP, if the "Content-Encoding" and "Transfer-Encoding" response

--- a/master/coords.html
+++ b/master/coords.html
@@ -269,7 +269,7 @@ as defined in [<a href="refs.html#ref-css-transforms-1">css-transforms-1</a>].</
 </dl>
 
 <p class="annotation">Transform on the <a>'svg'</a> element is a bit special due to the <a>'viewBox'</a> attribute. The transform should be applied as if the <a>'svg'</a> had a parent element with that transform set.
-<br/><br/><a href="http://www.w3.org/2015/01/08-svg-minutes.html">RESOLUTION: transform property applies conceptually to the outside of the 'svg' element and there is no difference between
+<br/><br/><a href="https://www.w3.org/2015/01/08-svg-minutes.html">RESOLUTION: transform property applies conceptually to the outside of the 'svg' element and there is no difference between
 presentation attribute and style property</a> (in terms of the visual result).</p>
 
 <p class="note">The <a>'viewBox'</a> attribute, in conjunction with the
@@ -1401,11 +1401,11 @@ provided by David Vest.</p>
   <table>
     <tr>
       <th>SVG 2 Requirement:</th>
-      <td><a href="http://www.w3.org/Graphics/SVG/WG/wiki/SVG2_Requirements_Input#Constrained_Transformations">SVG 2 will have constrained transformations based on SVG 1.2 Tiny.</a></td>
+      <td><a href="https://www.w3.org/Graphics/SVG/WG/wiki/SVG2_Requirements_Input#Constrained_Transformations">SVG 2 will have constrained transformations based on SVG 1.2 Tiny.</a></td>
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2014/04/09-svg-minutes.html#item06">Add vector effects extension proposal to SVG 2 specification.</a></td>
+      <td><a href="https://www.w3.org/2014/04/09-svg-minutes.html#item06">Add vector effects extension proposal to SVG 2 specification.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -1668,7 +1668,7 @@ to <a>viewport coordinate system</a> is as follows.</p>
 </div>
 
 <!--
-<p>Here, [DPR] is <a href="http://dev.w3.org/csswg/cssom-view/#dom-window-devicepixelratio">Device Pixel Ratio</a> (in scalar). And [BCM] presupposes that it is a matrix synthesizing the coordinate transformation by Browser Chrome's built-in zooming panning functions. Hereafter, x(<a href="intro.html#TermUserSpace">userspace</a>), y(<a href="intro.html#TermUserSpace">userspace</a>) is abbreviated as x, y.
+<p>Here, [DPR] is <a href="https://drafts.csswg.org/cssom-view/#dom-window-devicepixelratio">Device Pixel Ratio</a> (in scalar). And [BCM] presupposes that it is a matrix synthesizing the coordinate transformation by Browser Chrome's built-in zooming panning functions. Hereafter, x(<a href="intro.html#TermUserSpace">userspace</a>), y(<a href="intro.html#TermUserSpace">userspace</a>) is abbreviated as x, y.
 </p>
 -->
 
@@ -3297,7 +3297,7 @@ setMatrix(<var>matrix</var>) is called, the following steps are run:</p>
   <li>If the <a>SVGTransform</a> object is <a href='#ReadOnlyTransform'>read only</a>, then
   <a>throw</a> a <a>NoModificationAllowedError</a>.</li>
   <li>Let <var>newMatrix</var> be the result of <code><a>DOMMatrixReadOnly</a>.fromMatrix(<var>matrix</var>)</code>,
-  including the <a href="https://drafts.fxtf.org/geometry/#dommatrixinit-dictionary">validate and fix-up</a> steps for missing values.
+  including the <a href="https://drafts.csswg.org/geometry-1/#dommatrixinit-dictionary">validate and fix-up</a> steps for missing values.
   If that method throws an error, then re-throw that error and abort these steps.</li>
   <li>If <var>newMatrix</var>.is2D() would return true,
   then set the <a>SVGTransform</a> object's

--- a/master/definitions-masking.xml
+++ b/master/definitions-masking.xml
@@ -56,9 +56,9 @@
 
   <term name='clipping path' href='#clipping-path'/>
   <term name='clipping paths' href='#clipping-path'/>
-  <term name='masks' href='https://drafts.fxtf.org/css-masking-1/#masking'/>
+  <term name='masks' href='https://drafts.csswg.org/css-masking-1/#masking'/>
 
   <!-- === defined in other specifications ================================ -->
 
-  <term name='compound selector' href='http://dev.w3.org/csswg/selectors4/#compound'/>
+  <term name='compound selector' href='https://drafts.csswg.org/selectors-4/#compound'/>
 </definitions>

--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -743,7 +743,7 @@
   <interface name='DOMRect' href='https://www.w3.org/TR/geometry-1/#DOMRect'/>
   <interface name='DOMRectReadOnly' href='https://www.w3.org/TR/geometry-1/#domrectreadonly'/>
   <interface name='SVGRect' href='https://www.w3.org/TR/geometry-1/#DOMRect'/>
-  <interface name='DOMMatrix2DInit' href='https://drafts.fxtf.org/geometry/#dictdef-dommatrix2dinit'/>
+  <interface name='DOMMatrix2DInit' href='https://drafts.csswg.org/geometry-1/#dictdef-dommatrix2dinit'/>
   <interface name='SVGAnimatedRect' href='types.html#InterfaceSVGAnimatedRect'/>
   <interface name='SVGLength' href='types.html#InterfaceSVGLength'/>
   <interface name='SVGTransform' href='coords.html#InterfaceSVGTransform'/>
@@ -818,7 +818,7 @@
   <symbol name='repeat-style' href='https://www.w3.org/TR/css3-background/#ltrepeat-stylegt'/>
   <symbol name='shape-box' href='https://www.w3.org/TR/css-shapes-1/#typedef-shape-box'/>
   <symbol name='time' href='https://www.w3.org/TR/css3-values/#time'/>
-  <symbol name='transform-list' href='http://dev.w3.org/csswg/css-transforms/#typedef-transform-list'/>
+  <symbol name='transform-list' href='https://drafts.csswg.org/css-transforms/#typedef-transform-list'/>
   <symbol name='url' href='https://www.w3.org/TR/css3-values/#url-value'/>
   <symbol name='XML-Name' href='https://www.w3.org/TR/xml/#NT-Name'/>
   <symbol name='string' href='https://www.w3.org/TR/css3-values/#strings'/>
@@ -1110,7 +1110,7 @@
   <interface name='DocumentFragment' href='https://dom.spec.whatwg.org/#interface-documentfragment'/>
   <interface name='ShadowRoot' href='https://dom.spec.whatwg.org/#interface-shadowroot'/>
   <interface name='DOMImplementation' href='https://dom.spec.whatwg.org/#interface-domimplementation'/>
-  <interface name='DOMException' href='https://heycam.github.io/webidl/#idl-DOMException'/>
+  <interface name='DOMException' href='https://webidl.spec.whatwg.org/#idl-DOMException'/>
   <interface name='DOMStringMap' href='https://html.spec.whatwg.org/multipage/dom.html#domstringmap'/>
   <interface name='DOMTokenList' href='https://dom.spec.whatwg.org/#interface-domtokenlist'/>
   <interface name='Element' href='https://dom.spec.whatwg.org/#interface-element'/>
@@ -1142,25 +1142,25 @@
   <interface name='CanvasDrawPath' href='https://html.spec.whatwg.org/multipage/canvas.html#canvasdrawpath' />
 
   <!-- ... extended attributes .......................................................... -->
-  <term name='Exposed' href='https://heycam.github.io/webidl/#Exposed' />
-  <term name='NewObject' href='https://heycam.github.io/webidl/#NewObject' />
-  <term name='PutForwards' href='https://heycam.github.io/webidl/#PutForwards' />
-  <term name='SameObject' href='https://heycam.github.io/webidl/#SameObject' />
+  <term name='Exposed' href='https://webidl.spec.whatwg.org/#Exposed' />
+  <term name='NewObject' href='https://webidl.spec.whatwg.org/#NewObject' />
+  <term name='PutForwards' href='https://webidl.spec.whatwg.org/#PutForwards' />
+  <term name='SameObject' href='https://webidl.spec.whatwg.org/#SameObject' />
 
   <!-- ... terms .......................................................... -->
   <term name='Animation type' href='https://www.w3.org/TR/web-animations-1/#animation-type'/>
   <term name='not additive' href='https://drafts.csswg.org/css-values-4/#not-additive'/>
   <term name='event type' href='https://dom.spec.whatwg.org/#ref-for-dom-event-type'/>
   <term name='event handler content attribute' href='https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-content-attributes'/>
-  <term name='compound selector' href='http://dev.w3.org/csswg/selectors4/#compound'/>
-  <term name='compound selectors' href='http://dev.w3.org/csswg/selectors4/#compound'/>
+  <term name='compound selector' href='https://drafts.csswg.org/selectors-4/#compound'/>
+  <term name='compound selectors' href='https://drafts.csswg.org/selectors-4/#compound'/>
   <term name='tree order' href='https://dom.spec.whatwg.org/#concept-tree-order'/>
-  <term name='IndexSizeError' href='https://heycam.github.io/webidl/#indexsizeerror'/>
-  <term name='InvalidStateError' href='https://heycam.github.io/webidl/#invalidstateerror'/>
-  <term name='NoModificationAllowedError' href='https://heycam.github.io/webidl/#nomodificationallowederror'/>
-  <term name='NotSupportedError' href='https://heycam.github.io/webidl/#notsupportederror'/>
-  <term name='SyntaxError' href='https://heycam.github.io/webidl/#syntaxerror'/>
-  <term name='TypeError' href='https://heycam.github.io/webidl/#exceptiondef-typeerror'/>
+  <term name='IndexSizeError' href='https://webidl.spec.whatwg.org/#indexsizeerror'/>
+  <term name='InvalidStateError' href='https://webidl.spec.whatwg.org/#invalidstateerror'/>
+  <term name='NoModificationAllowedError' href='https://webidl.spec.whatwg.org/#nomodificationallowederror'/>
+  <term name='NotSupportedError' href='https://webidl.spec.whatwg.org/#notsupportederror'/>
+  <term name='SyntaxError' href='https://webidl.spec.whatwg.org/#syntaxerror'/>
+  <term name='TypeError' href='https://webidl.spec.whatwg.org/#exceptiondef-typeerror'/>
   <term name='CORS settings attribute' href='https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attribute'/>
   <term name='limited to only known values' href='https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#limited-to-only-known-values'/>
   <term name='No CORS' href='https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attribute'/>
@@ -1168,8 +1168,8 @@
   <term name='set of space-separated tokens' href='https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#set-of-space-separated-tokens'/>
   <term name='set of comma-separated tokens' href='https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#set-of-comma-separated-tokens'/>
   <term name='same origin' href='https://html.spec.whatwg.org/multipage/origin.html#same-origin'/>
-  <term name='throw' href='https://heycam.github.io/webidl/#dfn-throw'/>
-  <term name='thrown' href='https://heycam.github.io/webidl/#dfn-throw'/>
+  <term name='throw' href='https://webidl.spec.whatwg.org/#dfn-throw'/>
+  <term name='thrown' href='https://webidl.spec.whatwg.org/#dfn-throw'/>
 
   <term name='ignore' href='https://drafts.csswg.org/css-syntax/#css-ignored'/>
   <term name='ignored' href='https://drafts.csswg.org/css-syntax/#css-ignored'/>
@@ -1201,9 +1201,9 @@
   <term name='intrinsic aspect ratio' href='https://www.w3.org/TR/css3-images#intrinsic-aspect-ratio'/>
 
   <!-- ... Wrapped text ................................................... -->
-  <term name='CSS basic shape'  href='http://dev.w3.org/csswg/css-shapes/#basic-shape-functions'/>
-  <term name='CSS basic shapes' href='http://dev.w3.org/csswg/css-shapes/#basic-shape-functions'/>
-  <term name='forced line break' href='http://dev.w3.org/csswg/css-text/#forced-line-break'/>
+  <term name='CSS basic shape'  href='https://drafts.csswg.org/css-shapes/#basic-shape-functions'/>
+  <term name='CSS basic shapes' href='https://drafts.csswg.org/css-shapes/#basic-shape-functions'/>
+  <term name='forced line break' href='https://drafts.csswg.org/css-text/#forced-line-break'/>
 
   <!-- ... grammar symbols ................................................ -->
   <symbol name='angle' href='https://www.w3.org/TR/css-values/#angles'/>
@@ -1226,9 +1226,9 @@
   <property name='background' href='https://drafts.csswg.org/css-backgrounds-3/#background'/>
   <property name='min-width' href='https://www.w3.org/TR/css-sizing-3/#propdef-min-width'/>
   <property name='max-width' href='https://www.w3.org/TR/css-sizing-3/#propdef-max-width'/>
-  <property name='block-size' href='http://dev.w3.org/csswg/css-writing-modes/#block-size'/>
+  <property name='block-size' href='https://drafts.csswg.org/css-writing-modes/#block-size'/>
   <property name='shape-outside' href='https://www.w3.org/TR/css-shapes/#shape-outside-property'/>
 
-  <term name='block size' href='http://dev.w3.org/csswg/css-writing-modes/#block-size'/>
-  <term name='inline size' href='http://dev.w3.org/csswg/css-writing-modes/#inline-size'/>
+  <term name='block size' href='https://drafts.csswg.org/css-writing-modes/#block-size'/>
+  <term name='inline size' href='https://drafts.csswg.org/css-writing-modes/#inline-size'/>
 </definitions>

--- a/master/embedded.html
+++ b/master/embedded.html
@@ -243,7 +243,7 @@ elements within an SVG file.</p>
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/10/27-svg-irc#T18-52-24">We will allow auto-sized images in SVG 2.</a></td>
+      <td><a href="https://www.w3.org/2011/10/27-svg-irc#T18-52-24">We will allow auto-sized images in SVG 2.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -251,7 +251,7 @@ elements within an SVG file.</p>
     </tr>
     <tr>
       <th>Owner:</th>
-      <td>Cameron (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3340">ACTION-3340</a>)</td>
+      <td>Cameron (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3340">ACTION-3340</a>)</td>
     </tr>
   </table>
 </div>
@@ -264,7 +264,7 @@ elements within an SVG file.</p>
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/10/27-svg-irc#T18-45-13">We will have a method for <span class='element-name'>'image'</span> to select a part of an image to display, maybe by allowing <span class='attr-name'>'viewBox'</span> on it.</a></td>
+      <td><a href="https://www.w3.org/2011/10/27-svg-irc#T18-45-13">We will have a method for <span class='element-name'>'image'</span> to select a part of an image to display, maybe by allowing <span class='attr-name'>'viewBox'</span> on it.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -285,7 +285,7 @@ elements within an SVG file.</p>
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/07/29-svg-minutes.html#item08">SVG 2 will depend on CSS3 Image Values and CSS4 Image Values.</a></td>
+      <td><a href="https://www.w3.org/2011/07/29-svg-minutes.html#item08">SVG 2 will depend on CSS3 Image Values and CSS4 Image Values.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>

--- a/master/escript.html
+++ b/master/escript.html
@@ -11,7 +11,7 @@
   <h1>Removed: ECMAScript Language Binding</h1>
   <p>This appendix is no longer part of the SVG specification.</p>
   <p>
-    SVG language bindings are now defined by <a href="https://heycam.github.io/webidl/">Web IDL</a>.
+    SVG language bindings are now defined by <a href="https://webidl.spec.whatwg.org/">Web IDL</a>.
   </p>
   <p>
     You can view <a href="https://www.w3.org/TR/SVG11/escript.html">the appendix in SVG 1.1</a>,

--- a/master/filters.html
+++ b/master/filters.html
@@ -13,8 +13,8 @@
   <p>
     The filter property and elements are now defined in
     the Filter Effects Module
-    (<a href="https://drafts.fxtf.org/filter-effects/">latest editor's draft</a>,
-     <a href="https://www.w3.org/TR/filter-effects/">latest technical report</a>).
+    (<a href="https://drafts.csswg.org/filter-effects-1/">latest editor's draft</a>,
+     <a href="https://www.w3.org/TR/filter-effects-1/">latest technical report</a>).
   </p>
   <p>
     You can also view <a href="https://www.w3.org/TR/SVG11/filters.html">the chapter in SVG 1.1</a>,

--- a/master/fonts.html
+++ b/master/fonts.html
@@ -13,7 +13,7 @@
   <p>
     The elements that were defined in this chapter are now obsolete.
     The CSS Fonts Module defines how to specify fonts for documents including SVG
-    (<a href="https://drafts.fxtf.org/css-fonts/">latest editor's draft</a>,
+    (<a href="https://drafts.csswg.org/css-fonts/">latest editor's draft</a>,
      <a href="https://www.w3.org/TR/css-fonts/">latest technical report</a>).
     See the <a href="text.html">Text chapter</a> for SVG-specific details.
   </p>

--- a/master/images/linking/link01.svg
+++ b/master/images/linking/link01.svg
@@ -5,7 +5,7 @@
   </desc>
   <rect x=".01" y=".01" width="4.98" height="2.98" 
         fill="none" stroke="blue"  stroke-width=".03"/>
-  <a href="http://www.w3.org">
+  <a href="https://www.w3.org">
     <ellipse cx="2.5" cy="1.5" rx="2" ry="1"
              fill="red" />
   </a>

--- a/master/interact.html
+++ b/master/interact.html
@@ -56,7 +56,7 @@ including under which circumstances events are triggered.</p>
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/12/22-svg-irc#T21-23-17">SVG 2 will consider adding HTML document wide events (including hashchange) apply to SVG documents where they make sense.</a></td>
+      <td><a href="https://www.w3.org/2011/12/22-svg-irc#T21-23-17">SVG 2 will consider adding HTML document wide events (including hashchange) apply to SVG documents where they make sense.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -64,7 +64,7 @@ including under which circumstances events are triggered.</p>
     </tr>
     <tr>
       <th>Owner:</th>
-      <td>Cameron (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3278">ACTION-3278</a>)</td>
+      <td>Cameron (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3278">ACTION-3278</a>)</td>
     </tr>
   </table>
 </div>
@@ -77,7 +77,7 @@ including under which circumstances events are triggered.</p>
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/07/27-svg-minutes.html#item03">SVG 2 will move all events listener attributes to Element, in accordance with the similar move in HTML.</a></td>
+      <td><a href="https://www.w3.org/2011/07/27-svg-minutes.html#item03">SVG 2 will move all events listener attributes to Element, in accordance with the similar move in HTML.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -85,7 +85,7 @@ including under which circumstances events are triggered.</p>
     </tr>
     <tr>
       <th>Owner:</th>
-      <td>Cameron (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3283">ACTION-3283</a>)</td>
+      <td>Cameron (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3283">ACTION-3283</a>)</td>
     </tr>
   </table>
 </div>
@@ -98,7 +98,7 @@ including under which circumstances events are triggered.</p>
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/07/27-svg-minutes.html#item15">We decide to resolve ISSUE-2176 by introducing evt as an alias to event in event handlers.</a></td>
+      <td><a href="https://www.w3.org/2011/07/27-svg-minutes.html#item15">We decide to resolve ISSUE-2176 by introducing evt as an alias to event in event handlers.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -106,7 +106,7 @@ including under which circumstances events are triggered.</p>
     </tr>
     <tr>
       <th>Owner:</th>
-      <td>Cameron (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3093">ACTION-3093</a>)</td>
+      <td>Cameron (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3093">ACTION-3093</a>)</td>
     </tr>
   </table>
 </div>
@@ -119,7 +119,7 @@ including under which circumstances events are triggered.</p>
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/12/22-svg-irc#T21-31-24">SVG 2 may require drag &amp; drop functionality, and we'll investigate HTML5's functionality for that.</a></td>
+      <td><a href="https://www.w3.org/2011/12/22-svg-irc#T21-31-24">SVG 2 may require drag &amp; drop functionality, and we'll investigate HTML5's functionality for that.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -127,7 +127,7 @@ including under which circumstances events are triggered.</p>
     </tr>
     <tr>
       <th>Owner:</th>
-      <td>Erik (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3328">ACTION-3328</a>)</td>
+      <td>Erik (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3328">ACTION-3328</a>)</td>
     </tr>
   </table>
 </div>
@@ -958,7 +958,7 @@ myElement.addEventListener("click", myAction1, false)
       </tr>
       <tr>
         <th>Resolution:</th>
-        <td><a href="http://www.w3.org/2012/01/05-svg-irc#T21-07-03">SVG 2 will allow async/defer on <span class="element-name">'script'</span>.</a></td>
+        <td><a href="https://www.w3.org/2012/01/05-svg-irc#T21-07-03">SVG 2 will allow async/defer on <span class="element-name">'script'</span>.</a></td>
       </tr>
       <tr>
         <th>Purpose:</th>
@@ -966,7 +966,7 @@ myElement.addEventListener("click", myAction1, false)
       </tr>
       <tr>
         <th>Owner:</th>
-        <td>Cameron (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3280">ACTION-3280</a>)</td>
+        <td>Cameron (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3280">ACTION-3280</a>)</td>
       </tr>
     </table>
   </div>
@@ -979,7 +979,7 @@ myElement.addEventListener("click", myAction1, false)
       </tr>
       <tr>
         <th>Resolution:</th>
-        <td><a href="http://www.w3.org/2012/03/08-svg-irc#T21-09-09">SVG 2 will define how inline scriptable content will be processed, in a compatible way to HTML5</a></td>
+        <td><a href="https://www.w3.org/2012/03/08-svg-irc#T21-09-09">SVG 2 will define how inline scriptable content will be processed, in a compatible way to HTML5</a></td>
       </tr>
       <tr>
         <th>Purpose:</th>
@@ -987,7 +987,7 @@ myElement.addEventListener("click", myAction1, false)
       </tr>
       <tr>
         <th>Owner:</th>
-        <td>Cameron (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3282">ACTION-3282</a>)</td>
+        <td>Cameron (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3282">ACTION-3282</a>)</td>
       </tr>
     </table>
   </div>
@@ -1110,7 +1110,7 @@ myElement.addEventListener("click", myAction1, false)
     <dd>
       Identifies the scripting language for the given <a>'script'</a> element. The value
       must be a valid media type, per
-      <a href="http://www.ietf.org/rfc/rfc2046.txt">Multipurpose Internet Mail Extensions
+      <a href="https://www.ietf.org/rfc/rfc2046.txt">Multipurpose Internet Mail Extensions
       (MIME) Part Two</a> [<a href="refs.html#ref-rfc2046">rfc2046</a>].
       If a <a>'script/type'</a> is not provided, then the default scripting
       language assumed is ECMAScript, as if processed with the

--- a/master/intro.html
+++ b/master/intro.html
@@ -19,7 +19,7 @@
 <h2 id="AboutSVG">About SVG</h2>
 
 <p>This specification defines the features and syntax for
-<a href="http://www.w3.org/Graphics/SVG/">Scalable Vector Graphics (SVG)</a>.</p>
+<a href="https://www.w3.org/Graphics/SVG/">Scalable Vector Graphics (SVG)</a>.</p>
 
 <p>SVG is a language for describing two-dimensional graphics.
 As a standalone format or when mixed with other XML, it uses the
@@ -89,7 +89,7 @@ and standards efforts, as described in the following:</p>
   href="refs.html#ref-unicode">UNICODE</a>]
   and [<a href="refs.html#ref-charmod">charmod</a>].</li>
 
-  <li>SVG is compatible with <a href="http://www.w3.org/WAI/">W3C work on Web Accessibility</a>.
+  <li>SVG is compatible with <a href="https://www.w3.org/WAI/">W3C work on Web Accessibility</a>.
   See <a href="access.html">Accessibility Support</a>.</li>
 </ul>
 
@@ -107,7 +107,7 @@ Tiny 1.2 to be a deprecated branch of the SVG standard.
 <p>Within this specification, the key words "MUST", "MUST NOT",
 "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
 "RECOMMENDED", "MAY", and "OPTIONAL" are to be interpreted as
-described in <a href="http://www.ietf.org/rfc/rfc2119.txt"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>
+described in <a href="https://www.ietf.org/rfc/rfc2119.txt"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>
 [<a href="refs.html#ref-rfc2119">rfc2119</a>].
 However, for readability, these words do not appear in all
 uppercase letters in this specification.</p>

--- a/master/java.html
+++ b/master/java.html
@@ -11,7 +11,7 @@
   <h1>Removed: Java Language Binding</h1>
   <p>This appendix is no longer part of the SVG specification.</p>
   <p>
-    SVG language bindings are now defined by <a href="https://heycam.github.io/webidl/">Web IDL</a>.
+    SVG language bindings are now defined by <a href="https://webidl.spec.whatwg.org/">Web IDL</a>.
   </p>
   <p>
     You can view <a href="https://www.w3.org/TR/SVG11/java.html">the appendix in SVG 1.1</a>,

--- a/master/linking.html
+++ b/master/linking.html
@@ -60,7 +60,7 @@ on the scripting context when a <a>'script'</a> element's
 
   <dt><dfn id="TermURLReference" data-dfn-type="dfn" data-export="">URL reference</dfn></dt>
   <dd>An URL reference is an Internationalized Resource Identifier, as defined in
-  <a href="http://www.ietf.org/rfc/rfc3987.txt"><cite>Internationalized Resource Identifiers</cite></a>
+  <a href="https://www.ietf.org/rfc/rfc3987.txt"><cite>Internationalized Resource Identifiers</cite></a>
   [<a href='refs.html#ref-rfc3987'>rfc3987</a>]. See
   <a href="linking.html#URLReference">References</a> and
   <a href="struct.html#Head">References and the
@@ -84,7 +84,7 @@ on the scripting context when a <a>'script'</a> element's
 
   <dt><dfn id="TermDataURL" data-dfn-type="dfn" data-export="">data URL</dfn></dt>
   <dd>A <a>URL reference</a> to an embedded document
-    specified using the <a href="http://www.ietf.org/rfc/rfc2397.txt">"data" URL scheme</a>
+    specified using the <a href="https://www.ietf.org/rfc/rfc2397.txt">"data" URL scheme</a>
   [<a href="refs.html#ref-rfc2397">rfc2397</a>].
     Data URL references are neither
     <a>external file references</a> nor <a>same-document URL references</a>.
@@ -153,7 +153,7 @@ because the <a>URL</a> specification was not yet standardized.</p>
 
 <p>In this specification, the correct term <a>URL</a> is used for this "URI or sequence of characters
 plus an algorithm" and the escaping method, which turns URLs into URIs, is defined by reference to the
-<a href="http://www.ietf.org/rfc/rfc3987.txt">URL specification</a> [<a href="refs.html#ref-rfc3987">rfc3987</a>],
+<a href="https://www.ietf.org/rfc/rfc3987.txt">URL specification</a> [<a href="refs.html#ref-rfc3987">rfc3987</a>],
 which has since become an IETF Proposed Standard. Other W3C specifications are
 expected to be revised over time to remove these duplicate descriptions of the
 escaping procedure and to refer to <a>URL</a> directly.</p>
@@ -238,7 +238,7 @@ attribute must be a URL.</p>
 
 <p>Because it is impractical for any application to check that
 a value is an <a>URL reference</a>, this specification follows the lead
-of the <a href="http://www.ietf.org/rfc/rfc3986.txt">URL Specification</a>
+of the <a href="https://www.ietf.org/rfc/rfc3986.txt">URL Specification</a>
 in this matter and imposes no such conformance testing
 requirement on <a>SVG authoring tools</a>.
 An invalid URL does not make an SVG document non-conforming.
@@ -437,7 +437,7 @@ The absolute URL should be generated using one of the following methods:
 
 <p>If the protocol, such as HTTP, does not support <a>URLs</a> directly,
 the <a>URL</a> must be converted to a URI by the user agent, as described
-in section 3.1 of the <a href="http://www.ietf.org/rfc/rfc3987.txt">URL specification</a> [<a href="refs.html#ref-rfc3987">rfc3987</a>].</p>
+in section 3.1 of the <a href="https://www.ietf.org/rfc/rfc3987.txt">URL specification</a> [<a href="refs.html#ref-rfc3987">rfc3987</a>].</p>
 
 <p>After generating the absolute URL:</p>
 <ul>
@@ -947,7 +947,7 @@ section of the document.</p>
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2012/03/08-svg-irc#T21-05-52">SVG 2 will have media fragment identifiers.</a></td>
+      <td><a href="https://www.w3.org/2012/03/08-svg-irc#T21-05-52">SVG 2 will have media fragment identifiers.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -955,7 +955,7 @@ section of the document.</p>
     </tr>
     <tr>
       <th>Owner:</th>
-      <td>Cyril (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3442">ACTION-3442</a>)</td>
+      <td>Cyril (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3442">ACTION-3442</a>)</td>
     </tr>
   </table>
 </div>

--- a/master/masking.html
+++ b/master/masking.html
@@ -13,8 +13,8 @@
   <p>
     The mask and clip-path elements and properties are now defined in
     the CSS Masking Module
-    (<a href="https://drafts.fxtf.org/css-masking/">latest editor's draft</a>,
-     <a href="https://www.w3.org/TR/css-masking/">latest technical report</a>).
+    (<a href="https://drafts.csswg.org/css-masking-1/">latest editor's draft</a>,
+     <a href="https://www.w3.org/TR/css-masking-1/">latest technical report</a>).
   </p>
   <p>
     SVG-specific aspects of compositing are defined in the <a href="render.html">Rendering chapter</a>.

--- a/master/mimereg.html
+++ b/master/mimereg.html
@@ -23,7 +23,7 @@ Introduction
 </h2>
 
 <p>
-This appendix registers a new MIME media type, "image/svg+xml" in conformance with <a href="http://www.ietf.org/rfc/rfc4288.txt">BCP 13</a> and <a href="http://www.w3.org/2002/06/registering-mediatype.html">W3CRegMedia</a>.
+This appendix registers a new MIME media type, "image/svg+xml" in conformance with <a href="https://www.ietf.org/rfc/rfc4288.txt">BCP 13</a> and <a href="https://www.w3.org/2002/06/registering-mediatype.html">W3CRegMedia</a>.
 </p>
 
 <h2 id="mime-registration">

--- a/master/painting.html
+++ b/master/painting.html
@@ -64,7 +64,7 @@ they describe.  The <a href='#Markers'>Markers</a> section below describes
 how markers can be defined and used.</p>
 
 <p class="annotation">SVG 2 adds markers on shapes. Resolved at
-<a href="http://www.w3.org/2013/06/03-svg-minutes.html#item03">Tokyo F2F</a>.</p>
+<a href="https://www.w3.org/2013/06/03-svg-minutes.html#item03">Tokyo F2F</a>.</p>
 
 <!--
 <p>SVG uses the general notion of a <strong>paint server</strong>. Paint
@@ -84,7 +84,7 @@ paint servers.</p>
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/07/29-svg-minutes.html#item02">We will add new paint values currentFillPaint, currentStrokePaint etc. to SVG 2</a></td>
+      <td><a href="https://www.w3.org/2011/07/29-svg-minutes.html#item02">We will add new paint values currentFillPaint, currentStrokePaint etc. to SVG 2</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -92,7 +92,7 @@ paint servers.</p>
     </tr>
     <tr>
       <th>Owner:</th>
-      <td>Chris (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3094">ACTION-3094</a>)</td>
+      <td>Chris (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3094">ACTION-3094</a>)</td>
     </tr>
   </table>
 </div>
@@ -105,7 +105,7 @@ paint servers.</p>
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2013/06/03-svg-minutes.html#item10">We will allow multiple paints in the fill and stroke properties in SVG 2.</a></td>
+      <td><a href="https://www.w3.org/2013/06/03-svg-minutes.html#item10">We will allow multiple paints in the fill and stroke properties in SVG 2.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -113,12 +113,12 @@ paint servers.</p>
     </tr>
     <tr>
       <th>Owner:</th>
-      <td>Tav (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3500">ACTION-3500</a>)</td>
+      <td>Tav (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3500">ACTION-3500</a>)</td>
     </tr>
     <tr>
       <th>Deferred:</th>
       <td>This was dropped for SVG 2, but will be added later in sync with
-        <a href="https://drafts.fxtf.org/paint/">CSS Fill and Stroke Level 3</a>
+        <a href="https://drafts.csswg.org/fill-stroke/">CSS Fill and Stroke Level 3</a>
       </td>
     </tr>
   </table>
@@ -529,8 +529,8 @@ specifies group opacity.</p>
     </tr>
     <tr>
       <th>Resolutions:</th>
-      <td><a href="http://www.w3.org/2011/10/28-svg-irc#T17-46-34">SVG 2 will include non-scaling stroke.</a><br/>
-          <a href="http://www.w3.org/2012/02/02-svg-minutes.html#item05">SVG 2 will have the <span class="property">'vector-effect'</span> property.</a></td>
+      <td><a href="https://www.w3.org/2011/10/28-svg-irc#T17-46-34">SVG 2 will include non-scaling stroke.</a><br/>
+          <a href="https://www.w3.org/2012/02/02-svg-minutes.html#item05">SVG 2 will have the <span class="property">'vector-effect'</span> property.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -637,7 +637,7 @@ the stroke of a path.</p>
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/10/28-svg-irc#T18-09-48">SVG 2 shall include a way to specify stroke position.</a></td>
+      <td><a href="https://www.w3.org/2011/10/28-svg-irc#T18-09-48">SVG 2 shall include a way to specify stroke position.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -645,11 +645,11 @@ the stroke of a path.</p>
     </tr>
     <tr>
       <th>Owner:</th>
-      <td>Cameron (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3162">ACTION-3162</a>)</td>
+      <td>Cameron (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3162">ACTION-3162</a>)</td>
     </tr>
     <tr>
       <th>Note:</th>
-      <td>See <a href="http://www.w3.org/Graphics/SVG/WG/wiki/Proposals/Stroke_position">proposal page</a>.</td>
+      <td>See <a href="https://www.w3.org/Graphics/SVG/WG/wiki/Proposals/Stroke_position">proposal page</a>.</td>
     </tr>
   </table>
 </div>
@@ -1299,7 +1299,7 @@ description of positions along a path that dashes will be placed.</p>
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/10/28-svg-irc#T18-14-14">SVG 2 shall specify stroke dashing more precisely.</a></td>
+      <td><a href="https://www.w3.org/2011/10/28-svg-irc#T18-14-14">SVG 2 shall specify stroke dashing more precisely.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -1642,7 +1642,7 @@ a subpath is determined as follows:</p>
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/10/27-svg-irc#T18-12-30">We will improve markers for SVG 2.</a></td>
+      <td><a href="https://www.w3.org/2011/10/27-svg-irc#T18-12-30">We will improve markers for SVG 2.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -1650,7 +1650,7 @@ a subpath is determined as follows:</p>
     </tr>
     <tr>
       <th>Owner:</th>
-      <td>Cameron (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3286">ACTION-3286</a>)</td>
+      <td>Cameron (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3286">ACTION-3286</a>)</td>
     </tr>
   </table>
 </div>
@@ -1810,7 +1810,7 @@ for either attribute is an error (see
     <p class="annotation">
       We will add top/center/bottom, left/center/right keywords to
       refX/refY on marker/symbol. Resolved at
-      <a href="http://www.w3.org/2014/08/26-svg-minutes.html#item07">London
+      <a href="https://www.w3.org/2014/08/26-svg-minutes.html#item07">London
       F2F</a>. Values inspired by
       <a href="https://www.w3.org/TR/css3-background/#the-background-position">'background-position'</a>.
     </p>
@@ -2293,8 +2293,8 @@ the following:</p>
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2012/05/07-svg-minutes#item03">SVG 2 will adopt the <span class="property">'paint-order'</span> property proposal, though possibly with a different name.</a>
-      The property name is now resolved, see <a href="http://www.w3.org/2013/11/15-svg-minutes.html#item12">15 Nov 2013 minutes</a>.</td>
+      <td><a href="https://www.w3.org/2012/05/07-svg-minutes#item03">SVG 2 will adopt the <span class="property">'paint-order'</span> property proposal, though possibly with a different name.</a>
+      The property name is now resolved, see <a href="https://www.w3.org/2013/11/15-svg-minutes.html#item12">15 Nov 2013 minutes</a>.</td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -2302,7 +2302,7 @@ the following:</p>
     </tr>
     <tr>
       <th>Owner:</th>
-      <td>Cameron (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3285">ACTION-3285</a>)</td>
+      <td>Cameron (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3285">ACTION-3285</a>)</td>
     </tr>
   </table>
 </div>
@@ -2766,7 +2766,7 @@ following meanings:</p>
   </tr>
 </table>
 
-<p class="note">The <a href="http://dev.w3.org/csswg/css-images/#the-image-rendering">CSS Image Values and Replacement Content Module Level 4</a> may in the future redefine this property. In particular it should allow the choice between smoothing and keeping a pixelated look when upscaling.</p>
+<p class="note">The <a href="https://drafts.csswg.org/css-images/#the-image-rendering">CSS Image Values and Replacement Content Module Level 4</a> may in the future redefine this property. In particular it should allow the choice between smoothing and keeping a pixelated look when upscaling.</p>
 
 <p>The <a>'image-rendering'</a> property provides a hint to the implementation
 about how to make speed vs. quality tradeoffs as it performs

--- a/master/paths.html
+++ b/master/paths.html
@@ -683,7 +683,7 @@ command.</p>
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/11/04-svg-minutes.html#item08">Make arcs in paths easier.</a></td>
+      <td><a href="https://www.w3.org/2011/11/04-svg-minutes.html#item08">Make arcs in paths easier.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -691,7 +691,7 @@ command.</p>
     </tr>
     <tr>
       <th>Owner:</th>
-      <td>Cameron (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3151">ACTION-3151</a>)</td>
+      <td>Cameron (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3151">ACTION-3151</a>)</td>
     </tr>
   </table>
 </div>

--- a/master/pservers.html
+++ b/master/pservers.html
@@ -46,7 +46,7 @@ redefine them here. -->
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/10/28-svg-irc#T18-32-32">SVG 2 shall support filling and stroking from arbitrary elements.</a></td>
+      <td><a href="https://www.w3.org/2011/10/28-svg-irc#T18-32-32">SVG 2 shall support filling and stroking from arbitrary elements.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -914,7 +914,7 @@ shows how to fill a rectangle by referencing a linear gradient paint server.</p>
           </tr>
           <tr>
             <th>Resolution:</th>
-            <td><a href="http://www.w3.org/2011/07/29-svg-minutes.html#item06">Add an <span class="attr-name">'fr'</span> attribute to <span class="element-name">'radialGradient'</span>> for SVG 2.</a></td>
+            <td><a href="https://www.w3.org/2011/07/29-svg-minutes.html#item06">Add an <span class="attr-name">'fr'</span> attribute to <span class="element-name">'radialGradient'</span>> for SVG 2.</a></td>
           </tr>
           <tr>
             <th>Purpose:</th>
@@ -924,7 +924,7 @@ shows how to fill a rectangle by referencing a linear gradient paint server.</p>
           </tr>
           <tr>
             <th>Owner:</th>
-            <td>Erik (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3098">ACTION-3098</a>)</td>
+            <td>Erik (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3098">ACTION-3098</a>)</td>
           </tr>
         </table>
       </div>
@@ -1003,7 +1003,7 @@ shows how to fill a rectangle by referencing a linear gradient paint server.</p>
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/07/29-svg-minutes.html#item05">When the focal point is on the circle edge, with repeat, then the distance between the first and last stop for the repeating colors is 0 and the paint should generate a color that is the average of all the gradient stops.</a></td>
+      <td><a href="https://www.w3.org/2011/07/29-svg-minutes.html#item05">When the focal point is on the circle edge, with repeat, then the distance between the first and last stop for the repeating colors is 0 and the paint should generate a color that is the average of all the gradient stops.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -1011,7 +1011,7 @@ shows how to fill a rectangle by referencing a linear gradient paint server.</p>
     </tr>
     <tr>
       <th>Owner:</th>
-      <td>Erik (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3097">ACTION-3097</a>)</td>
+      <td>Erik (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3097">ACTION-3097</a>)</td>
     </tr>
     <tr>
       <th>Note:</th>
@@ -1032,7 +1032,7 @@ circle. The change was made to align with Canvas.</p>
 
 <p class="annotation">Allowing the focal point to lie outside the end
 circle was resolved at the
-<a href="http://www.w3.org/2012/09/19-svg-minutes.html#item01">Rigi
+<a href="https://www.w3.org/2012/09/19-svg-minutes.html#item01">Rigi
 Kaltbad working group meeting</a>.</p>
 
 <p>If the start circle defined by <a>'fx'</a>, <a>'fy'</a> and <a>'fr'</a> lies
@@ -1078,7 +1078,7 @@ maintain compatibility with SVG 1.1.</p>
 
 <p class="annotation">The color space for the weighted average is the
 same as in which the gradient is interpolated. See
-<a href="http://www.w3.org/2012/09/19-svg-minutes.html#item01">Rigi
+<a href="https://www.w3.org/2012/09/19-svg-minutes.html#item01">Rigi
 Kaltbad working group meeting</a>.</p>
 
 <p id="ExampleRadGrad01"><span class="example-ref">Example radgrad01</span>

--- a/master/publish.xml
+++ b/master/publish.xml
@@ -29,9 +29,9 @@
   </versions>
 
   <definitions href='definitions.xml'/>
-  <definitions href='definitions-filters.xml' base='https://drafts.fxtf.org/filter-effects/'/>
-  <definitions href='definitions-masking.xml' base='https://drafts.fxtf.org/css-masking-1/'/>
-  <definitions href='definitions-compositing.xml' base='https://drafts.fxtf.org/compositing-1/'/>
+  <definitions href='definitions-filters.xml' base='https://drafts.csswg.org/filter-effects-1/'/>
+  <definitions href='definitions-masking.xml' base='https://drafts.csswg.org/css-masking-1/'/>
+  <definitions href='definitions-compositing.xml' base='https://drafts.csswg.org/compositing-1/'/>
   <definitions href='../specs/animations/master/definitions.xml' base='https://w3c.github.io/svgwg/specs/animations/'/>
 
   <interfaces idl='../build/svg.idlx'/>

--- a/master/refs.html
+++ b/master/refs.html
@@ -29,7 +29,7 @@
   <dd><div>Gary Kacmarcik; Grisha Lyukshin; Hallvord Steen. <a href="https://www.w3.org/TR/clipboard-apis/"><cite>Clipboard API and events</cite></a>. 29 September 2017. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/clipboard-apis/">https://www.w3.org/TR/clipboard-apis/</a> ED:&nbsp;<a href="https://w3c.github.io/clipboard-apis/">https://w3c.github.io/clipboard-apis/</a></div></dd>
 
   <dt id="ref-compositing-1" class="normref">[<a href="https://www.w3.org/TR/compositing-1/">compositing-1</a>]</dt>
-  <dd><div>Rik Cabanier; Nikos Andronikos. <a href="https://www.w3.org/TR/compositing-1/"><cite>Compositing and Blending Level 1</cite></a>. 13 January 2015. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/compositing-1/">https://www.w3.org/TR/compositing-1/</a> ED:&nbsp;<a href="http://dev.w3.org/fxtf/compositing-1/">http://dev.w3.org/fxtf/compositing-1/</a></div></dd>
+  <dd><div>Rik Cabanier; Nikos Andronikos. <a href="https://www.w3.org/TR/compositing-1/"><cite>Compositing and Blending Level 1</cite></a>. 13 January 2015. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/compositing-1/">https://www.w3.org/TR/compositing-1/</a> ED:&nbsp;<a href="https://drafts.csswg.org/compositing-1/">https://drafts.csswg.org/compositing-1/</a></div></dd>
 
   <!-- removed, should point to fetch but [cors] not actually found in any chapter
   <dt id="ref-cors" class="normref">[<a href="https://www.w3.org/TR/cors/"><strong class="highlight">cors</strong></a>]</dt><dd><div>Anne van Kesteren. <a href="https://www.w3.org/TR/cors/"><cite>Cross-Origin Resource Sharing</cite></a>. 16 January 2014. W3C Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/cors/">https://www.w3.org/TR/<strong class="highlight">cors</strong>/</a></div></dd>
@@ -39,41 +39,41 @@
   <dd><div>Bert Bos; Tantek Çelik; Ian Hickson; Håkon Wium Lie et al. <a href="https://www.w3.org/TR/CSS2"><cite>Cascading Style Sheets Level 2 Revision 1 (CSS 2.1) Specification</cite></a>. 7 June 2011. W3C Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/CSS2">https://www.w3.org/TR/CSS2</a></div></dd>
 
   <dt id="ref-css-cascade-4" class="normref">[<a href="https://www.w3.org/TR/css-cascade-4/">css-cascade-4</a>]</dt>
-  <dd><div>Elika Etemad; Tab Atkins Jr.. <a href="https://www.w3.org/TR/css-cascade-4/"><cite>CSS Cascading and Inheritance Level 4</cite></a>. 14 January 2016. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-cascade-4/">https://www.w3.org/TR/<strong class="highlight">css-cascade</strong>-4/</a> ED:&nbsp;<a href="http://dev.w3.org/csswg/css-cascade/">http://dev.w3.org/csswg/<strong class="highlight">css-cascade</strong>/</a></div></dd>
+  <dd><div>Elika Etemad; Tab Atkins Jr.. <a href="https://www.w3.org/TR/css-cascade-4/"><cite>CSS Cascading and Inheritance Level 4</cite></a>. 14 January 2016. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-cascade-4/">https://www.w3.org/TR/<strong class="highlight">css-cascade</strong>-4/</a> ED:&nbsp;<a href="https://drafts.csswg.org/css-cascade/">https://drafts.csswg.org/<strong class="highlight">css-cascade</strong>/</a></div></dd>
 
   <dt id="ref-css-color-3" class="normref">[<a href="https://www.w3.org/TR/css-color-3">css-color-3</a>]</dt>
   <dd><div>Tantek Çelik; Chris Lilley; David Baron. <a href="https://www.w3.org/TR/css-color-3"><cite>CSS Color Module Level 3</cite></a>. 19 June 2018. W3C Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-color-3">https://www.w3.org/TR/css-color-3</a></div></dd>
 
   <dt id="ref-css-fonts-3" class="normref">[<a href="https://www.w3.org/TR/css-fonts-3/">css-fonts-3</a>]</dt>
-  <dd><div>John Daggett, Myles Maxfield, Chris Lilley. <a href="https://www.w3.org/TR/css-fonts-3/"><cite>CSS Fonts Module Level 3</cite></a>. 14 August 2018. W3C Proposed Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-fonts-3/">https://www.w3.org/TR/css-fonts-3/</a> ED:&nbsp;<a href="http://dev.w3.org/csswg/css-fonts/">http://dev.w3.org/csswg/css-fonts/</a></div></dd>
+  <dd><div>John Daggett, Myles Maxfield, Chris Lilley. <a href="https://www.w3.org/TR/css-fonts-3/"><cite>CSS Fonts Module Level 3</cite></a>. 14 August 2018. W3C Proposed Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-fonts-3/">https://www.w3.org/TR/css-fonts-3/</a> ED:&nbsp;<a href="https://drafts.csswg.org/css-fonts/">https://drafts.csswg.org/css-fonts/</a></div></dd>
 
   <dt id="ref-css-inline-3" class="normref">[<a href="https://www.w3.org/TR/css-inline-3/">css-inline-3</a>]</dt>
   <dd><div>Dave Cramer; Elika Etemad; Steve Zilles. <a href="https://www.w3.org/TR/css-inline-3/"><cite>CSS Inline Layout Module Level 3</cite></a>. 8 August 2018. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/css-inline-3/">https://www.w3.org/TR/css-inline-3/</a> ED:&nbsp;<a href="https://drafts.csswg.org/css-inline/">https://drafts.csswg.org/css-inline/</a></div></dd>
 
   <dt id="ref-css-text-3" class="normref">[<a href="https://www.w3.org/TR/css-text-3/">css-text-3</a>]</dt>
-  <dd><div>Elika Etemad; Koji Ishii. <a href="https://www.w3.org/TR/css-text-3/"><cite>CSS Text Module Level 3</cite></a>. 22 August 2017 . W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/css-text-3/">https://www.w3.org/TR/css-text-3/</a> ED:&nbsp;<a href="http://dev.w3.org/csswg/css-text-3/">http://dev.w3.org/csswg/css-text-3/</a></div></dd>
+  <dd><div>Elika Etemad; Koji Ishii. <a href="https://www.w3.org/TR/css-text-3/"><cite>CSS Text Module Level 3</cite></a>. 22 August 2017 . W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/css-text-3/">https://www.w3.org/TR/css-text-3/</a> ED:&nbsp;<a href="https://drafts.csswg.org/css-text-3/">https://drafts.csswg.org/css-text-3/</a></div></dd>
 
   <dt id="ref-css-text-4" class="normref">[<a href="https://www.w3.org/TR/css-text-4/">css-text-4</a>]</dt>
-  <dd><div>Elika Etemad; Koji Ishii; Alan Stearns. <a href="https://www.w3.org/TR/css-text-4/"><cite>CSS Text Module Level 4</cite></a>. 22 September 2015. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/css-text-4/">https://www.w3.org/TR/css-text-4/</a> ED:&nbsp;<a href="http://dev.w3.org/csswg/css-text-4/">http://dev.w3.org/csswg/css-text-4/</a></div></dd>
+  <dd><div>Elika Etemad; Koji Ishii; Alan Stearns. <a href="https://www.w3.org/TR/css-text-4/"><cite>CSS Text Module Level 4</cite></a>. 22 September 2015. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/css-text-4/">https://www.w3.org/TR/css-text-4/</a> ED:&nbsp;<a href="https://drafts.csswg.org/css-text-4/">https://drafts.csswg.org/css-text-4/</a></div></dd>
 
 
   <dt id="ref-css-text-decor-3" class="normref">[<a href="https://www.w3.org/TR/css-text-decor-3/">css-text-decor-3</a>]</dt>
-  <dd><div>Elika Etemad; Koji Ishii. <a href="https://www.w3.org/TR/css-text-decor-3/"><cite>CSS Text Decoration Module Level 3</cite></a>. 03 July 2018. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-text-decor-3/">https://www.w3.org/TR/css-text-decor-3/</a> ED:&nbsp;<a href="http://dev.w3.org/csswg/css-text-decor-3/">http://dev.w3.org/csswg/css-text-decor-3/</a></div></dd>
+  <dd><div>Elika Etemad; Koji Ishii. <a href="https://www.w3.org/TR/css-text-decor-3/"><cite>CSS Text Decoration Module Level 3</cite></a>. 03 July 2018. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-text-decor-3/">https://www.w3.org/TR/css-text-decor-3/</a> ED:&nbsp;<a href="https://drafts.csswg.org/css-text-decor-3/">https://drafts.csswg.org/css-text-decor-3/</a></div></dd>
 
   <dt id="ref-css-masking-1" class="normref">[<a href="https://www.w3.org/TR/css-masking-1/">css-masking-1</a>]</dt>
-  <dd><div>Dirk Schulze; Brian Birtles; Tab Atkins Jr.. <a href="https://www.w3.org/TR/css-masking-1/"><cite>CSS Masking Module Level 1</cite></a>. 26 August 2014. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-masking-1/">https://www.w3.org/TR/css-masking-1/</a> ED:&nbsp;<a href="http://dev.w3.org/fxtf/css-masking-1/">http://dev.w3.org/fxtf/css-masking-1/</a></div></dd>
+  <dd><div>Dirk Schulze; Brian Birtles; Tab Atkins Jr.. <a href="https://www.w3.org/TR/css-masking-1/"><cite>CSS Masking Module Level 1</cite></a>. 26 August 2014. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-masking-1/">https://www.w3.org/TR/css-masking-1/</a> ED:&nbsp;<a href="https://drafts.csswg.org/css-masking-1/">https://drafts.csswg.org/css-masking-1/</a></div></dd>
 
   <dt id="ref-cssom-1" class="normref">[<a href="https://www.w3.org/TR/cssom-1/">cssom-1</a>]</dt>
   <dd><div>Simon Pieters; Glenn Adams. <a href="https://www.w3.org/TR/cssom-1/"><cite>CSS Object Model (CSSOM)</cite></a>. 17 March 2016. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/cssom-1/">https://www.w3.org/TR/cssom-1/</a> ED:&nbsp;<a href="https://drafts.csswg.org/cssom/">https://drafts.csswg.org/cssom/</a></div></dd>
 
   <dt id="ref-css-ui-3" class="normref">[<a href="https://www.w3.org/TR/css-ui-3/">css-ui-3</a>]</dt>
-  <dd><div>Tantek Çelik; Florian Rivoal. <a href="https://www.w3.org/TR/css-ui-3/"><cite>CSS Basic User Interface Module Level 3 (CSS3 UI)</cite></a>. 21 June 2018. W3C Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-ui-3/">https://www.w3.org/TR/css-ui-3/</a> ED:&nbsp;<a href="http://dev.w3.org/csswg/css-ui/">http://dev.w3.org/csswg/css-ui/</a></div></dd>
+  <dd><div>Tantek Çelik; Florian Rivoal. <a href="https://www.w3.org/TR/css-ui-3/"><cite>CSS Basic User Interface Module Level 3 (CSS3 UI)</cite></a>. 21 June 2018. W3C Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-ui-3/">https://www.w3.org/TR/css-ui-3/</a> ED:&nbsp;<a href="https://drafts.csswg.org/css-ui/">https://drafts.csswg.org/css-ui/</a></div></dd>
 
   <dt id="ref-css-transforms-1" class="normref">[<a href="https://www.w3.org/TR/css-transforms-1/">css-transforms-1</a>]</dt>
-  <dd><div>Simon Fraser; Dean Jackson; Edward O'Connor; Dirk Schulze. <a href="https://www.w3.org/TR/css-transforms-1/"><cite>CSS Transforms Module Level 1</cite></a>. 30 November 2017. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/css-transforms-1/">https://www.w3.org/TR/css-transforms-1/</a> ED:&nbsp;<a href="http://dev.w3.org/csswg/css-transforms/">http://dev.w3.org/csswg/css-transforms/</a></div></dd>
+  <dd><div>Simon Fraser; Dean Jackson; Edward O'Connor; Dirk Schulze. <a href="https://www.w3.org/TR/css-transforms-1/"><cite>CSS Transforms Module Level 1</cite></a>. 30 November 2017. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/css-transforms-1/">https://www.w3.org/TR/css-transforms-1/</a> ED:&nbsp;<a href="https://drafts.csswg.org/css-transforms/">https://drafts.csswg.org/css-transforms/</a></div></dd>
 
   <dt id="ref-css-values-3" class="normref">[<a href="https://www.w3.org/TR/css-values/">css-values</a>]</dt>
-  <dd><div>Tab Atkins Jr.; Elika Etemad. <a href="https://www.w3.org/TR/css-values-3/"><cite>CSS Values and Units Module Level 3</cite></a>. 14 August 2018. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-values-3/">https://www.w3.org/TR/css-values/</a> ED:&nbsp;<a href="http://dev.w3.org/csswg/css-values-3/">http://dev.w3.org/csswg/css-values/</a></div></dd>
+  <dd><div>Tab Atkins Jr.; Elika Etemad. <a href="https://www.w3.org/TR/css-values-3/"><cite>CSS Values and Units Module Level 3</cite></a>. 14 August 2018. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-values-3/">https://www.w3.org/TR/css-values/</a> ED:&nbsp;<a href="https://drafts.csswg.org/css-values-3/">https://drafts.csswg.org/css-values/</a></div></dd>
 
   <dt id="ref-css-images-3" class="normref">[<a href="https://www.w3.org/TR/css3-images/">css-images-3</a>]</dt>
   <dd><div>Elika Etemad; Tab Atkins Jr.. <a href="https://www.w3.org/TR/css3-images/"><cite>CSS Image Values and Replaced Content Module Level 3</cite></a>. 17 April 2012. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css3-images/">https://www.w3.org/TR/css3-images/</a> ED: <a href="https://drafts.csswg.org/css-images-3/">https://drafts.csswg.org/css-images-3/</a></div></dd>
@@ -84,14 +84,14 @@
   </dd>
 
   <dt id="ref-css-shapes-1" class="normref">[<a href="https://www.w3.org/TR/css-shapes-1/">css-shapes-1</a>]</dt>
-  <dd><div>Vincent Hardy; Rossen Atanassov; Alan Stearns. <a href="https://www.w3.org/TR/css-shapes-1/"><cite>CSS Shapes Module Level 1</cite></a>. 20 March 2014. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-shapes-1/">https://www.w3.org/TR/css-shapes-1/</a> ED:&nbsp;<a href="http://dev.w3.org/csswg/css-shapes/">http://dev.w3.org/csswg/css-shapes/</a></div></dd>
+  <dd><div>Vincent Hardy; Rossen Atanassov; Alan Stearns. <a href="https://www.w3.org/TR/css-shapes-1/"><cite>CSS Shapes Module Level 1</cite></a>. 20 March 2014. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-shapes-1/">https://www.w3.org/TR/css-shapes-1/</a> ED:&nbsp;<a href="https://drafts.csswg.org/css-shapes/">https://drafts.csswg.org/css-shapes/</a></div></dd>
 
 
   <dt id="ref-css-writing-modes-3" class="normref">[<a href="https://www.w3.org/TR/css-writing-modes-3/">css-writing-modes-3</a>]</dt>
-  <dd><div>Elika Etemad; Koji Ishii. <a href="https://www.w3.org/TR/css-writing-modes-3/"><cite>CSS <strong class="highlight">Writing Modes</strong> Level 3</cite></a>. 24 May 2018. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-writing-modes-3/">https://www.w3.org/TR/css-writing-modes-3/</a> ED:&nbsp;<a href="http://dev.w3.org/csswg/css-writing-modes-3/">http://dev.w3.org/csswg/css-writing-modes-3/</a></div></dd>
+  <dd><div>Elika Etemad; Koji Ishii. <a href="https://www.w3.org/TR/css-writing-modes-3/"><cite>CSS <strong class="highlight">Writing Modes</strong> Level 3</cite></a>. 24 May 2018. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-writing-modes-3/">https://www.w3.org/TR/css-writing-modes-3/</a> ED:&nbsp;<a href="https://drafts.csswg.org/css-writing-modes-3/">https://drafts.csswg.org/css-writing-modes-3/</a></div></dd>
 
   <dt id="ref-css-scoping-1" class="normref">[<a href="https://www.w3.org/TR/css-scoping-1/">css-scoping-1</a>]</dt>
-  <dd><div>Tab Atkins Jr.; Elika Etemad. <a href="https://www.w3.org/TR/css-scoping-1/"><cite>CSS Scoping Module Level 1</cite></a>. 3 April 2014. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/css-scoping-1/">https://www.w3.org/TR/<strong class="highlight">css-scoping</strong>-1/</a> ED:&nbsp;<a href="http://dev.w3.org/csswg/css-scoping/">http://dev.w3.org/csswg/<strong class="highlight">css-scoping</strong>/</a></div></dd>
+  <dd><div>Tab Atkins Jr.; Elika Etemad. <a href="https://www.w3.org/TR/css-scoping-1/"><cite>CSS Scoping Module Level 1</cite></a>. 3 April 2014. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/css-scoping-1/">https://www.w3.org/TR/<strong class="highlight">css-scoping</strong>-1/</a> ED:&nbsp;<a href="https://drafts.csswg.org/css-scoping/">https://drafts.csswg.org/<strong class="highlight">css-scoping</strong>/</a></div></dd>
 
   <!-- replace references to DOM 4 with references to DOM LS
   <dt id="ref-dom" class="normref">[<a href="https://www.w3.org/TR/dom/">dom</a>]</dt>
@@ -104,17 +104,17 @@
   <dt id="ref-dom-level-2-style" class="normref">[<a href="https://www.w3.org/TR/DOM-Level-2-Style/">DOM-Level-2-Style</a>]</dt>
   <dd><div>Chris Wilson; Philippe Le Hégaret. <a href="https://www.w3.org/TR/DOM-Level-2-Style/"><cite>Document Object Model (DOM) Level 2 Style Specification</cite></a>. 13 November 2000. W3C Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/DOM-Level-2-Style/">https://www.w3.org/TR/DOM-Level-2-Style/</a></div></dd>
 
-  <dt id="ref-ecmascript" class="normref">[<a href="http://www.ecma-international.org/ecma-262/6.0/index.html">ECMASCRIPT</a>]</dt>
-  <dd><div>Allen Wirfs-Brock. <a href="http://www.ecma-international.org/ecma-262/6.0/index.html"><cite>ECMA-262 6th Edition, The ECMAScript 2015 Language Specification</cite></a>. June 2015. Standard. URL:&nbsp;<a href="http://www.ecma-international.org/ecma-262/6.0/index.html">http://www.ecma-international.org/ecma-262/6.0/index.html</a></div></dd>
+  <dt id="ref-ecmascript" class="normref">[<a href="https://www.ecma-international.org/ecma-262/6.0/index.html">ECMASCRIPT</a>]</dt>
+  <dd><div>Allen Wirfs-Brock. <a href="https://www.ecma-international.org/ecma-262/6.0/index.html"><cite>ECMA-262 6th Edition, The ECMAScript 2015 Language Specification</cite></a>. June 2015. Standard. URL:&nbsp;<a href="https://www.ecma-international.org/ecma-262/6.0/index.html">https://www.ecma-international.org/ecma-262/6.0/index.html</a></div></dd>
 
   <dt id="ref-fetch" class="normref">[<a href="https://fetch.spec.whatwg.org/">FETCH</a>]</dt>
   <dd><div>Anne van Kesteren. <a href="https://fetch.spec.whatwg.org/"><cite>Fetch Standard</cite></a>. Living Standard. URL:&nbsp;<a href="https://fetch.spec.whatwg.org/">https://fetch.spec.whatwg.org/</a></div></dd>
 
   <dt id="ref-filter-effects-1" class="normref">[<a href="https://www.w3.org/TR/filter-effects-1/">filter-effects-1</a>]</dt>
-  <dd><div>Dean Jackson; Erik Dahlström; Dirk Schulze. <a href="https://www.w3.org/TR/filter-effects-1/"><cite>Filter Effects Module Level 1</cite></a>. 25 November 2014. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/filter-effects-1/">https://www.w3.org/TR/filter-effects-1/</a> ED:&nbsp;<a href="https://dev.w3.org/fxtf/filters/">https://dev.w3.org/fxtf/filters/</a></div></dd>
+  <dd><div>Dean Jackson; Erik Dahlström; Dirk Schulze. <a href="https://www.w3.org/TR/filter-effects-1/"><cite>Filter Effects Module Level 1</cite></a>. 25 November 2014. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/filter-effects-1/">https://www.w3.org/TR/filter-effects-1/</a> ED:&nbsp;<a href="https://drafts.csswg.org/filter-effects-1/">https://drafts.csswg.org/filter-effects-1/</a></div></dd>
 
   <dt id="ref-geometry-1" class="normref">[<a href="https://www.w3.org/TR/geometry-1/">geometry-1</a>]</dt>
-  <dd><div>Simon Pieters; Dirk Schulze; Rik Cabanier. <a href="https://www.w3.org/TR/geometry-1/"><cite>Geometry Interfaces Module Level 1</cite></a>. 25 November 2014. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/geometry-1/">https://www.w3.org/TR/geometry-1/</a> ED:&nbsp;<a href="https://drafts.fxtf.org/geometry/">https://drafts.fxtf.org/geometry/</a></div></dd>
+  <dd><div>Simon Pieters; Dirk Schulze; Rik Cabanier. <a href="https://www.w3.org/TR/geometry-1/"><cite>Geometry Interfaces Module Level 1</cite></a>. 25 November 2014. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/geometry-1/">https://www.w3.org/TR/geometry-1/</a> ED:&nbsp;<a href="https://drafts.csswg.org/geometry-1/">https://drafts.csswg.org/geometry-1/</a></div></dd>
 
   <dt id="ref-graphics-aria-1.0" class="normref">[<a href="https://www.w3.org/TR/graphics-aria-1.0/">graphics-aria-1.0</a>]</dt>
   <dd><div>Amelia Bellamy-Royds; Fred Esch; Richard Schwerdtfeger; Léonie Watson. <a href="https://www.w3.org/TR/graphics-aria-1.0/"><cite>WAI-<strong class="highlight">ARIA Graphics</strong> Module</cite></a>. 26 June 2018. W3C Proposed Recommendation . URL:&nbsp;<a href="https://www.w3.org/TR/graphics-aria-1.0/">https://www.w3.org/TR/graphics-aria-1.0/</a> ED:&nbsp;<a href="https://w3c.github.io/graphics-aria/">https://w3c.github.io/graphics-aria/</a></div></dd>
@@ -192,8 +192,8 @@
   <dt id="ref-uievents" class="normref">[<a href="https://www.w3.org/TR/uievents/">uievents</a>]</dt>
   <dd><div>Gary Kacmarcik; Travis Leithead. <a href="https://www.w3.org/TR/uievents/"><cite>UI Events Specification</cite></a>. 04 August 2016. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/uievents/">https://www.w3.org/TR/uievents/</a> ED:&nbsp;<a href="https://w3c.github.io/uievents/">https://w3c.github.io/uievents/</a></div></dd>
 
-  <dt id="ref-unicode" class="normref">[<a href="http://www.unicode.org/versions/latest/">UNICODE</a>]</dt>
-  <dd><div><a href="http://www.unicode.org/versions/latest/"><cite>The Unicode Standard</cite></a>. URL:&nbsp;<a href="http://www.unicode.org/versions/latest/">http://www.unicode.org/versions/latest/</a></div></dd>
+  <dt id="ref-unicode" class="normref">[<a href="https://www.unicode.org/versions/latest/">UNICODE</a>]</dt>
+  <dd><div><a href="https://www.unicode.org/versions/latest/"><cite>The Unicode Standard</cite></a>. URL:&nbsp;<a href="https://www.unicode.org/versions/latest/">https://www.unicode.org/versions/latest/</a></div></dd>
 
   <dt id="ref-URL" class="normref">[<a href="https://url.spec.whatwg.org/">URL</a>]</dt>
   <dd><div>Anne van Kesteren; Sam Ruby. <a href="https://url.spec.whatwg.org/"><cite>URL</cite></a>. 9 August 2018. Living Standard. URL:&nbsp;<a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a></div></dd>
@@ -205,7 +205,7 @@
   <dd><div>Brian Birtles; Shane Stephens; Alex Danilo; Tab Atkins Jr.. <a href="https://www.w3.org/TR/web-animations-1/"><cite><strong class="highlight">Web Animations</strong></cite></a>. 13 September 2016. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/web-animations-1/">https://www.w3.org/TR/web-animations-1/</a> ED:&nbsp;<a href="https://w3c.github.io/web-animations/">https://w3c.github.io/web-animations/</a></div></dd>
 
   <dt id="ref-webidl" class="normref">[<a href="https://www.w3.org/TR/WebIDL-1/">WebIDL</a>]</dt>
-  <dd><div>Cameron McCormack; Boris Zbarsky. <a href="https://www.w3.org/TR/WebIDL-1/"><cite>WebIDL Level 1</cite></a>. 15 December 2016. W3C Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/WebIDL-1/">https://www.w3.org/TR/WebIDL-1/</a> ED:&nbsp;<a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a></div></dd>
+  <dd><div>Cameron McCormack; Boris Zbarsky. <a href="https://www.w3.org/TR/WebIDL-1/"><cite>WebIDL Level 1</cite></a>. 15 December 2016. W3C Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/WebIDL-1/">https://www.w3.org/TR/WebIDL-1/</a> ED:&nbsp;<a href="https://webidl.spec.whatwg.org/">https://webidl.spec.whatwg.org/</a></div></dd>
 
   <dt id="ref-woff" class="normref">[<a href="https://www.w3.org/TR/WOFF/">WOFF</a>]</dt>
   <dd><div>Jonathan Kew; Tal Leming; Erik van Blokland. <a href="https://www.w3.org/TR/WOFF/"><cite>WOFF File Format 1.0</cite></a>. 13 December 2012. W3C Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/WOFF/">https://www.w3.org/TR/WOFF/</a></div></dd>
@@ -244,45 +244,45 @@
       edition of CSS Color 4</a> is available at
       https://www.w3.org/TR/css-color-4/.
   </dd>
-  <dt id="ref-css-shapes-2" class="informref">[<a href="http://dev.w3.org/csswg/css-shapes-2/">css-shapes-2</a>]</dt>
+  <dt id="ref-css-shapes-2" class="informref">[<a href="https://drafts.csswg.org/css-shapes-2/">css-shapes-2</a>]</dt>
   <dd>
-    <cite class="w3cwd"><a href="http://dev.w3.org/csswg/css-shapes-2/">CSS Shapes Module Level 2</a></cite>,
+    <cite class="w3cwd"><a href="https://drafts.csswg.org/css-shapes-2/">CSS Shapes Module Level 2</a></cite>,
     Alan Stearns ed.
     World Wide Web Consortium, 5 July 2018.
-    <br/>The <a href="http://dev.w3.org/csswg/css-shapes-2/">latest
+    <br/>The <a href="https://drafts.csswg.org/css-shapes-2/">latest
       edition of CSS Shapes 2</a> is available at
-    http://dev.w3.org/csswg/css-shapes-2/.
+    https://drafts.csswg.org/css-shapes-2/.
   </dd>
-  <dt id="ref-css-syntax-3" class="informref">[<a href="http://dev.w3.org/csswg/css-syntax-3/">css-syntax-3</a>]</dt>
+  <dt id="ref-css-syntax-3" class="informref">[<a href="https://drafts.csswg.org/css-syntax-3/">css-syntax-3</a>]</dt>
   <dd>
-    <cite class="w3cwd"><a href="http://dev.w3.org/csswg/css-syntax-3/">CSS Syntax Module Level 3</a></cite>,
+    <cite class="w3cwd"><a href="https://drafts.csswg.org/css-syntax-3/">CSS Syntax Module Level 3</a></cite>,
     Tab Atkins ed.
     World Wide Web Consortium,  February 2014.
-    <br/>The <a href="http://dev.w3.org/csswg/css-syntax-3/">latest
+    <br/>The <a href="https://drafts.csswg.org/css-syntax-3/">latest
       edition of CSS Syntax 3</a> is available at
-    http://dev.w3.org/csswg/css-syntax-3/.
+    https://drafts.csswg.org/css-syntax-3/.
   </dd>
 
   <dt id="ref-css-animations-1" class="informref">[<a href="https://www.w3.org/TR/css-animations-1/">css-animations-1</a>]</dt>
   <dd><div>Dean Jackson; David Hyatt; Chris Marrin; Sylvain Galineau; David Baron. <a href="https://www.w3.org/TR/css-animations-1/"><cite>CSS Animations</cite></a>. 30 November 2017. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/css-animations-1/">https://www.w3.org/TR/css-animations-1/</a> ED:&nbsp;<a href="https://drafts.csswg.org/css-animations/">https://drafts.csswg.org/css-animations/</a></div></dd>
 
   <dt id="ref-css-transitions-1" class="informref">[<a href="https://www.w3.org/TR/css-transitions-1/">css-transitions-1</a>]</dt>
-  <dd><div>Dean Jackson; David Hyatt; Chris Marrin; David Baron. <a href="https://www.w3.org/TR/css-transitions-1/"><cite>CSS Transitions</cite></a>. 30 November 2017. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/css-transitions-1/">https://www.w3.org/TR/css-transitions-1/</a> ED:&nbsp;<a href="http://dev.w3.org/csswg/css-transitions/">http://dev.w3.org/csswg/css-transitions/</a></div></dd>
+  <dd><div>Dean Jackson; David Hyatt; Chris Marrin; David Baron. <a href="https://www.w3.org/TR/css-transitions-1/"><cite>CSS Transitions</cite></a>. 30 November 2017. W3C Working Draft. URL:&nbsp;<a href="https://www.w3.org/TR/css-transitions-1/">https://www.w3.org/TR/css-transitions-1/</a> ED:&nbsp;<a href="https://drafts.csswg.org/css-transitions/">https://drafts.csswg.org/css-transitions/</a></div></dd>
 
-  <dt id="ref-dc11" class="informref">[<a href="http://dublincore.org/documents/2012/06/14/dces/">DC11</a>]</dt>
-  <dd><div>Dublin Core metadata initiative. <a href="http://dublincore.org/documents/2012/06/14/dces/"><cite>Dublin Core Metadata Element Set, Version 1.1</cite></a>. 14 June 2012. DCMI recommendation. URL:&nbsp;<a href="http://dublincore.org/documents/2012/06/14/dces/">http://dublincore.org/documents/2012/06/14/dces/</a></div></dd>
+  <dt id="ref-dc11" class="informref">[<a href="https://dublincore.org/documents/2012/06/14/dces/">DC11</a>]</dt>
+  <dd><div>Dublin Core metadata initiative. <a href="https://dublincore.org/documents/2012/06/14/dces/"><cite>Dublin Core Metadata Element Set, Version 1.1</cite></a>. 14 June 2012. DCMI recommendation. URL:&nbsp;<a href="https://dublincore.org/documents/2012/06/14/dces/">https://dublincore.org/documents/2012/06/14/dces/</a></div></dd>
 
   <dt id="ref-editing" class="informref">[<a href="https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html">EDITING</a>]</dt>
   <dd><div>A. Gregor. <a href="https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html"><cite>HTML Editing APIs</cite></a>. URL:&nbsp;<a href="https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html">https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html</a></div></dd>
 
-  <dt id="ref-icc" class="informref">[<a href="http://www.color.org/specification/ICC1v43_2010-12.pdf">ICC</a>]</dt>
-  <dd><div>International Color Consortium, <a href="http://www.color.org/specification/ICC1v43_2010-12.pdf"><cite>ICC.1:2010 (Profile version 4.3.0.0)</cite></a>. December 2010. URL:&nbsp;<a href="http://www.color.org/specification/ICC1v43_2010-12.pdf">http://www.color.org/specification/ICC1v43_2010-12.pdf</a></div></dd>
+  <dt id="ref-icc" class="informref">[<a href="https://www.color.org/specification/ICC1v43_2010-12.pdf">ICC</a>]</dt>
+  <dd><div>International Color Consortium, <a href="https://www.color.org/specification/ICC1v43_2010-12.pdf"><cite>ICC.1:2010 (Profile version 4.3.0.0)</cite></a>. December 2010. URL:&nbsp;<a href="https://www.color.org/specification/ICC1v43_2010-12.pdf">https://www.color.org/specification/ICC1v43_2010-12.pdf</a></div></dd>
 
   <dt id="ref-mathml3" class="informref">[<a href="https://www.w3.org/TR/MathML3/">MathML3</a>]</dt>
   <dd><div>David Carlisle; Patrick D F Ion; Robert R Miner. <a href="https://www.w3.org/TR/MathML3/"><cite>Mathematical Markup Language (MathML) Version 3.0 2nd Edition</cite></a>. 10 April 2014. W3C Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/MathML3/">https://www.w3.org/TR/MathML3/</a></div></dd>
 
-  <dt id="ref-opentype" class="informref">[<a href="http://www.microsoft.com/typography/otspec/default.htm">OPENTYPE</a>]</dt>
-  <dd><div><a href="http://www.microsoft.com/typography/otspec/default.htm"><cite>OpenType specification</cite></a>. URL:&nbsp;<a href="http://www.microsoft.com/typography/otspec/default.htm">http://www.microsoft.com/typography/otspec/default.htm</a></div></dd>
+  <dt id="ref-opentype" class="informref">[<a href="https://www.microsoft.com/typography/otspec/default.htm">OPENTYPE</a>]</dt>
+  <dd><div><a href="https://www.microsoft.com/typography/otspec/default.htm"><cite>OpenType specification</cite></a>. URL:&nbsp;<a href="https://www.microsoft.com/typography/otspec/default.htm">https://www.microsoft.com/typography/otspec/default.htm</a></div></dd>
 
   <dt id="ref-rdf11-primer" class="informref">[<a href="https://www.w3.org/TR/rdf11-primer/">rdf11-primer</a>]</dt>
   <dd><div>Guus Schreiber; Yves Raimond. <a href="https://www.w3.org/TR/rdf11-primer/"><cite>RDF 1.1 Primer</cite></a>. 24 June 2014. W3C Note. URL:&nbsp;<a href="https://www.w3.org/TR/rdf11-primer/">https://www.w3.org/TR/rdf11-primer/</a></div></dd>

--- a/master/render.html
+++ b/master/render.html
@@ -21,7 +21,7 @@
     The SVG 2 rendering model will follow the rules defined by the <a href="https://www.w3.org/TR/compositing/">Compositing and Blending specification</a>.
   </p>
   <p>
-    Resolution: <a href="http://www.w3.org/2012/07/24-svg-minutes.html#item09">Seattle/Paris 2012 F2F day 3</a>.
+    Resolution: <a href="https://www.w3.org/2012/07/24-svg-minutes.html#item09">Seattle/Paris 2012 F2F day 3</a>.
   </p>
   <p>
     Owner: Nikos (Action 3332).

--- a/master/shapes.html
+++ b/master/shapes.html
@@ -168,7 +168,7 @@ following the rules specified above and in <a href="coords.html#Units">Units</a>
 
 <p class="annotation">
   Path decomposition resolved during teleconference on
-  <a href="http://www.w3.org/2013/06/03-svg-minutes.html#item03">June
+  <a href="https://www.w3.org/2013/06/03-svg-minutes.html#item03">June
   3rd, 2013</a>.
 </p>
 
@@ -231,7 +231,7 @@ radius.</p>
 
 <p class="annotation">
   Path decomposition resolved during teleconference on
-  <a href="http://www.w3.org/2013/06/03-svg-minutes.html#item03">June
+  <a href="https://www.w3.org/2013/06/03-svg-minutes.html#item03">June
   3rd, 2013</a>.
 </p>
 
@@ -312,7 +312,7 @@ with the current <a>user coordinate system</a> based on a center point and two r
 
 <p class="annotation">
   Path decomposition resolved during teleconference on
-  <a href="http://www.w3.org/2013/06/03-svg-minutes.html#item03">June
+  <a href="https://www.w3.org/2013/06/03-svg-minutes.html#item03">June
   3rd, 2013</a>.
 </p>
 

--- a/master/struct.html
+++ b/master/struct.html
@@ -187,7 +187,7 @@ information, refer to the <a href="https://www.w3.org/TR/2006/REC-xml-names-2006
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/10/28-svg-irc#T00-23-44">We will allow <span class='attr-name'>'transform'</span> on <span class='element-name'>'svg'</span> in SVG 2.</a></td>
+      <td><a href="https://www.w3.org/2011/10/28-svg-irc#T00-23-44">We will allow <span class='attr-name'>'transform'</span> on <span class='element-name'>'svg'</span> in SVG 2.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -387,13 +387,13 @@ directly.</p>
 
     <p class="annotation">
       Add refX/refY to symbol element. Resolved at
-      <a href="http://www.w3.org/2014/04/08-svg-minutes.html#item12">Leipzig F2F</a>.
+      <a href="https://www.w3.org/2014/04/08-svg-minutes.html#item12">Leipzig F2F</a>.
       Status: Done.
     </p>
     <p class="annotation">
       We will add top/center/bottom, left/center/right keywords to
       refX/refY on marker/symbol. Resolved at
-      <a href="http://www.w3.org/2014/08/26-svg-minutes.html#item07">London
+      <a href="https://www.w3.org/2014/08/26-svg-minutes.html#item07">London
       F2F</a>. Values inspired by
       <a href="https://www.w3.org/TR/css3-background/#the-background-position">'background-position'</a>.
       Status: Done.
@@ -503,7 +503,7 @@ behaves as a symbol definition, and must not be rendered.
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/10/28-svg-irc#T00-33-43">We will relax referencing requirements to particular elements to allow dropping fragments to mean referencing root element, where it makes sense, such as with use, in SVG 2.</a></td>
+      <td><a href="https://www.w3.org/2011/10/28-svg-irc#T00-33-43">We will relax referencing requirements to particular elements to allow dropping fragments to mean referencing root element, where it makes sense, such as with use, in SVG 2.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -511,7 +511,7 @@ behaves as a symbol definition, and must not be rendered.
     </tr>
     <tr>
       <th>Owner:</th>
-      <td>Cameron (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3417">ACTION-3417</a>)</td>
+      <td>Cameron (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3417">ACTION-3417</a>)</td>
     </tr>
     <tr>
       <th>Status:</th>
@@ -1616,7 +1616,7 @@ versions of a given extension.</p>
     </table>
   </dt>
   <dd>
-    <p>The value is a <a>set of comma-separated tokens</a>, each of which must be a <a href="http://tools.ietf.org/html/bcp47#section-2.1">Language-Tag</a> value, as defined in <a href="http://www.ietf.org/rfc/bcp/bcp47.txt">BCP 47</a>
+    <p>The value is a <a>set of comma-separated tokens</a>, each of which must be a <a href="https://tools.ietf.org/html/bcp47#section-2.1">Language-Tag</a> value, as defined in <a href="https://www.ietf.org/rfc/bcp/bcp47.txt">BCP 47</a>
     [<a href="refs.html#ref-bcp47">BCP47</a>].
     </p>
   </dd>
@@ -2181,7 +2181,7 @@ the <span class='attr-name'>'lang'</span> attribute in no namespace must be igno
       </tr>
       <tr>
         <td><dfn id="LangAttribute" data-dfn-for="core-attributes" data-dfn-type="element-attr">lang</dfn></td>
-        <td><a href="http://tools.ietf.org/html/bcp47#section-2.1">Language-Tag</a> <span class='syntax'>[ABNF]</span></td>
+        <td><a href="https://tools.ietf.org/html/bcp47#section-2.1">Language-Tag</a> <span class='syntax'>[ABNF]</span></td>
         <td>(none)</td>
         <td>no</td>
       </tr>
@@ -2205,7 +2205,7 @@ or the empty string. Setting the attribute to the empty string indicates that th
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/03/03-svg-minutes.html#item04">We drop xml:space from SVG 2 and remove the relating tests from the SVG 1.1. test suite.</a></td>
+      <td><a href="https://www.w3.org/2011/03/03-svg-minutes.html#item04">We drop xml:space from SVG 2 and remove the relating tests from the SVG 1.1. test suite.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -2213,8 +2213,8 @@ or the empty string. Setting the attribute to the empty string indicates that th
     </tr>
     <tr>
       <th>Owner:</th>
-      <td>Chris (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3004">ACTION-3004</a>, done; and
-                 <a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3005">ACTION-3005</a>, done)</td>
+      <td>Chris (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3004">ACTION-3004</a>, done; and
+                 <a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3005">ACTION-3005</a>, done)</td>
     </tr>
     <tr>
       <th>Status</th>
@@ -3136,9 +3136,9 @@ the following steps are run:</p>
 <p>The <b id="__svg__SVGSVGElement__deselectAll">deselectAll</b> method is
 used to remove any selections from the document.  When deselectAll() is called,
 all <a href="https://www.w3.org/TR/2014/WD-dom-20140204/#concept-range">ranges</a>
-from the document's <a href="http://w3c.github.io/selection-api/#dom-selection">selection</a>
-are removed and the <a href="http://w3c.github.io/selection-api/#dom-selection">selection</a>'s
-<a href="http://w3c.github.io/selection-api/#dfn-direction">direction</a> is set to
+from the document's <a href="https://w3c.github.io/selection-api/#dom-selection">selection</a>
+are removed and the <a href="https://w3c.github.io/selection-api/#dom-selection">selection</a>'s
+<a href="https://w3c.github.io/selection-api/#dfn-direction">direction</a> is set to
 forwards. [<a href="refs.html#ref-dom">DOM</a>][<a href="refs.html#ref-editing">EDITING</a>]
 This method is deprecated, as it duplicates functionality from the Selection API.</p>
 

--- a/master/styling.html
+++ b/master/styling.html
@@ -45,7 +45,7 @@ these are required.</p>
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/10/28-svg-irc#T18-45-45">SVG 2 <span class='element-name'>'style'</span> element shall be aligned with the HTML5 <span class='element-name'>'style'</span> element.</a></td>
+      <td><a href="https://www.w3.org/2011/10/28-svg-irc#T18-45-45">SVG 2 <span class='element-name'>'style'</span> element shall be aligned with the HTML5 <span class='element-name'>'style'</span> element.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -53,7 +53,7 @@ these are required.</p>
     </tr>
     <tr>
       <th>Owner:</th>
-      <td>Cameron (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3277">ACTION-3277</a>)</td>
+      <td>Cameron (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3277">ACTION-3277</a>)</td>
     </tr>
   </table>
 </div>
@@ -88,7 +88,7 @@ element in HTML</a>.</p>
   </dt>
   <dd>
     <p>This attribute specifies the style sheet language of
-    the element's contents, as a <a href="http://www.ietf.org/rfc/rfc2046.txt">media type</a>.
+    the element's contents, as a <a href="https://www.ietf.org/rfc/rfc2046.txt">media type</a>.
     [<a href="refs.html#ref-rfc2046">rfc2046</a>].
     If the attribute is not specified, then the
     style sheet language is assumed to be CSS.

--- a/master/text.html
+++ b/master/text.html
@@ -455,7 +455,7 @@
       </tr>
       <tr>
 	<th>Resolution:</th>
-	<td><a href="http://www.w3.org/2011/03/01-svg-minutes.html#item03">We will mandate WOFF support in SVG 2.</a></td>
+	<td><a href="https://www.w3.org/2011/03/01-svg-minutes.html#item03">We will mandate WOFF support in SVG 2.</a></td>
       </tr>
       <tr>
 	<th>Purpose:</th>
@@ -733,7 +733,7 @@
       </tr>
       <tr>
 	<th>Resolution:</th>
-	<td><a href="http://www.w3.org/2012/03/15-svg-irc#T21-07-21">SVG 2 will support glyphs being aligned to different baselines, perhaps by using existing or improved CSS properties.</a></td>
+	<td><a href="https://www.w3.org/2012/03/15-svg-irc#T21-07-21">SVG 2 will support glyphs being aligned to different baselines, perhaps by using existing or improved CSS properties.</a></td>
       </tr>
       <tr>
 	<th>Purpose:</th>
@@ -995,7 +995,7 @@
       </tr>
       <tr>
 	<th>Resolution:</th>
-	<td><a href="http://www.w3.org/2011/12/01-svg-irc#T21-02-34">SVG 2 will allow transforms on <span class="element-name">'tspan'</span>.</a></td>
+	<td><a href="https://www.w3.org/2011/12/01-svg-irc#T21-02-34">SVG 2 will allow transforms on <span class="element-name">'tspan'</span>.</a></td>
       </tr>
       <tr>
 	<th>Purpose:</th>
@@ -1658,7 +1658,7 @@
       </tr>
       <tr>
 	<th>Resolution:</th>
-	<td><a href="http://www.w3.org/2012/02/02-svg-minutes.html#item10">SVG 2 will include the improved text from SVG Tiny 1.2 on characters and glyphs, text layout, text selection, text search.</a></td>
+	<td><a href="https://www.w3.org/2012/02/02-svg-minutes.html#item10">SVG 2 will include the improved text from SVG Tiny 1.2 on characters and glyphs, text layout, text selection, text search.</a></td>
       </tr>
       <tr>
 	<th>Purpose:</th>
@@ -1666,7 +1666,7 @@
       </tr>
       <tr>
 	<th>Owner:</th>
-	<td>Chris (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3236">ACTION-3236</a>)</td>
+	<td>Chris (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3236">ACTION-3236</a>)</td>
       </tr>
     </table>
   </div>
@@ -1679,7 +1679,7 @@
       </tr>
       <tr>
 	<th>Resolution:</th>
-	<td><a href="http://www.w3.org/2011/11/17-svg-irc#T22-04-11">SVG 2 will require automatic text wrapping compatible with CSS.</a></td>
+	<td><a href="https://www.w3.org/2011/11/17-svg-irc#T22-04-11">SVG 2 will require automatic text wrapping compatible with CSS.</a></td>
       </tr>
       <tr>
 	<th>Purpose:</th>
@@ -1893,11 +1893,11 @@
 
   <p class="annotation">
     'extent' added by resolution from
-    <a href="http://www.w3.org/2015/02/12-svg-minutes.html#action17">February
+    <a href="https://www.w3.org/2015/02/12-svg-minutes.html#action17">February
       12th, 2015</a>. 'extent' replaces the 'width' and 'height'
     attributes, added by resolution from June 27th, 2013.
     Replaced by 'inline-size' presentation attribute per resolution from
-    <a href="http://www.w3.org/2015/06/11-svg-minutes.html#item09">Linkoping
+    <a href="https://www.w3.org/2015/06/11-svg-minutes.html#item09">Linkoping
       F2F, June 11, 2015</a>.
   </p>
 
@@ -3266,7 +3266,7 @@
       </tr>
       <tr>
 	<th>Resolution:</th>
-	<td><a href="http://www.w3.org/2011/07/29-svg-minutes.html#item08">SVG 2 Will use CSS3 definitions for text layout (white space, bidi, etc.) that is not specific to SVG.</a></td>
+	<td><a href="https://www.w3.org/2011/07/29-svg-minutes.html#item08">SVG 2 Will use CSS3 definitions for text layout (white space, bidi, etc.) that is not specific to SVG.</a></td>
       </tr>
       <tr>
 	<th>Purpose:</th>
@@ -3274,8 +3274,8 @@
       </tr>
       <tr>
 	<th>Owner:</th>
-	<td>Cameron and Chris (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3004">ACTION-3004</a>,
-          <a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3005">ACTION-3005</a>)</td>
+	<td>Cameron and Chris (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3004">ACTION-3004</a>,
+          <a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3005">ACTION-3005</a>)</td>
       </tr>
     </table>
   </div>
@@ -3500,7 +3500,7 @@
 
   <p class="annotation">
     Placing text along a basic shape was resolved at the
-    <a href="http://www.w3.org/2015/02/12-svg-minutes.html#item05">Sydney
+    <a href="https://www.w3.org/2015/02/12-svg-minutes.html#item05">Sydney
     (2015)</a> meeting.
   </p>
 
@@ -3532,7 +3532,7 @@
       </tr>
       <tr>
 	<th>Resolution:</th>
-	<td><a href="http://www.w3.org/2011/11/17-svg-irc#T22-23-10">We will clarify <span class='attr-value'>method="stretch"</span> on <span class="element-name">>'textPath'</span> elements.</a></td>
+	<td><a href="https://www.w3.org/2011/11/17-svg-irc#T22-23-10">We will clarify <span class='attr-value'>method="stretch"</span> on <span class="element-name">>'textPath'</span> elements.</a></td>
       </tr>
       <tr>
 	<th>Purpose:</th>
@@ -3687,7 +3687,7 @@
 
       <p class="annotation">
 	Rendering all glyphs was agreed to for basic shapes at the
-	<a href="http://www.w3.org/2015/02/12-svg-minutes.html#item05">Sydney
+	<a href="https://www.w3.org/2015/02/12-svg-minutes.html#item05">Sydney
 	  (2015)</a> meeting (but missing in minutes). Limiting the
 	wrapping to a path with a single closed sub-path and to one
 	loop, effected by the 'startOffset' attribute agreed to at the
@@ -3810,7 +3810,7 @@
       </p>
       <p class="annotation">
 	Adding 'side' was resolved at the
-	<a href="http://www.w3.org/2015/02/12-svg-minutes.html#item05">Sydney
+	<a href="https://www.w3.org/2015/02/12-svg-minutes.html#item05">Sydney
 	  (2015)</a> meeting.
       </p>
 
@@ -4744,7 +4744,7 @@ the dash pattern at the same positions across different implementations.</p>
       </tr>
       <tr>
 	<th>Resolution:</th>
-	<td><a href="http://www.w3.org/2011/07/29-svg-minutes.html#item08">SVG 2 will depend on CSS3 Fonts.</a></td>
+	<td><a href="https://www.w3.org/2011/07/29-svg-minutes.html#item08">SVG 2 will depend on CSS3 Fonts.</a></td>
       </tr>
       <tr>
 	<th>Purpose:</th>
@@ -4753,7 +4753,7 @@ the dash pattern at the same positions across different implementations.</p>
       </tr>
       <tr>
 	<th>Owner:</th>
-	<td>Chris (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3123">ACTION-3123</a>)</td>
+	<td>Chris (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3123">ACTION-3123</a>)</td>
       </tr>
     </table>
   </div>
@@ -4986,7 +4986,7 @@ the dash pattern at the same positions across different implementations.</p>
       </tr>
       <tr>
 	<th>Resolution:</th>
-	<td><a href="http://www.w3.org/2012/01/13-svg-irc#T03-24-06">SVG 2 will deprecate <span class="property">'baseline-shift'</span> and use <span class="property">'vertical-align'</span> instead.</a></td>
+	<td><a href="https://www.w3.org/2012/01/13-svg-irc#T03-24-06">SVG 2 will deprecate <span class="property">'baseline-shift'</span> and use <span class="property">'vertical-align'</span> instead.</a></td>
       </tr>
       <tr>
 	<th>Purpose:</th>
@@ -4994,7 +4994,7 @@ the dash pattern at the same positions across different implementations.</p>
       </tr>
       <tr>
 	<th>Owner:</th>
-	<td>Cameron (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3281">ACTION-3281</a>)</td>
+	<td>Cameron (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3281">ACTION-3281</a>)</td>
       </tr>
     </table>
   </div>
@@ -5051,7 +5051,7 @@ the dash pattern at the same positions across different implementations.</p>
       </tr>
       <tr>
 	<th>Resolution:</th>
-	<td><a href="http://www.w3.org/2011/03/03-svg-minutes.html#item04">We will add text-overflow in SVG 2.</a></td>
+	<td><a href="https://www.w3.org/2011/03/03-svg-minutes.html#item04">We will add text-overflow in SVG 2.</a></td>
       </tr>
       <tr>
 	<th>Purpose:</th>
@@ -5059,7 +5059,7 @@ the dash pattern at the same positions across different implementations.</p>
       </tr>
       <tr>
 	<th>Owner:</th>
-	<td>Erik (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3003">ACTION-3003</a>)</td>
+	<td>Erik (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3003">ACTION-3003</a>)</td>
       </tr>
     </table>
   </div>
@@ -5401,7 +5401,7 @@ the dash pattern at the same positions across different implementations.</p>
     Note that a glyph corresponding to a white-space character should
     only be displayed as a visible but blank space, even if the glyph
     itself happens to be non-blank.
-    See <a href="http://www.unicode.org/faq/unsup_char.html">display
+    See <a href="https://www.unicode.org/faq/unsup_char.html">display
     of unsupported characters</a>
     [<a href="refs.html#ref-unicode">UNICODE</a>].
   </p>
@@ -5687,7 +5687,7 @@ links.</p>
       </tr>
       <tr>
 	<th>Resolution:</th>
-	<td><a href="http://www.w3.org/2012/01/13-svg-irc#T05-07-07">We will add a DOM method to convert a <span class='element-name'>'text'</span> element to outline path data, possibly moving the functionality to the FXTF.</a></td>
+	<td><a href="https://www.w3.org/2012/01/13-svg-irc#T05-07-07">We will add a DOM method to convert a <span class='element-name'>'text'</span> element to outline path data, possibly moving the functionality to the FXTF.</a></td>
       </tr>
       <tr>
 	<th>Purpose:</th>
@@ -5695,7 +5695,7 @@ links.</p>
       </tr>
       <tr>
 	<th>Owner:</th>
-	<td>Cameron (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3076">ACTION-3076</a>)</td>
+	<td>Cameron (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3076">ACTION-3076</a>)</td>
       </tr>
       <tr>
 	<th>Status:</th>
@@ -6025,11 +6025,11 @@ characters.  The following steps must be followed when this method is called:</p
   <li>If <var>charnum</var> ≥ <var>count</var> or <var>end</var> ≥ <var>count</var>,
   then <a>throw</a> an <a>IndexSizeError</a>.</li>
   <li>Remove all <a href="https://www.w3.org/TR/2014/WD-dom-20140204/#concept-range">ranges</a>
-  from the document's <a href="http://w3c.github.io/selection-api/#dfn-selection">selection</a>. [<a href="refs.html#ref-dom">DOM</a>][<a href="refs.html#ref-editing">EDITING</a>]</li>
-  <li>Set the <a href="http://w3c.github.io/selection-api/#dfn-selection">selection</a>'s
-  <a href="http://w3c.github.io/selection-api/#dfn-direction">direction</a> to
+  from the document's <a href="https://w3c.github.io/selection-api/#dfn-selection">selection</a>. [<a href="refs.html#ref-dom">DOM</a>][<a href="refs.html#ref-editing">EDITING</a>]</li>
+  <li>Set the <a href="https://w3c.github.io/selection-api/#dfn-selection">selection</a>'s
+  <a href="https://w3c.github.io/selection-api/#dfn-direction">direction</a> to
   forwards.</li>
-  <li>Add to the <a href="http://w3c.github.io/selection-api/#dfn-selection">selection</a>
+  <li>Add to the <a href="https://w3c.github.io/selection-api/#dfn-selection">selection</a>
   a new <a href="https://www.w3.org/TR/2014/WD-dom-20140204/#concept-range">range</a> whose
   <a href="https://www.w3.org/TR/2014/WD-dom-20140204/#concept-range-start">start</a> is the
   <a href="https://www.w3.org/TR/2014/WD-dom-20140204/#concept-range-bp">boundary point</a>

--- a/master/types.html
+++ b/master/types.html
@@ -77,7 +77,7 @@ six methods for describing an attribute's syntax:</p>
   appearing in the Value column.</li>
 
   <li>By reference to an
-  <a href="http://tools.ietf.org/html/std68">ABNF symbol</a> defined
+  <a href="https://tools.ietf.org/html/std68">ABNF symbol</a> defined
   in another specification [<a href="refs.html#ref-rfc5234">rfc5234</a>].  This is
   indicated by <span class="syntax">[ABNF]</span> appearing in the Value
   column.</li>
@@ -102,7 +102,7 @@ six methods for describing an attribute's syntax:</p>
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/10/28-svg-irc#T16-40-11">We will make property values case insensitivity.</a></td>
+      <td><a href="https://www.w3.org/2011/10/28-svg-irc#T16-40-11">We will make property values case insensitivity.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -110,7 +110,7 @@ six methods for describing an attribute's syntax:</p>
     </tr>
     <tr>
       <th>Owner:</th>
-      <td>Cameron (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3276">ACTION-3276</a>)</td>
+      <td>Cameron (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3276">ACTION-3276</a>)</td>
     </tr>
     <tr>
       <th>Status:</th>
@@ -134,7 +134,7 @@ follows:</p>
   <li>Replace all instances of <a>&lt;angle&gt;</a> in <var>grammar</var> with
   [<a>&lt;angle&gt;</a> | <a>&lt;number&gt;</a>].</li>
   <li>Return the result of
-  <a href="http://dev.w3.org/csswg/css-syntax/#parse-grammar">parsing
+  <a href="https://drafts.csswg.org/css-syntax/#parse-grammar">parsing
   <var>value</var> with <var>grammar</var></a>.</li>
 </ol>
 
@@ -148,7 +148,7 @@ the CSS Value Definition Syntax.</p>
 
 <p id="attribute-css-value">When any other attribute defined using the CSS Value
 Definition Syntax is parsed, this is done by
-<a href="http://dev.w3.org/csswg/css-syntax/#parse-grammar">parsing the
+<a href="https://drafts.csswg.org/css-syntax/#parse-grammar">parsing the
 attribute's value according to the grammar given in attribute definition
 table</a>.</p>
 
@@ -234,7 +234,7 @@ with the specific requirements and dependencies listed in this section.
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/10/27-svg-irc#T18-35-49">We will generally improve the SVG DOM for SVG 2.</a></td>
+      <td><a href="https://www.w3.org/2011/10/27-svg-irc#T18-35-49">We will generally improve the SVG DOM for SVG 2.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -242,11 +242,11 @@ with the specific requirements and dependencies listed in this section.
     </tr>
     <tr>
       <th>Owner:</th>
-      <td>Cameron (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3273">ACTION-3273</a>)</td>
+      <td>Cameron (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3273">ACTION-3273</a>)</td>
     </tr>
     <tr>
       <th>Note:</th>
-      <td>See <a href="http://www.w3.org/Graphics/SVG/WG/wiki/SVG_2_DOM">SVG 2 DOM</a> Wiki page.</td>
+      <td>See <a href="https://www.w3.org/Graphics/SVG/WG/wiki/SVG_2_DOM">SVG 2 DOM</a> Wiki page.</td>
     </tr>
   </table>
 </div>
@@ -259,7 +259,7 @@ with the specific requirements and dependencies listed in this section.
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/10/27-svg-irc#T18-23-23">We will improve the SVG path DOM APIs in SVG 2.</a></td>
+      <td><a href="https://www.w3.org/2011/10/27-svg-irc#T18-23-23">We will improve the SVG path DOM APIs in SVG 2.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -275,9 +275,9 @@ with the specific requirements and dependencies listed in this section.
 
 <h3 id="SVGDOMDependencies">Dependencies for SVG DOM support</h3>
 
-<p class="ready-for-wider-review">The SVG DOM is defined in terms of <a href="https://heycam.github.io/webidl/">Web IDL</a>
+<p class="ready-for-wider-review">The SVG DOM is defined in terms of <a href="https://webidl.spec.whatwg.org/">Web IDL</a>
 interfaces. All IDL fragments in this specification must be interpreted as
-required for <a href="https://heycam.github.io/webidl/#dfn-conforming-set-of-idl-fragments">conforming IDL fragments</a>,
+required for <a href="https://webidl.spec.whatwg.org/#dfn-conforming-set-of-idl-fragments">conforming IDL fragments</a>,
 as described in the Web IDL specification. [<a href="refs.html#ref-webidl">WebIDL</a>]</p>
 
 <p>The SVG DOM builds upon a number of DOM specifications.  In particular:</p>
@@ -312,7 +312,7 @@ as described in the Web IDL specification. [<a href="refs.html#ref-webidl">WebID
   </li>
 
   <li>The SVG DOM requires complete support for
-  <a href="http://www.w3.org/TR/2014/CR-geometry-1-20141125/">Geometry Interfaces Module Level 1</a>
+  <a href="https://www.w3.org/TR/2014/CR-geometry-1-20141125/">Geometry Interfaces Module Level 1</a>
   ([<a href="refs.html#ref-geometry-1">geometry-1</a>]).
   </li>
 </ul>
@@ -390,7 +390,7 @@ reflects the <a>'ry'</a> presentation attribute on the associated <a>'rect'</a> 
 <p>The way this reflection is done depends on the type of the IDL attribute:</p>
     <ul>
       <li>If the type of the reflecting IDL attribute is a
-      <a href="http://heycam.github.io/webidl/#dfn-primitive-type">primitive type</a> (such as
+      <a href="https://webidl.spec.whatwg.org/#dfn-primitive-type">primitive type</a> (such as
       <b>long</b>, as used by <a href="https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex">tabIndex</a>
        on <a>SVGElement</a>) or <b>DOMString</b> (as used by
       <a href="styling.html#__svg__SVGStyleElement__title">title</a> on <a>SVGStyleElement</a>),
@@ -627,7 +627,7 @@ while a <a>DOMRect</a> consists of many <span class="DOMInterfaceName">double</s
   <dt class="DOMInterfaceName">float</dt>
   <dt class="DOMInterfaceName">long</dt>
   <dt class="DOMInterfaceName">short</dt>
-  <dt>Any other <a href="https://heycam.github.io/webidl/#dfn-numeric-type">numeric type</a> defined in WebIDL</dt>
+  <dt>Any other <a href="https://webidl.spec.whatwg.org/#dfn-numeric-type">numeric type</a> defined in WebIDL</dt>
   <dd>Initialized as <span class="attr-value">0</span>.</dd>
 
   <dt class="DOMInterfaceName">boolean</dt>
@@ -673,7 +673,7 @@ DOM attributes that reflect enumerated values using integer constants are an exc
 these throw a <a>TypeError</a> when set to an out-of-range integer,
 or to the constant (0) that represents an unknown attribute value.
 This is consistent with the
-<a href="https://heycam.github.io/webidl/#es-enumeration">behavior of the WebIDL enumeration type</a>
+<a href="https://webidl.spec.whatwg.org/#es-enumeration">behavior of the WebIDL enumeration type</a>
 [<a href="refs.html#ref-webidl">WebIDL</a>].
 </p>
 
@@ -689,7 +689,7 @@ SVG language (such as the <a>SVGPathElement</a> interface for the
 <a>'path'</a> element) derive from the <a>SVGElement</a> interface.</p>
 
 <p class="note">The CSSOM specification
-<a href="http://dev.w3.org/csswg/cssom/#the-elementcssinlinestyle-interface">augments
+<a href="https://drafts.csswg.org/cssom/#the-elementcssinlinestyle-interface">augments
 SVGElement with a style IDL attribute</a>, so that the <a>'style attribute'</a>
 attribute can be accessed in the same way as on HTML elements.</p>
 
@@ -737,11 +737,11 @@ element is the <a>outermost svg element</a>, then null is returned.</p>
     <tr><th>SVG 2 Requirement:</th>
     <td>Detect if a mouse event is on the fill or stroke of a shape.</td></tr>
     <tr><th>Resolution:</th>
-    <td><a href="http://www.w3.org/2012/03/22-svg-irc#T20-20-03">SVG 2 will make it easier to detect if an mouse event is on the stroke or fill of an element.</a></td></tr>
+    <td><a href="https://www.w3.org/2012/03/22-svg-irc#T20-20-03">SVG 2 will make it easier to detect if an mouse event is on the stroke or fill of an element.</a></td></tr>
     <tr><th>Purpose:</th>
     <td>To allow authors to discriminate between pointer events on the fill and stroke of an element without having to duplicate the element</td></tr>
     <tr><th>Owner:</th>
-    <td>Cameron (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3279">ACTION-3279</a>)</td></tr>
+    <td>Cameron (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3279">ACTION-3279</a>)</td></tr>
     <tr><th>Status:</th>
     <td>Done.</td></tr>
   </table>
@@ -1655,7 +1655,7 @@ When convertToSpecifiedUnits(unitType) is called, the following steps are run:</
     </tr>
     <tr>
       <th>Resolution:</th>
-      <td><a href="http://www.w3.org/2011/02/28-svg-minutes.html#item04">Add array style indexing and .length and .item to svg list types.</a></td>
+      <td><a href="https://www.w3.org/2011/02/28-svg-minutes.html#item04">Add array style indexing and .length and .item to svg list types.</a></td>
     </tr>
     <tr>
       <th>Purpose:</th>
@@ -1663,7 +1663,7 @@ When convertToSpecifiedUnits(unitType) is called, the following steps are run:</
     </tr>
     <tr>
       <th>Owner:</th>
-      <td>Erik (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/2975">ACTION-2975</a>)</td>
+      <td>Erik (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/2975">ACTION-2975</a>)</td>
     </tr>
     <tr>
       <th>Status:</th>
@@ -1891,7 +1891,7 @@ the following steps are run, depending on the list element type:</p>
 </dl>
 </div>
 
-<p>The <a href="http://heycam.github.io/webidl/#dfn-supported-property-indices">supported property indices</a>
+<p>The <a href="https://webidl.spec.whatwg.org/#dfn-supported-property-indices">supported property indices</a>
 of a <a>list interface</a> object is the set of all non-negative integers
 less than the length of the list.</p>
 
@@ -2387,11 +2387,11 @@ the following steps are run:</p>
     <tr><th>SVG 2 Requirement:</th>
     <td>Make it easier to read and write to attributes in the SVG DOM.</td></tr>
     <tr><th>Resolution:</th>
-    <td><a href="http://www.w3.org/2011/10/27-svg-irc#T18-19-13">We will make it easier to read and write to attributes in the SVG DOM in SVG2.</a></td></tr>
+    <td><a href="https://www.w3.org/2011/10/27-svg-irc#T18-19-13">We will make it easier to read and write to attributes in the SVG DOM in SVG2.</a></td></tr>
     <tr><th>Purpose:</th>
     <td>To avoid the awkward access to the base values of <a>SVGAnimatedLength</a>s.</td></tr>
     <tr><th>Owner:</th>
-    <td>Cameron (<a href="http://www.w3.org/Graphics/SVG/WG/track/actions/3414">ACTION-3414</a>)</td></tr>
+    <td>Cameron (<a href="https://www.w3.org/Graphics/SVG/WG/track/actions/3414">ACTION-3414</a>)</td></tr>
   </table>
 </div>
 -->


### PR DESCRIPTION
This is fixing a lot of the outdated links in the spec.
fix #1131 