### PR TITLE
Define `getPathSegmentAtLength()` behavior for `NaN` distance

### DIFF
--- a/specs/paths/master/Overview.html
+++ b/specs/paths/master/Overview.html
@@ -1525,7 +1525,8 @@ The <a>SVGPathData</a> interface corresponds to the typed value of the <a>'d'</a
       <dd class="operation">
         <div>Returns the <a>SVGPathSegment</a> which is <var>distance</var>
         units along the path, utilizing the user agent's distance-along-a-path
-        algorithm. The <var>distance</var> shall be clamped to the range
+        algorithm. If <var>distance</var> is NaN, returns null.
+        Otherwise, the <var>distance</var> shall be clamped to the range
         [0, <em>total-length-of-path</em>] before passing it to the distance-along-a-path algorithm.
           <p>If no valid path data exists, returns null.</p>
         </div>


### PR DESCRIPTION
Clarify that `getPathSegmentAtLength()` returns null when the distance parameter is `NaN`, since `NaN` cannot be meaningfully clamped to a numeric range. This aligns with graceful-degradation model used elsewhere in SVG and matches Firefox's shipping behavior.

Fixes #1128