### PR TITLE
Define `getPathSegmentAtLength()` behavior at segment boundary

### DIFF
--- a/specs/paths/master/Overview.html
+++ b/specs/paths/master/Overview.html
@@ -1527,6 +1527,8 @@ The <a>SVGPathData</a> interface corresponds to the typed value of the <a>'d'</a
         units along the path, utilizing the user agent's distance-along-a-path
         algorithm. The <var>distance</var> shall be clamped to the range
         [0, <em>total-length-of-path</em>] before passing it to the distance-along-a-path algorithm.
+        If the clamped distance falls exactly on the boundary between two segments,
+        the later segment shall be returned.
           <p>If no valid path data exists, returns null.</p>
         </div>
         <dl class="operation">


### PR DESCRIPTION
Clarify that when the distance falls exactly on the boundary between two segments, the later segment is returned. This is consistent with `getPointAtLength()` behavior and matches Firefox's implementation.

Fixes #1129