### PR TITLE
Clarify that `getPathData()` returns the attribute base value

### DIFF
--- a/specs/paths/master/Overview.html
+++ b/specs/paths/master/Overview.html
@@ -1410,7 +1410,9 @@ interface mixin <b>SVGPathData</b> {
       <dt id="__svg__SVGPathData__getPathData" class="operation first-child">sequence&lt;<a>SVGPathSegment</a>> <b>getPathData</b>(optional <a>SVGPathDataSettings</a> <var>settings</var>)</dt>
         <dd class="operation">
         <div>Returns the sequence of path segments that corresponds to the
-             path data, optionally normalizing the values and segment types.
+             base value of the <a>'d'</a> attribute, optionally normalizing the
+             values and segment types. This does not reflect CSS computed values
+             or animated values.
           <p>If no valid path data exists, returns an empty sequence.</p>
         </div>
         <dl class="operation">
@@ -1435,7 +1437,9 @@ interface mixin <b>SVGPathData</b> {
       <dt id="__svg__SVGPathData__setPathData" class="operation">undefined <b>setPathData</b>(sequence&lt;<a>SVGPathSegment</a>> <var>pathData</var>)</dt>
         <dd class="operation">
         <div>
-          Sets the sequence of path segments as the new path data.
+          Sets the sequence of path segments as the new base value of the
+          <a>'d'</a> attribute, equivalent to calling <code>setAttribute("d", ...)</code>
+          with the serialized path data.
         </div>
         <dl class="operation">
           <dt class="parameters-header">Parameters</dt>
@@ -1457,7 +1461,8 @@ interface mixin <b>SVGPathData</b> {
 
 The <a>SVGPathElement</a> interface corresponds to the <a>'path'</a>
 element.
-The <a>SVGPathData</a> interface corresponds to the typed value of the <a>'d'</a> geometry property.
+The <a>SVGPathData</a> mixin operates on the base value of the <a>'d'</a> attribute,
+not the CSS resolved value or any animated value.
 
 <pre class="idl">interface <b>SVGPathElement</b> : <a>SVGGeometryElement</a> {
 


### PR DESCRIPTION
Clarify that `getPathData()` operates on the base value of the `d` attribute, not the CSS resolved value or animated value. Similarly, `setPathData()` is equivalent to `setAttribute('d', ...)`. This matches `getAttribute('d')` semantics and Firefox's shipping behavior.

Fixes #1130