### PR TITLE
fix #893 - drop section about completion of segments.

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -617,6 +617,8 @@ have been made.</p>
     per CSSWG resolution.
     <a href="https://github.com/w3c/csswg-drafts/issues/13901">csswg-drafts#13901</a>
     (<a href="https://github.com/w3c/csswg-drafts/issues/13901#issuecomment-4500370159">resolution, 20 May 2026</a>)</li>
+    <li>Dropped section 9.3.4.1. Segment-completing close path operation per SVGWG resolution. <a href="https://github.com/w3c/svgwg/issues/893">svgwg-drafts#893</a>
+    (<a href="https://github.com/w3c/csswg-drafts/issues/13901#issuecomment-4500370159">resolution, 18 June 2026</a>) </li>
 </ul>
 </div>
 

--- a/master/paths.html
+++ b/master/paths.html
@@ -421,31 +421,6 @@ next subpath. If a "closepath" is followed immediately by any
 other command, then the next subpath must start at the same <a>initial point</a>
 as the current subpath.</p>
 
-<h4 id="Segment-CompletingClosePath">Segment-completing close path operation</h4>
-
-<p>
-In order to represent the basic shapes as equivalent paths,
-there must be a way to close curved shapes
-without introducing an additional straight-line segment
-(even if that segment would have zero length).
-For that purpose, a segment-completing close path operation is defined here.
-</p>
-<p>
-A <dfn id="TermSegment-CompletingClosePath">segment-completing close path</dfn> operation <em>combines</em> with the previous path command,
-with two effects:
-</p>
-<ul>
-  <li>It ensures that the final coordinate point of the previous command exactly matches
-  the <a>initial point</a> of the current subpath.</li>
-  <li>It joins the final and initial points of the subpath, making it a closed subpath.</li>
-</ul>
-
-<p class="note">
-Segment-completing close path operations are not currently supported
-as a command in the path data syntax.
-The working group has proposed such a syntax for future versions of the specification.
-</p>
-
 <h3 id="PathDataLinetoCommands">The <strong>"lineto"</strong> commands</h3>
 
 <p>The various "lineto" commands draw straight lines from the


### PR DESCRIPTION
As discussed on SVG WG meeting on June 18, 2026.
RESOLUTION: Remove section 9.3.4.1
https://www.w3.org/2026/06/18-svg-minutes.html
For https://github.com/w3c/svgwg/issues/893