### PR TITLE
Revert SVG*→DOM* geometry-interface aliasing (#706)

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -179,11 +179,17 @@ have been made.</p>
 <h3 id="types">Basic Data Types and Interfaces chapter</h3>
 
 <ul>
-  <li>All appearance of <a>SVGMatrix</a> were replaced by <a>DOMMatrix</a> or <a>DOMMatrixReadOnly</a>.</li>
-
-  <li>All appearance of <a>SVGRect</a> were replaced by <a>DOMRect</a> or <a>DOMRectReadOnly</a>.</li>
-
-  <li>All appearance of <a>SVGPoint</a> were replaced by <a>DOMPoint</a> or <a>DOMPointReadOnly</a>.</li>
+  <li>Reverted SVG 2's aliasing of <a>SVGMatrix</a>, <a>SVGRect</a>, and
+  <a>SVGPoint</a> to the CSS Geometry <a>DOMMatrix</a>, <a>DOMRect</a>, and
+  <a>DOMPoint</a> equivalents respectively per
+  <a href="https://github.com/w3c/svgwg/issues/706">svgwg#706</a> (2019-10
+  WG resolutions). No browser engine adopted the aliasing across the
+  ~10 years it was specified, so the SVG 2 spec returns to its SVG 1.1
+  position: SVG geometry interfaces are standalone (not aliases). The
+  <a>DOMPointInit</a> and <a>DOMMatrix2DInit</a> dictionaries continue to
+  be used as input types in SVG methods (per resolution #3). Mixin-based
+  factoring of the geometry interface members (resolution #4) is deferred
+  pending CSS WG approval.</li>
 
   <li>Removed the SVGStylable and SVGLangSpace interfaces and moved all of their members on to <a>SVGElement</a>.</li>
 
@@ -257,7 +263,7 @@ have been made.</p>
       overrides <a>Element</a>.className. Not normative.
     <a href="https://github.com/w3c/svgwg/issues/298">Issue discussion</a>
     <a href="https://github.com/w3c/svgwg/pull/301">Edits</a></li>
-  <li>Specify <a>DOMPointInit</a> as argument type for isPointInFill() and isPointInStroke() instead of <a>DOMPoint</a>, and
+  <li>Specify <a>DOMPointInit</a> as argument type for isPointInFill() and isPointInStroke() instead of <a>SVGPoint</a>, and
     specify algorithm used for isPointInFill() and isPointInStroke().
     <a href="https://github.com/w3c/svgwg/issues/416">Issue discussion</a>
     <a href="https://github.com/w3c/svgwg/pull/443">Edits</a></li>
@@ -713,7 +719,7 @@ have been made.</p>
 <ul>
 
   <li>Specify <a>DOMPointInit</a> as argument type for getCharNumAtPosition() instead of
-    <a>DOMPoint</a>.
+    <a>SVGPoint</a>.
     <a href="https://github.com/w3c/svgwg/issues/389">Issue discussion</a>
     <a href="https://github.com/w3c/svgwg/pull/414">Edits</a>
   </li>

--- a/master/coords.html
+++ b/master/coords.html
@@ -3183,7 +3183,7 @@ two modes.  It can:</p>
 <p>An <a>SVGTransform</a> object maintains an internal
 <a href='https://drafts.csswg.org/css-transforms-1/#typedef-transform-function'>&lt;transform-function&gt;</a>
 value, which is called its <dfn id="TransformValue" data-dfn-type="dfn">value</dfn>.
-It also maintains a <a>DOMMatrix</a> object,
+It also maintains a <a>SVGMatrix</a> object,
 which is called its <dfn id="TransformMatrixObject" data-dfn-type="dfn" data-export="">matrix object</dfn>,
 which is the object returned from the <a href="#__svg__SVGTransform__matrix">matrix</a>
 IDL attribute.  An <a>SVGTransform</a> object's
@@ -3203,7 +3203,7 @@ interface <b>SVGTransform</b> {
   const unsigned short <a href="coords.html#__svg__SVGTransform__SVG_TRANSFORM_SKEWY">SVG_TRANSFORM_SKEWY</a> = 6;
 
   readonly attribute unsigned short <a href="coords.html#__svg__SVGTransform__type">type</a>;
-  [<a>SameObject</a>] readonly attribute <a>DOMMatrix</a> <a href="coords.html#__svg__SVGTransform__matrix">matrix</a>;
+  [<a>SameObject</a>] readonly attribute <a>SVGMatrix</a> <a href="coords.html#__svg__SVGTransform__matrix">matrix</a>;
   readonly attribute float <a href="coords.html#__svg__SVGTransform__angle">angle</a>;
 
   undefined <a href="coords.html#__svg__SVGTransform__setMatrix">setMatrix</a>(optional <a>DOMMatrix2DInit</a> matrix = {});
@@ -3351,51 +3351,53 @@ the following steps are run:</p>
   reflected attribute.</li>
 </ol>
 
-<p>This specification imposes additional requirements on the behavior of <a>DOMMatrix</a>
+<p>This specification imposes additional requirements on the behavior of <a>SVGMatrix</a>
 objects beyond those described in the
-<a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/">Geometry Interfaces</a>
+<a href="https://drafts.csswg.org/geometry-1/">Geometry Interfaces</a>
 specification, so that they can be used to reflect presentation attributes
 that take transform values.</p>
 
-<p id="MatrixMode">Every <a>DOMMatrix</a> object operates in one of two modes.
+<p id="MatrixMode">Every <a>SVGMatrix</a> object operates in one of two modes.
 It can:</p>
 
 <ol>
   <li><em>reflect an <a>SVGTransform</a></em> (being exposed through the
   <a href="#__svg__SVGTransform__matrix">matrix</a> IDL attribute on
   an <a>SVGTransform</a>), or</li>
-  <li><em>be detached</em>, which is the case for <a>DOMMatrix</a> objects
+  <li><em>be detached</em>, which is the case for <a>SVGMatrix</a> objects
   created using their constructor or with
   <a href="struct.html#__svg__SVGSVGElement__createSVGMatrix">createSVGMatrix</a>.</li>
 </ol>
 
-<p id="ReadOnlyMatrix">A <a>DOMMatrix</a> can be designated as <em>read only</em>,
+<p id="ReadOnlyMatrix">A <a>SVGMatrix</a> can be designated as <em>read only</em>,
 which means that attempts to modify the object will result in an exception
-being thrown.  When assigning to any of a read only <a>DOMMatrix</a>'s
+being thrown.  When assigning to any of a read only <a>SVGMatrix</a>'s
 IDL attributes, or when invoking any of its mutable transform methods,
 a <a>NoModificationAllowedError</a> exception will be <a>thrown</a>
 instead of updating the internal value.</p>
 
-<p class='note'>Note that this applies only to the read-write <a>DOMMatrix</a>
-interface; the <a>DOMMatrixReadOnly</a> interface, which is not used for reflecting
-<a>'transform'</a>, will already throw an exception if an attempt is made to modify it.</p>
+<p class='note'>Note that per <a href="https://github.com/w3c/svgwg/issues/706">svgwg#706</a>
+(2019-10 WG resolutions) SVG 2 reverts to the SVG 1.1 idiom: there is no
+separate read-only-variant interface. An <a>SVGMatrix</a> may be designated
+read-only via an internal flag; writes throw <a>NoModificationAllowedError</a>
+on the same interface.</p>
 
-<p>When assigning to any of a writable <a>DOMMatrix</a>'s
+<p>When assigning to any of a writable <a>SVGMatrix</a>'s
 IDL attributes, or when invoking any of its mutable transform methods,
 the following steps are run after updating the internal matrix value:</p>
 
 <ol class='algorithm'>
-  <li>If the <a>DOMMatrix</a> <a href='#MatrixMode'>reflects an SVGTransform</a>,
+  <li>If the <a>SVGMatrix</a> <a href='#MatrixMode'>reflects an SVGTransform</a>,
   then:
     <ol>
-      <li>If the <a>DOMMatrix</a> would return true from its
-      <a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/#dom-dommatrixreadonly-is2d">is2d</a>
+      <li>If the <a>SVGMatrix</a> would return true from its
+      <a href="https://drafts.csswg.org/geometry-1/#dom-dommatrixreadonly-is2d">is2d</a>
       method, then set the <a>SVGTransform</a> object's
       <a href='#TransformValue'>value</a> to a <span class='prop-value'>matrix(…)</span>
-      value that represents the same matrix as the <a>DOMMatrix</a>.</li>
+      value that represents the same matrix as the <a>SVGMatrix</a>.</li>
       <li>Otherwise, set the <a>SVGTransform</a> object's
       <a href='#TransformValue'>value</a> to a <span class='prop-value'>matrix3d(…)</span>
-      value that represents the same matrix as the <a>DOMMatrix</a>.</li>
+      value that represents the same matrix as the <a>SVGMatrix</a>.</li>
       <li>If the <a>SVGTransform</a> object
       <a href="#TransformMode">reflects an element of a
       presentation attribute value</a>, then <a>reserialize</a> the
@@ -3467,7 +3469,7 @@ consolidate() method is called, the following steps are run:</p>
   <var>matrix</var>.</li>
   <li>If <var>transform</var>'s
   <a href="#TransformMatrixObject">matrix object</a> would return true from its
-  <a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/#dom-dommatrixreadonly-is2d">is2d</a>
+  <a href="https://drafts.csswg.org/geometry-1/#dom-dommatrixreadonly-is2d">is2d</a>
   method, then set <var>transform</var>'s
   <a href='#TransformValue'>value</a> to a <span class='prop-value'>matrix(…)</span>
   value that represents the same matrix as the <a href="#TransformMatrixObject">matrix object</a>.</li>

--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -737,12 +737,12 @@
   <interface name='SVGFitToViewBox' href='types.html#InterfaceSVGFitToViewBox'/>
   <interface name='SVGNumber' href='types.html#InterfaceSVGNumber'/>
   <interface name='SVGAngle' href='types.html#InterfaceSVGAngle'/>
-  <interface name='DOMMatrix' href='https://www.w3.org/TR/geometry-1/#DOMMatrix'/>
-  <interface name='DOMMatrixReadOnly' href='https://www.w3.org/TR/geometry-1/#dommatrixreadonly'/>
-  <interface name='SVGMatrix' href='https://www.w3.org/TR/geometry-1/#dommatrix'/>
-  <interface name='DOMRect' href='https://www.w3.org/TR/geometry-1/#DOMRect'/>
-  <interface name='DOMRectReadOnly' href='https://www.w3.org/TR/geometry-1/#domrectreadonly'/>
-  <interface name='SVGRect' href='https://www.w3.org/TR/geometry-1/#DOMRect'/>
+  <interface name='DOMMatrix' href='https://drafts.csswg.org/geometry-1/#dommatrix'/>
+  <interface name='DOMMatrixReadOnly' href='https://drafts.csswg.org/geometry-1/#dommatrixreadonly'/>
+  <interface name='SVGMatrix' href='https://drafts.csswg.org/geometry-1/#dommatrix'/>
+  <interface name='DOMRect' href='https://drafts.csswg.org/geometry-1/#domrect'/>
+  <interface name='DOMRectReadOnly' href='https://drafts.csswg.org/geometry-1/#domrectreadonly'/>
+  <interface name='SVGRect' href='https://drafts.csswg.org/geometry-1/#domrect'/>
   <interface name='DOMMatrix2DInit' href='https://drafts.csswg.org/geometry-1/#dictdef-dommatrix2dinit'/>
   <interface name='SVGAnimatedRect' href='types.html#InterfaceSVGAnimatedRect'/>
   <interface name='SVGLength' href='types.html#InterfaceSVGLength'/>
@@ -764,10 +764,10 @@
   <interface name='SVGAnimatedBoolean' href='types.html#InterfaceSVGAnimatedBoolean'/>
   <interface name='SVGUnitTypes' href='types.html#InterfaceSVGUnitTypes'/>
   <interface name='SVGStyleElement' href='styling.html#InterfaceSVGStyleElement'/>
-  <interface name='SVGPoint' href='https://www.w3.org/TR/geometry-1/#dom-dompoint'/>
-  <interface name='DOMPoint' href='https://www.w3.org/TR/geometry-1/#dom-dompoint'/>
-  <interface name='DOMPointInit' href='https://www.w3.org/TR/geometry-1/#dictdef-dompointinit'/>
-  <interface name='DOMPointReadOnly' href='https://www.w3.org/TR/geometry-1/#dom-dompointreadonly'/>
+  <interface name='SVGPoint' href='https://drafts.csswg.org/geometry-1/#dompoint'/>
+  <interface name='DOMPoint' href='https://drafts.csswg.org/geometry-1/#dompoint'/>
+  <interface name='DOMPointInit' href='https://drafts.csswg.org/geometry-1/#dictdef-dompointinit'/>
+  <interface name='DOMPointReadOnly' href='https://drafts.csswg.org/geometry-1/#dompointreadonly'/>
   <interface name='SVGPointList' href='shapes.html#InterfaceSVGPointList'/>
   <interface name='SVGPreserveAspectRatio' href='coords.html#InterfaceSVGPreserveAspectRatio'/>
   <interface name='SVGAnimatedPreserveAspectRatio' href='coords.html#InterfaceSVGAnimatedPreserveAspectRatio'/>

--- a/master/shapes.html
+++ b/master/shapes.html
@@ -691,7 +691,7 @@ if there is no animation currently affecting the attribute.</p>
 <h3 id="InterfaceSVGPointList">Interface SVGPointList</h3>
 
 <p>The <a>SVGPointList</a> interface is a <a>list interface</a> whose
-elements are <a>DOMPoint</a> objects.  An <a>SVGPointList</a>
+elements are <a>SVGPoint</a> objects.  An <a>SVGPointList</a>
 object represents a list of points.</p>
 
 <pre class="idl">[<a>Exposed</a>=Window]
@@ -701,24 +701,24 @@ interface <b>SVGPointList</b> {
   readonly attribute unsigned long <a href="types.html#__svg__SVGNameList__numberOfItems">numberOfItems</a>;
 
   undefined <a href="types.html#__svg__SVGNameList__clear">clear</a>();
-  <a>DOMPoint</a> <a href="types.html#__svg__SVGNameList__initialize">initialize</a>(<a>DOMPoint</a> newItem);
-  getter <a>DOMPoint</a> <a href="types.html#__svg__SVGNameList__getItem">getItem</a>(unsigned long index);
-  <a>DOMPoint</a> <a href="types.html#__svg__SVGNameList__insertItemBefore">insertItemBefore</a>(<a>DOMPoint</a> newItem, unsigned long index);
-  <a>DOMPoint</a> <a href="types.html#__svg__SVGNameList__replaceItem">replaceItem</a>(<a>DOMPoint</a> newItem, unsigned long index);
-  <a>DOMPoint</a> <a href="types.html#__svg__SVGNameList__removeItem">removeItem</a>(unsigned long index);
-  <a>DOMPoint</a> <a href="types.html#__svg__SVGNameList__appendItem">appendItem</a>(<a>DOMPoint</a> newItem);
-  <a href="types.html#__svg__SVGNameList__setter">setter</a> undefined (unsigned long index, <a>DOMPoint</a> newItem);
+  <a>SVGPoint</a> <a href="types.html#__svg__SVGNameList__initialize">initialize</a>(<a>SVGPoint</a> newItem);
+  getter <a>SVGPoint</a> <a href="types.html#__svg__SVGNameList__getItem">getItem</a>(unsigned long index);
+  <a>SVGPoint</a> <a href="types.html#__svg__SVGNameList__insertItemBefore">insertItemBefore</a>(<a>SVGPoint</a> newItem, unsigned long index);
+  <a>SVGPoint</a> <a href="types.html#__svg__SVGNameList__replaceItem">replaceItem</a>(<a>SVGPoint</a> newItem, unsigned long index);
+  <a>SVGPoint</a> <a href="types.html#__svg__SVGNameList__removeItem">removeItem</a>(unsigned long index);
+  <a>SVGPoint</a> <a href="types.html#__svg__SVGNameList__appendItem">appendItem</a>(<a>SVGPoint</a> newItem);
+  <a href="types.html#__svg__SVGNameList__setter">setter</a> undefined (unsigned long index, <a>SVGPoint</a> newItem);
 };</pre>
 
 <p>The behavior of all of the interface members of <a>SVGPointList</a> are
 defined in <a href="types.html#ListInterfaces">List interfaces</a>.</p>
 
-<p>This specification imposes additional requirements on the behaviour of <a>DOMPoint</a>
+<p>This specification imposes additional requirements on the behaviour of <a>SVGPoint</a>
 objects beyond those described in the
-<a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/">Geometry Interfaces</a>
+<a href="https://drafts.csswg.org/geometry-1/">Geometry Interfaces</a>
 specification, so that they can be used to reflect <a>'polygon/points'</a> attributes.</p>
 
-<p id="PointMode">Every <a>DOMPoint</a> object operates in one of four modes. It
+<p id="PointMode">Every <a>SVGPoint</a> object operates in one of four modes. It
 can:</p>
 
 <div class='ready-for-wg-review'>
@@ -735,48 +735,49 @@ can:</p>
   (being exposed through the
   <a href="struct.html#__svg__SVGSVGElement__currentTranslate">currentTranslate</a>
   member on <a>SVGSVGElement</a>), or</li>
-  <li><em>be detached</em>, which is the case for <a>DOMPoint</a> objects created
+  <li><em>be detached</em>, which is the case for <a>SVGPoint</a> objects created
   using their constructor or with
   <a href='struct.html#__svg__SVGSVGElement__createSVGPoint'>createSVGPoint</a>.</li>
 </ol>
 </div>
 
-<p id="PointAssociatedElement">A <a>DOMPoint</a> object can be <em>associated</em>
+<p id="PointAssociatedElement">A <a>SVGPoint</a> object can be <em>associated</em>
 with a particular element.  The associated element is used to
 determine which element's content attribute to update if the object <a>reflects</a>
-an attribute.  Unless otherwise described, a <a>DOMPoint</a> object is not
+an attribute.  Unless otherwise described, a <a>SVGPoint</a> object is not
 associated with any element.</p>
 
-<p id="ReadOnlyPoint">A <a>DOMPoint</a> object can be designated as <em>read only</em>,
+<p id="ReadOnlyPoint">A <a>SVGPoint</a> object can be designated as <em>read only</em>,
 which means that attempts to modify the object will result in an exception
-being thrown.  When assigning to a read only <a>DOMPoint</a>'s
-<a href='https://www.w3.org/TR/2014/WD-geometry-1-20140522/#dom-dompointreadonly-dompoint-x'>x</a>,
-<a href='https://www.w3.org/TR/2014/WD-geometry-1-20140522/#dom-dompointreadonly-dompoint-y'>y</a>,
-<a href='https://www.w3.org/TR/2014/WD-geometry-1-20140522/#dom-dompointreadonly-dompoint-w'>w</a> or
-<a href='https://www.w3.org/TR/2014/WD-geometry-1-20140522/#dom-dompointreadonly-dompoint-z'>z</a>
+being thrown.  When assigning to a read only <a>SVGPoint</a>'s
+<a href='https://drafts.csswg.org/geometry-1/#dom-dompointreadonly-x'>x</a>,
+<a href='https://drafts.csswg.org/geometry-1/#dom-dompointreadonly-y'>y</a>,
+<a href='https://drafts.csswg.org/geometry-1/#dom-dompointreadonly-w'>w</a> or
+<a href='https://drafts.csswg.org/geometry-1/#dom-dompointreadonly-z'>z</a>
 IDL attribute, a <a>NoModificationAllowedError</a> must be
 <a>thrown</a> instead of updating the internal coordinate value.</p>
 
-<p class='note'>Note that this applies only to the read-write <a>DOMPoint</a>
-interface; the <a>DOMPointReadOnly</a> interface, which is not used for reflecting
-the <a>'polygon/points'</a> attribute, will already throw an exception if
-an attempt is made to modify it.</p>
+<p class='note'>Note that per <a href="https://github.com/w3c/svgwg/issues/706">svgwg#706</a>
+(2019-10 WG resolutions) SVG 2 reverts to the SVG 1.1 idiom: there is no
+separate read-only-variant interface. An <a>SVGPoint</a> may be designated
+read-only via an internal flag; writes throw <a>NoModificationAllowedError</a>
+on the same interface.</p>
 
-<p id="AssignToDOMPoint">When assigning to a writable <a>DOMPoint</a>'s
-<a href='https://www.w3.org/TR/2014/WD-geometry-1-20140522/#dom-dompointreadonly-dompoint-x'>x</a>,
-<a href='https://www.w3.org/TR/2014/WD-geometry-1-20140522/#dom-dompointreadonly-dompoint-y'>y</a>,
-<a href='https://www.w3.org/TR/2014/WD-geometry-1-20140522/#dom-dompointreadonly-dompoint-w'>w</a> or
-<a href='https://www.w3.org/TR/2014/WD-geometry-1-20140522/#dom-dompointreadonly-dompoint-z'>z</a>
+<p id="AssignToDOMPoint">When assigning to a writable <a>SVGPoint</a>'s
+<a href='https://drafts.csswg.org/geometry-1/#dom-dompointreadonly-x'>x</a>,
+<a href='https://drafts.csswg.org/geometry-1/#dom-dompointreadonly-y'>y</a>,
+<a href='https://drafts.csswg.org/geometry-1/#dom-dompointreadonly-w'>w</a> or
+<a href='https://drafts.csswg.org/geometry-1/#dom-dompointreadonly-z'>z</a>
 IDL attribute, the following steps are run after updating
 the internal coordinate value:</p>
 
 <ol class='algorithm'>
-  <li>If the <a>DOMPoint</a> <a href='#PointMode'>reflects an element of the
+  <li>If the <a>SVGPoint</a> <a href='#PointMode'>reflects an element of the
   base value</a> of a <a>reflected</a> attribute, then <a>reserialize</a>
   the reflected attribute using the <a>SVGPointList</a> that reflects
   the attribute's base value.
   </li>
-  <li>Otherwise, if the <a>DOMPoint</a> <a href='#PointMode'>represents
+  <li>Otherwise, if the <a>SVGPoint</a> <a href='#PointMode'>represents
   the current translation</a> of an <a>'svg'</a> element and that
   element is the <a>outermost svg element</a>, then:
     <ol>
@@ -784,7 +785,7 @@ the internal coordinate value:</p>
       be the 2x3 matrix that represents the document's magnification and panning
       transform.</li>
       <li>Let <var>x</var> and <var>y</var> be the x and y coordinates of the
-      <a>DOMPoint</a> object, respectively.</li>
+      <a>SVGPoint</a> object, respectively.</li>
       <li>Set the document's magnification and panning transform to
       [<var>a</var> 0 0 <var>d</var> <var>x</var> <var>y</var>].</li>
     </ol>

--- a/master/struct.html
+++ b/master/struct.html
@@ -2834,7 +2834,7 @@ in the DOM.  The <a>SVGSVGElement</a> interface also contains
 miscellaneous utility methods, such as data type object factory methods.</p>
 
 <p>An <a>SVGSVGElement</a> object maintains an internal
-<a>DOMPoint</a> object, called its
+<a>SVGPoint</a> object, called its
 <dfn id="CurrentTranslatePointObject" data-dfn-type="dfn" data-export="">current translate point object</dfn>,
 which is the object returned from the <a href="#__svg__SVGSVGElement__currentTranslate">currentTranslate</a>
 IDL attribute.</p>
@@ -2848,21 +2848,21 @@ interface <b>SVGSVGElement</b> : <a>SVGGraphicsElement</a> {
   [<a>SameObject</a>] readonly attribute <a>SVGAnimatedLength</a> <a href="struct.html#__svg__SVGSVGElement__height">height</a>;
 
   attribute float <a href="struct.html#__svg__SVGSVGElement__currentScale">currentScale</a>;
-  [<a>SameObject</a>] readonly attribute <a>DOMPointReadOnly</a> <a href="struct.html#__svg__SVGSVGElement__currentTranslate">currentTranslate</a>;
+  [<a>SameObject</a>] readonly attribute <a>SVGPoint</a> <a href="struct.html#__svg__SVGSVGElement__currentTranslate">currentTranslate</a>;
 
-  <a>NodeList</a> <a href="struct.html#__svg__SVGSVGElement__getIntersectionList">getIntersectionList</a>(<a>DOMRectReadOnly</a> rect, <a>SVGElement</a>? referenceElement);
-  <a>NodeList</a> <a href="struct.html#__svg__SVGSVGElement__getEnclosureList">getEnclosureList</a>(<a>DOMRectReadOnly</a> rect, <a>SVGElement</a>? referenceElement);
-  boolean <a href="struct.html#__svg__SVGSVGElement__checkIntersection">checkIntersection</a>(<a>SVGElement</a> element, <a>DOMRectReadOnly</a> rect);
-  boolean <a href="struct.html#__svg__SVGSVGElement__checkEnclosure">checkEnclosure</a>(<a>SVGElement</a> element, <a>DOMRectReadOnly</a> rect);
+  <a>NodeList</a> <a href="struct.html#__svg__SVGSVGElement__getIntersectionList">getIntersectionList</a>(<a>SVGRect</a> rect, <a>SVGElement</a>? referenceElement);
+  <a>NodeList</a> <a href="struct.html#__svg__SVGSVGElement__getEnclosureList">getEnclosureList</a>(<a>SVGRect</a> rect, <a>SVGElement</a>? referenceElement);
+  boolean <a href="struct.html#__svg__SVGSVGElement__checkIntersection">checkIntersection</a>(<a>SVGElement</a> element, <a>SVGRect</a> rect);
+  boolean <a href="struct.html#__svg__SVGSVGElement__checkEnclosure">checkEnclosure</a>(<a>SVGElement</a> element, <a>SVGRect</a> rect);
 
   undefined <a href="struct.html#__svg__SVGSVGElement__deselectAll">deselectAll</a>();
 
   [<a>NewObject</a>] <a>SVGNumber</a> <a href="struct.html#__svg__SVGSVGElement__createSVGNumber">createSVGNumber</a>();
   [<a>NewObject</a>] <a>SVGLength</a> <a href="struct.html#__svg__SVGSVGElement__createSVGLength">createSVGLength</a>();
   [<a>NewObject</a>] <a>SVGAngle</a> <a href="struct.html#__svg__SVGSVGElement__createSVGAngle">createSVGAngle</a>();
-  [<a>NewObject</a>] <a>DOMPoint</a> <a href="struct.html#__svg__SVGSVGElement__createSVGPoint">createSVGPoint</a>();
-  [<a>NewObject</a>] <a>DOMMatrix</a> <a href="struct.html#__svg__SVGSVGElement__createSVGMatrix">createSVGMatrix</a>();
-  [<a>NewObject</a>] <a>DOMRect</a> <a href="struct.html#__svg__SVGSVGElement__createSVGRect">createSVGRect</a>();
+  [<a>NewObject</a>] <a>SVGPoint</a> <a href="struct.html#__svg__SVGSVGElement__createSVGPoint">createSVGPoint</a>();
+  [<a>NewObject</a>] <a>SVGMatrix</a> <a href="struct.html#__svg__SVGSVGElement__createSVGMatrix">createSVGMatrix</a>();
+  [<a>NewObject</a>] <a>SVGRect</a> <a href="struct.html#__svg__SVGSVGElement__createSVGRect">createSVGRect</a>();
   [<a>NewObject</a>] <a>SVGTransform</a> <a href="struct.html#__svg__SVGSVGElement__createSVGTransform">createSVGTransform</a>();
   [<a>NewObject</a>] <a>SVGTransform</a> <a href="struct.html#__svg__SVGSVGElement__createSVGTransformFromMatrix">createSVGTransformFromMatrix</a>(optional <a>DOMMatrix2DInit</a> matrix = {});
 
@@ -2956,7 +2956,7 @@ translate point object</a> must be <a href="shapes.html#ReadOnlyPoint">read only
 when its <a>'svg'</a> element is not the <a>outermost svg element</a>,
 and writable otherwise.</p>
 
-<p class="note">See the rules for <a href="shapes.html#AssignToDOMPoint">assigning to a DOMPoint</a>
+<p class="note">See the rules for <a href="shapes.html#AssignToDOMPoint">assigning to a SVGPoint</a>
 for how modifying the <a href="#CurrentTranslatePointObject">current
 translate point object</a> affects the document's magnification and panning transform.</p>
 
@@ -3163,9 +3163,9 @@ object is returned according to the following table:</p>
   <tr><td><a href="#__svg__SVGSVGElement__createSVGNumber">createSVGNumber</a></td><td>A new, <a href="types.html#NumberMode">detached</a> <a>SVGNumber</a> object whose value is 0.</td></tr>
   <tr><td><a href="#__svg__SVGSVGElement__createSVGLength">createSVGLength</a></td><td>A new, <a href="types.html#LengthMode">detached</a> <a>SVGLength</a> object whose value is the unitless <a>&lt;number&gt;</a> 0.</td></tr>
   <tr><td><a href="#__svg__SVGSVGElement__createSVGAngle">createSVGAngle</a></td><td>A new, <a href="types.html#AngleMode">detached</a> <a>SVGAngle</a> object whose value is the unitless <a>&lt;number&gt;</a> 0.</td></tr>
-  <tr><td><a href="#__svg__SVGSVGElement__createSVGPoint">createSVGPoint</a></td><td>A new, <a href="shapes.html#PointMode">detached</a> <a>DOMPoint</a> object whose coordinates are all 0.</td></tr>
-  <tr><td><a href="#__svg__SVGSVGElement__createSVGMatrix">createSVGMatrix</a></td><td>A new, <a href="coords.html#MatrixMode">detached</a> <a>DOMMatrix</a> object representing the identity matrix.</td></tr>
-  <tr><td><a href="#__svg__SVGSVGElement__createSVGRect">createSVGRect</a></td><td>A new, <a>DOMRect</a> object whose x, y, width and height are all 0.</td></tr>
+  <tr><td><a href="#__svg__SVGSVGElement__createSVGPoint">createSVGPoint</a></td><td>A new, <a href="shapes.html#PointMode">detached</a> <a>SVGPoint</a> object whose coordinates are all 0.</td></tr>
+  <tr><td><a href="#__svg__SVGSVGElement__createSVGMatrix">createSVGMatrix</a></td><td>A new, <a href="coords.html#MatrixMode">detached</a> <a>SVGMatrix</a> object representing the identity matrix.</td></tr>
+  <tr><td><a href="#__svg__SVGSVGElement__createSVGRect">createSVGRect</a></td><td>A new, <a>SVGRect</a> object whose x, y, width and height are all 0.</td></tr>
   <tr><td><a href="#__svg__SVGSVGElement__createSVGTransform">createSVGTransform</a></td><td>A new, <a href="coords.html#TransformMode">detached</a> <a>SVGTransform</a> object whose value is <span class='prop-value'>matrix(1, 0, 0, 1, 0, 0)</span>.</td></tr>
 </table>
 
@@ -3173,8 +3173,8 @@ object is returned according to the following table:</p>
 <a href="#__svg__SVGSVGElement__createSVGMatrix">createSVGMatrix</a> and
 <a href="#__svg__SVGSVGElement__createSVGRect">createSVGRect</a> methods
 are all deprecated and kept only for compatibility with legacy content.
-Authors are encouraged to use the <a>DOMPoint</a>, <a>DOMMatrix</a> and
-<a>DOMRect</a> constructors instead.</p>
+Authors are encouraged to use the <a>SVGPoint</a>, <a>SVGMatrix</a> and
+<a>SVGRect</a> constructors instead.</p>
 
 <p>The <b id="__svg__SVGSVGElement__createSVGTransformFromMatrix">createSVGTransformFromMatrix</b>
 method is used to create a new <a>SVGTransform</a> object from a matrix object.

--- a/master/text.html
+++ b/master/text.html
@@ -5736,9 +5736,9 @@ interface <b>SVGTextContentElement</b> : <a>SVGGraphicsElement</a> {
   long <a href="text.html#__svg__SVGTextContentElement__getNumberOfChars">getNumberOfChars</a>();
   float <a href="text.html#__svg__SVGTextContentElement__getComputedTextLength">getComputedTextLength</a>();
   float <a href="text.html#__svg__SVGTextContentElement__getSubStringLength">getSubStringLength</a>(unsigned long charnum, unsigned long nchars);
-  <a>DOMPoint</a> <a href="text.html#__svg__SVGTextContentElement__getStartPositionOfChar">getStartPositionOfChar</a>(unsigned long charnum);
-  <a>DOMPoint</a> <a href="text.html#__svg__SVGTextContentElement__getEndPositionOfChar">getEndPositionOfChar</a>(unsigned long charnum);
-  <a>DOMRect</a> <a href="text.html#__svg__SVGTextContentElement__getExtentOfChar">getExtentOfChar</a>(unsigned long charnum);
+  <a>SVGPoint</a> <a href="text.html#__svg__SVGTextContentElement__getStartPositionOfChar">getStartPositionOfChar</a>(unsigned long charnum);
+  <a>SVGPoint</a> <a href="text.html#__svg__SVGTextContentElement__getEndPositionOfChar">getEndPositionOfChar</a>(unsigned long charnum);
+  <a>SVGRect</a> <a href="text.html#__svg__SVGTextContentElement__getExtentOfChar">getExtentOfChar</a>(unsigned long charnum);
   float <a href="text.html#__svg__SVGTextContentElement__getRotationOfChar">getRotationOfChar</a>(unsigned long charnum);
   long <a href="text.html#__svg__SVGTextContentElement__getCharNumAtPosition">getCharNumAtPosition</a>(optional <a>DOMPointInit</a> point = {});
   undefined <a href="text.html#__svg__SVGTextContentElement__selectSubString">selectSubString</a>(unsigned long charnum, unsigned long nchars);
@@ -5905,7 +5905,7 @@ called, the following steps are run:</p>
   that correspond to the character at index <var>charnum</var>,
   in the coordinate system of the current element.</li>
   <li>Return a newly created, <a href="shapes.html#PointMode">detached</a>
-  <a>DOMPoint</a> object representing the point <var>p</var>.</li>
+  <a>SVGPoint</a> object representing the point <var>p</var>.</li>
 </ol>
 
 <p>The <b id="__svg__SVGTextContentElement__getEndPositionOfChar">getEndPositionOfChar</b>
@@ -5934,7 +5934,7 @@ called, the following steps are run:</p>
   <li>Let <var>advance</var> be <var>cluster</var>'s advance.</li>
   <li>Set <var>p</var> to <var>p</var> + <var>advance</var> · <var>direction</var>.</li>
   <li>Return a newly created, <a href="shapes.html#PointMode">detached</a>
-  <a>DOMPoint</a> object representing the point <var>p</var>.</li>
+  <a>SVGPoint</a> object representing the point <var>p</var>.</li>
 </ol>
 
 <p>The <b id="__svg__SVGTextContentElement__getExtentOfChar">getExtentOfChar</b>
@@ -5955,7 +5955,7 @@ is called, the following steps are run:</p>
   <li>Let <var>rect</var> be the rectangle that forms the tightest
   bounding box around <var>quad</var> in the current element's
   coordinate system.</li>
-  <li>Return a newly created <a>DOMRect</a> object representing the
+  <li>Return a newly created <a>SVGRect</a> object representing the
   rectangle <var>rect</var>.</li>
 </ol>
 

--- a/master/types.html
+++ b/master/types.html
@@ -312,7 +312,7 @@ as described in the Web IDL specification. [<a href="refs.html#ref-webidl">WebID
   </li>
 
   <li>The SVG DOM requires complete support for
-  <a href="https://www.w3.org/TR/2014/CR-geometry-1-20141125/">Geometry Interfaces Module Level 1</a>
+  <a href="https://drafts.csswg.org/geometry-1/">Geometry Interfaces Module Level 1</a>
   ([<a href="refs.html#ref-geometry-1">geometry-1</a>]).
   </li>
 </ul>
@@ -515,14 +515,14 @@ specific value, the following steps must be performed:</p>
       from getting <var>value</var>'s <a href="#__svg__SVGAngle__valueAsString">valueAsString</a>
       member.</dd>
 
-      <dt><a>DOMRect</a></dt>
+      <dt><a>SVGRect</a></dt>
       <dd>
         <ol>
           <li>Let <var>components</var> be a list of four values, being the values of the
-          <a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/#dom-domrectreadonly-domrect-x">x</a>,
-          <a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/#dom-domrectreadonly-domrect-y">y</a>,
-          <a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/#dom-domrectreadonly-domrect-width">width</a> and
-          <a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/#dom-domrectreadonly-domrect-height">height</a>
+          <a href="https://drafts.csswg.org/geometry-1/#dom-domrect-x">x</a>,
+          <a href="https://drafts.csswg.org/geometry-1/#dom-domrect-y">y</a>,
+          <a href="https://drafts.csswg.org/geometry-1/#dom-domrect-width">width</a> and
+          <a href="https://drafts.csswg.org/geometry-1/#dom-domrect-height">height</a>
           members of <var>value</var>.</li>
 
           <li>Let <var>serialized components</var> be a list of four strings,
@@ -549,7 +549,7 @@ specific value, the following steps must be performed:</p>
         <ol>
           <li>Let <var>elements</var> be the list of values in <var>value</var>.
             <p class="note">The values will be <a>SVGNumber</a>, <a>SVGLength</a>,
-            <a>DOMPoint</a> or <a>SVGTransform</a> objects, or <b>DOMString</b> values,
+            <a>SVGPoint</a> or <a>SVGTransform</a> objects, or <b>DOMString</b> values,
             depending on <var>value</var>'s type.</p>
           </li>
 
@@ -567,12 +567,12 @@ specific value, the following steps must be performed:</p>
               <dd>The string is the value that would be returned
               from getting the value's <a href="#__svg__SVGLength__valueAsString">valueAsString</a>
               member.</dd>
-              <dt>a <a>DOMPoint</a> object</dt>
+              <dt>a <a>SVGPoint</a> object</dt>
               <dd>The string value is computed as follows:
                 <ol>
                   <li>Let <var>string</var> be an empty string.</li>
                   <li>Let <var>x</var> and <var>y</var> be the values of the
-                  <a>DOMPoint</a> object's x and y coordinates, respectively.</li>
+                  <a>SVGPoint</a> object's x and y coordinates, respectively.</li>
                   <li>Append to <var>string</var> an implementation specific string
                   that, if parsed as <a>&lt;number&gt;</a> using CSS syntax, would return the number
                   value closest to <var>x</var>, given
@@ -618,7 +618,7 @@ If an interface is not listed below that means
 that the object initialization shall be done using the values for the
 objects that the interface contains, e.g.,
 an <a>SVGAnimatedString</a> consists of two <span class="DOMInterfaceName">DOMString</span> members,
-while a <a>DOMRect</a> consists of many <span class="DOMInterfaceName">double</span>s.</p>
+while a <a>SVGRect</a> consists of many <span class="DOMInterfaceName">double</span>s.</p>
 
 <dl id="SVGObjectInitValues">
   <dt class="DOMInterfaceName">DOMString</dt>
@@ -761,9 +761,9 @@ is to directly render graphics into a group.</p>
 interface <b>SVGGraphicsElement</b> : <a>SVGElement</a> {
   [<a>SameObject</a>] readonly attribute <a>SVGAnimatedTransformList</a> <a href="types.html#__svg__SVGGraphicsElement__transform">transform</a>;
 
-  <a>DOMRect</a> <a href="types.html#__svg__SVGGraphicsElement__getBBox">getBBox</a>(optional <a>SVGBoundingBoxOptions</a> options = {});
-  <a>DOMMatrix</a>? <a href="types.html#__svg__SVGGraphicsElement__getCTM">getCTM</a>();
-  <a>DOMMatrix</a>? <a href="types.html#__svg__SVGGraphicsElement__getScreenCTM">getScreenCTM</a>();
+  <a>SVGRect</a> <a href="types.html#__svg__SVGGraphicsElement__getBBox">getBBox</a>(optional <a>SVGBoundingBoxOptions</a> options = {});
+  <a>SVGMatrix</a>? <a href="types.html#__svg__SVGGraphicsElement__getCTM">getCTM</a>();
+  <a>SVGMatrix</a>? <a href="types.html#__svg__SVGGraphicsElement__getScreenCTM">getScreenCTM</a>();
 };
 
 <a>SVGGraphicsElement</a> includes <a>SVGTests</a>;</pre>
@@ -780,10 +780,10 @@ with <var>fill</var>, <var>stroke</var>, <var>markers</var>
 and <var>clipped</var> members of the <var>options</var> dictionary argument
 used to control which parts of the element are included in the bounding box,
 using the element's user coordinate system as the coordinate system to return the
-bounding box in. A newly created <a>DOMRect</a> object that defines the
+bounding box in. A newly created <a>SVGRect</a> object that defines the
 computed bounding box is returned. If the element's geometric attributes
 are missing or have invalid values (e.g. negative width or height),
-such that the element is not rendered, then a <a>DOMRect</a> with x, y,
+such that the element is not rendered, then a <a>SVGRect</a> with x, y,
 width and height all set to 0 is returned.</p>
 
 <p>The <b id="__svg__SVGGraphicsElement__getCTM">getCTM</b> method is used to
@@ -816,7 +816,7 @@ steps are run:</p>
     </dl>
   </li>
   <li>Return a newly created, <a href="coords.html#MatrixMode">detached</a>
-  <a>DOMMatrix</a> object that represents the same matrix as <var>ctm</var>.</li>
+  <a>SVGMatrix</a> object that represents the same matrix as <var>ctm</var>.</li>
 </ol>
 
 <p>The <b id="__svg__SVGGraphicsElement__getScreenCTM">getScreenCTM</b> method
@@ -850,7 +850,7 @@ When getScreenCTM() is called, the following steps are run:</p>
     </div>
   </li>
   <li>Return a newly created, <a href="coords.html#MatrixMode">detached</a>
-  <a>DOMMatrix</a> object that represents the same matrix as <var>ctm</var>.</li>
+  <a>SVGMatrix</a> object that represents the same matrix as <var>ctm</var>.</li>
 </ol>
 
 <p class='note'>This method would have been more aptly named as <code>getClientCTM</code>,
@@ -874,7 +874,7 @@ interface <b>SVGGeometryElement</b> : <a>SVGGraphicsElement</a> {
   boolean <a href="types.html#__svg__SVGGeometryElement__isPointInFill">isPointInFill</a>(optional <a>DOMPointInit</a> point = {});
   boolean <a href="types.html#__svg__SVGGeometryElement__isPointInStroke">isPointInStroke</a>(optional <a>DOMPointInit</a> point = {});
   float <a href="types.html#__svg__SVGGeometryElement__getTotalLength">getTotalLength</a>();
-  <a>DOMPoint</a> <a href="types.html#__svg__SVGGeometryElement__getPointAtLength">getPointAtLength</a>(float distance);
+  <a>SVGPoint</a> <a href="types.html#__svg__SVGGeometryElement__getPointAtLength">getPointAtLength</a>(float distance);
 };</pre>
 
 <p>The <b id="__svg__SVGGeometryElement__isPointInFill">isPointInFill</b> method,
@@ -947,7 +947,7 @@ getPointAtLength(<var>distance</var>) is called, the following steps are run:</p
   <li>Let (<var>x</var>, <var>y</var>) be the point on the path at distance
   <var>distance</var>.</li>
   <li>Return a newly created, <a href="shapes.html#PointMode">detached</a>
-  <a>DOMPoint</a> object representing the point
+  <a>SVGPoint</a> object representing the point
   (<var>x</var>, <var>y</var>).</li>
 </ol>
 
@@ -1701,7 +1701,7 @@ few unanimated attributes that take a list of strings.</p>
 
 <p>where <var>Name</var> is a descriptive name for the list element's
 ("Number", "Length", "Point", "Transform" or "String") and <var>Type</var> is the IDL type of the
-list's elements (<a>SVGNumber</a>, <a>SVGLength</a>, <a>DOMPoint</a>, <a>SVGTransform</a> or <b>DOMString</b>).</p>
+list's elements (<a>SVGNumber</a>, <a>SVGLength</a>, <a>SVGPoint</a>, <a>SVGTransform</a> or <b>DOMString</b>).</p>
 
 <p>The <a>SVGTransformList</a> interface takes the above form but has
 two additional methods on it.</p>
@@ -1743,7 +1743,7 @@ the following steps:</p>
   (as supported by the <a>'transform'</a> property), <var>new length</var>
   is 0.</li>
 
-  <li>If the list element type is <a>SVGNumber</a>, <a>SVGLength</a>, <a>DOMPoint</a> or <a>SVGTransform</a>, then:
+  <li>If the list element type is <a>SVGNumber</a>, <a>SVGLength</a>, <a>SVGPoint</a> or <a>SVGTransform</a>, then:
     <ol>
       <li>If <var>length</var> &gt; <var>new length</var>, then:
         <ol>
@@ -1806,11 +1806,11 @@ the following steps are run, depending on the list element type:</p>
     set it to be no longer read only.  Set the <a>SVGLength</a> to have
     unspecified <a href="#LengthAssociatedElement">directionality</a>.
   </dd>
-  <dt><a>DOMPoint</a></dt>
+  <dt><a>SVGPoint</a></dt>
   <dd>
-    Set the <a>DOMPoint</a> to no longer be
+    Set the <a>SVGPoint</a> to no longer be
     <a href="shapes.html#PointAssociatedElement">associated</a> with any element.
-    If the <a>DOMPoint</a> is <a href='shapes.html#ReadOnlyPoint'>read only</a>,
+    If the <a>SVGPoint</a> is <a href='shapes.html#ReadOnlyPoint'>read only</a>,
     set it to be no longer read only.
   </dd>
   <dt><a>SVGTransform</a></dt>
@@ -1862,19 +1862,19 @@ the following steps are run, depending on the list element type:</p>
         <em>read only</em>.</dd>
       </dl>
   </dd>
-  <dt><a>DOMPoint</a></dt>
+  <dt><a>SVGPoint</a></dt>
   <dd>
     <a href="shapes.html#PointAssociatedElement">Associate</a> the
-    <a>DOMPoint</a> with the element that the <a>list interface</a>
+    <a>SVGPoint</a> with the element that the <a>list interface</a>
     object is associated with.
     Additionally, depending on which IDL attribute the <a>list interface</a>
     object is reflected through:
       <dl class='switch'>
         <dt>baseVal</dt>
-        <dd>Set the <a>DOMPoint</a> to <a href="shapes.html#PointMode">reflect an
+        <dd>Set the <a>SVGPoint</a> to <a href="shapes.html#PointMode">reflect an
         element of the base value</a>.</dd>
         <dt>animVal</dt>
-        <dd>Set the <a>DOMPoint</a> to <a href="shapes.html#PointMode">reflect an
+        <dd>Set the <a>SVGPoint</a> to <a href="shapes.html#PointMode">reflect an
         element of the base value</a>.</dd>
       </dl>
   </dd>
@@ -2533,8 +2533,8 @@ reflected as an <a>SVGAnimatedRect</a> is <a>'viewBox'</a>.</p>
 
 <pre class="idl">[<a>Exposed</a>=Window]
 interface <b>SVGAnimatedRect</b> {
-  [<a>SameObject</a>] readonly attribute <a>DOMRect</a> <a href="types.html#__svg__SVGAnimatedRect__baseVal">baseVal</a>;
-  [<a>SameObject</a>] readonly attribute <a>DOMRectReadOnly</a> <a href="types.html#__svg__SVGAnimatedRect__animVal">animVal</a>;
+  [<a>SameObject</a>] readonly attribute <a>SVGRect</a> <a href="types.html#__svg__SVGAnimatedRect__baseVal">baseVal</a>;
+  [<a>SameObject</a>] readonly attribute <a>SVGRect</a> <a href="types.html#__svg__SVGAnimatedRect__animVal">animVal</a>;
 };</pre>
 
 <p class='ready-for-wider-review'>The <b id="__svg__SVGAnimatedRect__baseVal">baseVal</b>
@@ -2542,11 +2542,11 @@ and <b id="__svg__SVGAnimatedRect__animVal">animVal</b> IDL
 attributes represent the current non-animated rectangle value of
 the reflected attribute.  On getting <a href="#__svg__SVGAnimatedRect__baseVal">baseVal</a>
 or <a href="#__svg__SVGAnimatedRect__animVal">animVal</a>,
-a <a>DOMRect</a> object is returned.</p>
+a <a>SVGRect</a> object is returned.</p>
 
 <p class='ready-for-wider-review'>Upon creation of the <a href="#__svg__SVGAnimatedRect__baseVal">baseVal</a>
 or <a href="#__svg__SVGAnimatedRect__animVal">animVal</a>
-<a>DOMRect</a> objects, and afterwards whenever the reflected content attribute
+<a>SVGRect</a> objects, and afterwards whenever the reflected content attribute
 is added, removed, or changed, the following steps are run:</p>
 
 <ol class='algorithm'>
@@ -2555,24 +2555,24 @@ is added, removed, or changed, the following steps are run:</p>
   or invalid).</li>
   <li>Let <var>x</var>, <var>y</var>, <var>width</var> and <var>height</var>
   be those corresponding components of <var>value</var>.</li>
-  <li>Set the <a>DOMRect</a> object's
-  <a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/#x-coordinate">x coordinate</a>,
-  <a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/#y-coordinate">y coordinate</a>,
-  <a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/#width">width</a> and
-  <a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/#height">height</a>
+  <li>Set the <a>SVGRect</a> object's
+  <a href="https://drafts.csswg.org/geometry-1/#rectangle-x-coordinate">x coordinate</a>,
+  <a href="https://drafts.csswg.org/geometry-1/#rectangle-y-coordinate">y coordinate</a>,
+  <a href="https://drafts.csswg.org/geometry-1/#rectangle-width-dimension">width</a> and
+  <a href="https://drafts.csswg.org/geometry-1/#rectangle-height-dimension">height</a>
   to <var>x</var>, <var>y</var>, <var>width</var> and <var>height</var>,
   respectively.</li>
 </ol>
 
 <p class='ready-for-wider-review'>Whenever the
-<a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/#x-coordinate">x coordinate</a>,
-<a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/#y-coordinate">y coordinate</a>,
-<a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/#width">width</a> or
-<a href="https://www.w3.org/TR/2014/WD-geometry-1-20140522/#height">height</a> property
+<a href="https://drafts.csswg.org/geometry-1/#rectangle-x-coordinate">x coordinate</a>,
+<a href="https://drafts.csswg.org/geometry-1/#rectangle-y-coordinate">y coordinate</a>,
+<a href="https://drafts.csswg.org/geometry-1/#rectangle-width-dimension">width</a> or
+<a href="https://drafts.csswg.org/geometry-1/#rectangle-height-dimension">height</a> property
 of the <a href="#__svg__SVGAnimatedRect__baseVal">baseVal</a> or
 <a href="#__svg__SVGAnimatedRect__animVal">animVal</a>
-<a>DOMRect</a> object changes, except as part of the previous algorithm that
-reflects the value of the content attribute into the <a>DOMRect</a>, the reflected
+<a>SVGRect</a> object changes, except as part of the previous algorithm that
+reflects the value of the content attribute into the <a>SVGRect</a>, the reflected
 content attribute must be <a>reserialized</a>.</p>
 
 <h3 id="InterfaceSVGAnimatedNumberList">Interface SVGAnimatedNumberList</h3>


### PR DESCRIPTION
Per the 2019-10 WG resolutions: undo SVG 2's aliasing of SVGPoint/SVGRect/SVGMatrix to the corresponding DOM* Geometry interfaces. No browser engine adopted the aliasing over ~10 years, so the spec returns to its SVG 1.1 position: SVG geometry interfaces are standalone, not aliases.

Resolutions implemented:
R1. Revert SVG*→DOM* aliasing (pending CSS WG approval). R2. Use SVG* geometry interfaces in SVG spec IDL.
R3. Keep DOM*Init dictionary types as input parameters.

Deferred:
R4. Mixin extraction in CSS Geometry (pending CSS WG approval).

Changes:

* types.html, shapes.html, coords.html, struct.html, text.html — IDL return / attribute types reverted from DOMPoint/Rect/Matrix (and their *ReadOnly variants) to SVGPoint/SVGRect/SVGMatrix; DOMPointInit + DOMMatrix2DInit kept on isPointInFill, isPointInStroke, getCharNumAtPosition, setMatrix, createSVGTransformFromMatrix.

* shapes.html, coords.html — rewrote the two prose notes that explained the (now-removed) read-only-variant interface distinction to reflect the SVG 1.1 read-only-via-flag idiom.

* One DOMMatrixReadOnly.fromMatrix(matrix) call preserved in coords.html as a cross-spec API invocation.

* changes.html: 3 obsolete aliasing-introduction entries replaced with one revert-announcement entry.

* definitions.xml: autolink entries unchanged structurally; only Geometry-1 hrefs normalized.

* All Geometry-1 URL references migrated from www.w3.org/TR/{,2014/CR-,2014/WD-}geometry-1{,-YYYYMMDD}/ to drafts.csswg.org/geometry-1/, with fragment-anchor remapping (e.g. #dom-dompointreadonly-dompoint-x → #dom-dompointreadonly-x; #x-coordinate → #rectangle-x-coordinate).