### PR TITLE
remove instanceRoot / animatedInstanceRoot - fix #852

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -431,7 +431,6 @@ have been made.</p>
       <li>Prohibit event listeners from being directly added to elements in the use-element shadow tree.</li>
       <li>Make use elements and symbols map to the graphics-object role by default, so the shadow content will be accessible.</li>
       <li>Make the SVGSymbolElement interface extend from SVGGraphicsElement, so that rendered symbol element instances have all the behavior of graphics elements (e.g., getBBox)</li>
-      <li>Restore the (animated)instanceRoot properties on the SVGUseElement interface.</li>
     </ul>
   </li>
   <li>Change role mapping for the <a>'a'</a> element to depend on whether it is actually a valid link.</li>
@@ -462,6 +461,12 @@ have been made.</p>
     <li>
       Remove <code>zoomAndPan</code> attribute and related text.
       <a href="https://github.com/w3c/svgwg/issues/56">Issue discussion</a>
+    </li>
+    <li>
+      Remove the <code>instanceRoot</code> and <code>animatedInstanceRoot</code>
+      properties from the <a>SVGUseElement</a> interface,
+      as they have been removed from all browsers.
+      <a href="https://github.com/w3c/svgwg/issues/852">Issue discussion</a>
     </li>
   </ul>
 </div>

--- a/master/struct.html
+++ b/master/struct.html
@@ -3290,8 +3290,6 @@ interface <b>SVGUseElement</b> : <a>SVGGraphicsElement</a> {
   [<a>SameObject</a>] readonly attribute <a>SVGAnimatedLength</a> <a href="struct.html#__svg__SVGUseElement__y">y</a>;
   [<a>SameObject</a>] readonly attribute <a>SVGAnimatedLength</a> <a href="struct.html#__svg__SVGUseElement__width">width</a>;
   [<a>SameObject</a>] readonly attribute <a>SVGAnimatedLength</a> <a href="struct.html#__svg__SVGUseElement__height">height</a>;
-  [<a>SameObject</a>] readonly attribute <a>SVGElement</a>? <a href="struct.html#__svg__SVGUseElement__instanceRoot">instanceRoot</a>;
-  [<a>SameObject</a>] readonly attribute <a>SVGElement</a>? <a href="struct.html#__svg__SVGUseElement__animatedInstanceRoot">animatedInstanceRoot</a>;
 };
 
 <a>SVGUseElement</a> includes <a>SVGURIReference</a>;</pre>
@@ -3304,17 +3302,6 @@ interface <b>SVGUseElement</b> : <a>SVGGraphicsElement</a> {
 <a>reflect</a> the computed values of the <a>'x'</a>, <a>'y'</a>, <a>'width'</a> and
 <a>'height'</a> properties and their corresponding
 presentation attributes, respectively.</p>
-
-<p>The <b id="__svg__SVGUseElement__instanceRoot">instanceRoot</b> and
-<b id="__svg__SVGUseElement__animatedInstanceRoot">animatedInstanceRoot</b>
-IDL attributes both point to the <a>instance root</a>,
-the <a>element instance</a> that is a direct child
-of this element's shadow root
-(<code>u.instanceRoot</code> is equivalent to getting <code>u.shadowRoot.firstChild</code>).
-If this element does not have a shadow tree
-(for example, because its URI is invalid
-or because it has been disabled by <a>conditional processing</a>),
-then getting these attributes returns null.</p>
 
 </edit:with>
 


### PR DESCRIPTION
instanceRoot and animatedInstanceRoot is not implemented in any browsers. This removes it from the spec. It was previously used before shadow tree existed for the <use> element.

Kept: the "instance root" concept term (TermInstanceRoot), still used by 5 autolinks in render.html/struct.html. Verified no orphans

master/struct.html:
  removed the two IDL attribute declarations from SVGUseElement + the prose paragraph describing them
master/changes.html:
  dropped the obsolete "Restore the (animated)instanceRoot" entry; added a cr3 removal entry citing #852