### PR TITLE
Fix typo in SVGAngle.unitType algorithm

### DIFF
--- a/master/types.html
+++ b/master/types.html
@@ -1470,7 +1470,7 @@ are run:</p>
 
 <ol class='algorithm'>
   <li>If the <a>SVGAngle</a>'s <a href='#AngleValue'>value</a> is a unitless
-  <a>&lt;number&gt;</a> or a <a>&lt;length&gt;</a> with a
+  <a>&lt;number&gt;</a> or a <a>&lt;angle&gt;</a> with a
   <span class='prop-value'>deg</span>,
   <span class='prop-value'>rad</span> or
   <span class='prop-value'>grad</span> unit, then return the corresponding constant


### PR DESCRIPTION
`SVGAngle` represents either a `<number>` or an `<angle>`, not a `<length>`