### PR TITLE
Correct presentational attribute table for `height` and `width`

### DIFF
--- a/master/styling.html
+++ b/master/styling.html
@@ -350,7 +350,18 @@ the presentation attribute name is the same as the property name, in lower-case 
   </tr>
   <tr>
     <td>
-      <a>'height'</a>, <a>'width'</a>, <a>'x'</a>, <a>'y'</a>
+      <a>'height'</a>, <a>'width'</a>
+    </td>
+    <td>
+      <a>'foreignObject'</a>,
+      <a>'image'</a>,
+      <a>'rect'</a>, and
+      the outermost <a>'svg'</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a>'x'</a>, <a>'y'</a>
     </td>
     <td>
       <a>'foreignObject'</a>,


### PR DESCRIPTION
99eb17c updated `height` and `width` to not be presentation attributes for `<symbol>`, `<use>`, and non-outermost `<svg>`s - this commit updates the presentational attribute table to reflect that change.