### PR TITLE
fix #893 - drop the remaining segment-completing references

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -630,6 +630,13 @@ have been made.</p>
     (<a href="https://github.com/w3c/csswg-drafts/issues/13901#issuecomment-4500370159">resolution, 20 May 2026</a>)</li>
     <li>Dropped section 9.3.4.1. Segment-completing close path operation per SVGWG resolution. <a href="https://github.com/w3c/svgwg/issues/893">svgwg-drafts#893</a>
     (<a href="https://github.com/w3c/csswg-drafts/issues/13901#issuecomment-4500370159">resolution, 18 June 2026</a>) </li>
+    <li>Removed the remaining references to the dropped
+    segment-completing close path operation.
+    The <a>equivalent path</a> of <a>'rect'</a>, <a>'circle'</a> and <a>'ellipse'</a>
+    now ends with an ordinary
+    <a href="paths.html#PathDataClosePathCommand">closepath</a> command,
+    so every equivalent path can be expressed in the path data syntax.
+    <a href="https://github.com/w3c/svgwg/issues/893">Issue #893</a></li>
 </ul>
 </div>
 

--- a/master/paths.html
+++ b/master/paths.html
@@ -60,9 +60,6 @@ Notes</a>.</p>
 <dfn id="TermEquivalentPath">equivalent path</dfn> is, which is
 what their shape is as a path.  (The equivalent path of a
 <a>'path'</a> element is simply the path itself.)
-In order to define the basic shapes as equivalent paths,
-a <a>segment-completing close path</a> operation is defined,
-which cannot currently be represented in the basic path syntax.
 </p>
 
 <h2 id="PathElement">The <span class="element-name">'path'</span> element</h2>

--- a/master/shapes.html
+++ b/master/shapes.html
@@ -47,6 +47,18 @@ shapes.</p>
 <p>The <a>equivalent path</a> and algorithm to compute the stroke for each shape
   are defined in the shape sections below.</p>
 
+<p class="note">
+  The <a>equivalent paths</a> of <a>'rect'</a>, <a>'circle'</a> and <a>'ellipse'</a> below
+  each end with a <a href="paths.html#PathDataClosePathCommand">closepath</a>
+  that draws a line of zero length,
+  because the command before it already ends at the <a>initial point</a>.
+  A zero-length line does not change how the shape is filled or stroked.
+  It can affect where <a>vertex markers</a> go,
+  but markers on these elements are placed by the rules in
+  <a href="painting.html#VertexMarkerProperties">Vertex markers</a>,
+  not by counting the commands listed for each shape.
+</p>
+
 <h2 id="RectElement">The <span class="element-name">'rect'</span> element</h2>
 
 <edit:with element='rect'>
@@ -162,8 +174,11 @@ following the rules specified above and in <a href="coords.html#Units">Units</a>
 
   <li><em>if</em> both <var>rx</var> and <var>ry</var> are greater than zero,
   perform an absolute <a href="paths.html#PathDataEllipticalArcCommands">elliptical arc</a>
-  operation with a <a>segment-completing close path</a> operation,
-  using the same parameters as previously.</li>
+  operation to coordinate (<var>x+rx</var>,<var>y</var>),
+  using the same parameters as previously;</li>
+
+  <li>perform a <a href="paths.html#PathDataClosePathCommand">closepath</a>
+  command.</li>
 </ol>
 
 <p class="annotation">
@@ -226,7 +241,8 @@ radius.</p>
   <li>arc to <var>cx</var>,<var>cy+r</var>;</li>
   <li>arc to <var>cx-r</var>,<var>cy</var>;</li>
   <li>arc to <var>cx</var>,<var>cy-r</var>;</li>
-  <li>arc with a <a>segment-completing close path</a> operation.</li>
+  <li>arc to <var>cx+r</var>,<var>cy</var>;</li>
+  <li>a <a href="paths.html#PathDataClosePathCommand">closepath</a> command.</li>
 </ol>
 
 <p class="annotation">
@@ -307,7 +323,8 @@ with the current <a>user coordinate system</a> based on a center point and two r
   <li>arc to <var>cx</var>,<var>cy+ry</var>;</li>
   <li>arc to <var>cx-rx</var>,<var>cy</var>;</li>
   <li>arc to <var>cx</var>,<var>cy-ry</var>;</li>
-  <li>arc with a <a>segment-completing close path</a> operation.</li>
+  <li>arc to <var>cx+rx</var>,<var>cy</var>;</li>
+  <li>a <a href="paths.html#PathDataClosePathCommand">closepath</a> command.</li>
 </ol>
 
 <p class="annotation">


### PR DESCRIPTION
The section went away in f579d453 but four links to the term stayed, and they render as "@@ unknown term" in the built spec. Three of them are in the equivalent-path algorithms for rect, circle and ellipse.

The final arc now ends at the initial point and an ordinary closepath closes the subpath, so every equivalent path can be written in the path data syntax. The closing line has zero length; a note in the Basic Shapes chapter says so, and says why that does not change fill or stroke.

The closepath is unconditional, so a rect with square corners is now closed too. Previously only the rounded-corner step closed the shape, which left a plain rect open and its first corner unjoined. See #753.

Spelling out the closepath rather than relying on the last command landing on the start point matters because those two are not the same thing, and that rule is currently only a note. See #1161.