### PR TITLE
fix #1168 - an absent list attribute reflects an empty list

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -304,6 +304,19 @@ have been made.</p>
 
 <ul><li>Adjust getBBox() to return 0 when any values are invalid. March 2026. <a href="https://github.com/w3c/svgwg/issues/1018">Issue #1018</a></li></ul>
 
+<ul>
+  <li>Clarified step 1 of the algorithm for
+    <a href="types.html#TermSynchronizeList">synchronizing a list interface
+    object</a>, so that an attribute which is absent or unparsable gives an
+    empty list when its <a>initial value</a> is
+    <span class="attr-value">(none)</span>. Previously the step asked for the
+    <a>initial value</a> with no answer for the
+    <span class="attr-value">(none)</span> case, which left the reflected list
+    undefined for an attribute that had been removed by script.
+    <a href="https://github.com/w3c/svgwg/issues/1168">Issue #1168</a>
+  </li>
+</ul>
+
 <h3 id="structure">Document Structure chapter</h3>
 
 <ul>

--- a/master/changes.html
+++ b/master/changes.html
@@ -763,6 +763,14 @@ have been made.</p>
     purposes of text positioning attributes (e.g. counting by Unicode
     code points).
   </li>
+  <li>Changed the initial value of <a>'text/x'</a> and <a>'text/y'</a>
+    on <a>'text'</a> from <span class="attr-value">0</span> to
+    <span class="attr-value">(none)</span>, so that the reflected
+    <a>SVGLengthList</a> is empty when the attribute is absent, as all
+    implementations do. The rendering default moved into the prose on
+    the initial <a>current text position</a>.
+    <a href="https://github.com/w3c/svgwg/issues/1168">Issue #1168</a>
+  </li>
 </ul>
 </div>
 

--- a/master/text.html
+++ b/master/text.html
@@ -642,6 +642,13 @@
   </p>
 
   <p>
+    If no <a>'text/x'</a> (<a>'text/y'</a>) attribute establishes the
+    initial <a>current text position</a>, then its X (Y) coordinate is
+    <span class="attr-value">0</span> in the current user coordinate
+    system.
+  </p>
+
+  <p>
     A <dfn id="TermBaselineTable" data-dfn-type="dfn" data-export="">baseline-table</dfn> specifies the position of one or more
     baselines in the design space coordinate system. The function of
     the baseline table is to facilitate the alignment of different
@@ -1036,7 +1043,7 @@
 	<tr>
           <td><dfn id="TextElementXAttribute" data-dfn-type="element-attr" data-dfn-for="text" data-export="">x</dfn>, <dfn id="TextElementYAttribute" data-dfn-type="element-attr" data-dfn-for="text" data-export="">y</dfn></td>
           <td>[ [ <a>&lt;length-percentage&gt;</a> | <a>&lt;number&gt;</a> ]+ ]#</td>
-          <td>0 for <a>'text'</a>;<br/> (none) for <a>'tspan'</a></td>
+          <td>(none)</td>
           <td>yes</td>
 	</tr>
       </table>
@@ -1065,7 +1072,7 @@
       </p>
       <p>
 	If more characters exist than <a>&lt;length&gt;</a>s,
-    or if the attribute is not specified on a <a>'tspan'</a>,
+    or if the attribute is not specified,
     then for each additional character:
       </p>
       <ol style="list-style-type: lower-alpha">
@@ -1081,7 +1088,10 @@
 	    the starting X (Y) coordinate for rendering the glyphs
         corresponding to the given character is the X (Y) coordinate
         of the resulting <a>current text position</a> from the most
-        recently rendered glyph for the current <a>'text'</a> element.
+        recently rendered glyph for the current <a>'text'</a> element,
+        or the X (Y) coordinate of the initial <a>current text
+        position</a> if no glyph has yet been rendered for that
+        element.
         </li>
       </ol>
       <p class="note">

--- a/master/types.html
+++ b/master/types.html
@@ -1735,8 +1735,10 @@ the following steps:</p>
 
 <ol class='algorithm'>
   <li class='ready-for-wider-review'>Let <var>value</var> be the base value of the
-    reflected content attribute (using the attribute's <a>initial value</a>
-    if it is not present or invalid).</li>
+    reflected content attribute. If the attribute is not present, or if its
+    value cannot be parsed, let <var>value</var> be the attribute's
+    <a>initial value</a>, or an empty list if the attribute's
+    <a>initial value</a> is <span class="attr-value">(none)</span>.</li>
   <li>Let <var>length</var> be the number of items in the list.</li>
   <li>Let <var>new length</var> be the number of values in <var>value</var>.
   If <var>value</var> is the keyword <span class='prop-value'>none</span>


### PR DESCRIPTION
Two commits.

**1. `text` x and y get `(none)` as their initial value.**

The Initial value column feeds rendering, animation, and what the DOM reports. For `text` x and y the cell said `0`, and `0` is one value of the attribute's grammar, so a literal reading gave the reflected `SVGLengthList` one item when the attribute was absent. No engine does that: Safari 27.0, Firefox 157.0 and Chrome 155.0.0.0 all report an empty list, and `svg/types/scripted/SVGList-parse-invalid-clears-items.html` asserts it.

`(none)` is not a gap in the table. [Reflecting content attributes in the DOM](https://w3c.github.io/svgwg/svg2-draft/types.html#ReflectingAttributes) already routes it:

> If the attribute's initial value is `(none)`, the object is initialized as defined in [Reflecting an empty initial value](https://w3c.github.io/svgwg/svg2-draft/types.html#SVGObjectInitialization).

and that section says every list interface is "Initialized as the empty list", with a worked example for `text/dx`. So this commit puts `x` on the same route that `dx`, `dy` and `rotate` already take, rather than inventing anything.

The `0` was also wrong where it stood, for rendering. Three sentences of the current draft compose badly: the initial value of `text/x` is `0`, an initial value ["is to be used for the purposes of rendering"](https://w3c.github.io/svgwg/svg2-draft/types.html#TermInitialValue), and on a path ["any 'x' attributes on 'text' or 'tspan' elements represent new absolute offsets along the path, thus providing explicit new values for startpoint-on-the-path"](https://w3c.github.io/svgwg/svg2-draft/text.html#TextpathLayoutRules). Together they say that

```html
<text><textPath href="#p" startOffset="50%">Hello</textPath></text>
```

must start at the beginning of the path, because the absent `x` supplies an absolute offset of `0` that replaces the `startOffset`. All three engines start it at the halfway point. With no initial value there is nothing to be read as an offset.

The rendering default moves into the prose on the initial current text position, and the per-character fallback in the attribute definition now names that position for the first character, since an absent `x` on `text` and an absent `x` on `tspan` are the same case once the cell is `(none)`.

**2. `synchronize` step 1 names the empty list.**

The first commit alone is not enough, and this is the part the earlier version of this description missed. `#SVGObjectInitialization` is reachable from one place in the specification, the initialization-on-access paragraph, and both of that paragraph's conditions are about how the object came to exist rather than the attribute's state now: "hasn't been specified explicitly in the document markup", and "initialized upon access". Neither `synchronize` algorithm links to it.

So with the cell at `(none)` and step 1 unchanged:

- an attribute **removed by script** runs `synchronize`, not initialization, and step 1 asked for an initial value that no longer exists
- an attribute that is **present but unparsable**, `x=""` included, is excluded by that section's own gate ("only if there is no explicit value for the reflected content attribute") and had the same problem

Both were left undefined rather than fixed. Step 1 now reads:

> Let *value* be the base value of the reflected content attribute. If the attribute is not present, or if its value cannot be parsed, let *value* be the attribute's initial value, or an empty list if the attribute's initial value is `(none)`.

That makes the three paths agree, which is what all three engines already do, and it is also the only edit here that reaches `feColorMatrix` `values`, whose initial value is the identity matrix and is defined in Filter Effects 1.

Measurements behind all of the above are in the issue, three engines throughout.

Fixes #1168
