### PR TITLE
fix #366 - define color-interpolation by way of CSS Color 4

### DIFF
--- a/master/changes.html
+++ b/master/changes.html
@@ -820,6 +820,14 @@ have been made.</p>
   <li>Moved the <span class='property'>color-interpolation-filters</span> property
   to the Filter Effects specification.</li>
 
+  <li>Removed <a href="render.html#PaintersModel">compositing and blending</a>
+  from the list of operations that <a>'color-interpolation'</a> affects, and
+  defined the values of the property by reference to the
+  <a href="https://drafts.csswg.org/css-color-4/#interpolation-color-space">interpolation
+  color space</a> definitions of CSS Color 4.
+  [<a href="refs.html#ref-css-color-4">css-color-4</a>]</li>
+
+
   <li>Added the <span class="prop-value">context-fill</span> and <span class="prop-value">context-stroke</span>
   paint values.</li>
 
@@ -912,6 +920,11 @@ have been made.</p>
   <li>Added the solidcolor element and its two properties solid-color
     and solid-opacity, ported over from SVG Tiny 1.2. (Renamed 'solidColor' to
   'solidcolor'.)</li>
+
+  <li>Said that gradient stop interpolation happens in the interpolation color
+  space given by <a>'color-interpolation'</a>, which is now defined by
+  reference to CSS Color 4.
+  [<a href="refs.html#ref-css-color-4">css-color-4</a>]</li>
 
   <li>Added an <a>'radialGradient/fr'</a> attribute to the <a>'radialGradient'</a> element,
   which allows specifying the radius of the focal circle.</li>

--- a/master/changes.html
+++ b/master/changes.html
@@ -827,6 +827,10 @@ have been made.</p>
   color space</a> definitions of CSS Color 4.
   [<a href="refs.html#ref-css-color-4">css-color-4</a>]</li>
 
+  <li>Added <a>&lt;color-interpolation-method&gt;</a> to the values of
+  <a>'color-interpolation'</a>, so that an author can ask for any of the
+  interpolation color spaces of CSS Color 4 and not only the two sRGB ones.
+  [<a href="refs.html#ref-css-color-4">css-color-4</a>]</li>
 
   <li>Added the <span class="prop-value">context-fill</span> and <span class="prop-value">context-stroke</span>
   paint values.</li>

--- a/master/definitions.xml
+++ b/master/definitions.xml
@@ -801,6 +801,7 @@
   <symbol name='align' href='coords.html#DataTypeAlign'/>
   <symbol name='alpha-value' href='https://www.w3.org/TR/css-color/#typedef-alpha-value'/>
   <symbol name='color' href='https://www.w3.org/TR/css3-values/#colors'/>
+  <symbol name='color-interpolation-method' href='https://drafts.csswg.org/css-color-4/#color-interpolation-method'/>
   <symbol name='dasharray' href='painting.html#DataTypeDasharray'/>
   <symbol name='frequency' href='https://www.w3.org/TR/css3-values/#frequency'/>
   <symbol name='icccolor' href='https://w3c.github.io/svgwg/specs/color/#DataTypeICCColor'/>

--- a/master/painting.html
+++ b/master/painting.html
@@ -2439,30 +2439,39 @@ has the same rendering behavior as
   </tr>
 </table>
 
-<p>The SVG user agent performs color interpolations and compositing
-at various points as it processes SVG content.  The <a>'color-interpolation'</a>
-property controls which color space is used for the following graphics operations:</p>
+<p>The SVG user agent interpolates colors at various points as it processes SVG
+content.  The <a>'color-interpolation'</a> property specifies the
+<a href="https://drafts.csswg.org/css-color-4/#interpolation-color-space">interpolation
+color space</a> used for the following graphics operations:
+[<a href="refs.html#ref-css-color-4">css-color-4</a>]</p>
 
 <ul>
   <li>interpolating between <a href="pservers.html#Gradients">gradient</a> stops,</li>
 
-  <li>interpolating color when performing color animations with
-  <a>'animate'</a>,</li>
-  <li>and <a href="render.html#PaintersModel">compositing and blending</a> of
-  <a>graphics elements</a> into the current background.</li>
+  <li>and interpolating color when performing color animations with
+  <a>'animate'</a>.</li>
 </ul>
+
+<p class="note">In SVG 1.1 this property also selected the color space for
+<a href="render.html#PaintersModel">compositing and blending</a> of
+<a>graphics elements</a> into the current background.  No user agent implemented
+that, and the requirement has been removed.  Compositing and blending are
+performed as defined in Compositing and Blending.
+[<a href="refs.html#ref-compositing-1">compositing-1</a>]</p>
 
 <p class="note">For <a href="https://www.w3.org/TR/filter-effects/">filter effects</a>, the
 <a>'color-interpolation-filters'</a> property controls which color space is used.
 [<a href="refs.html#ref-filter-effects-1">filter-effects-1</a>]</p>
+
+<p class="note">The computed value of <a>'color-interpolation'</a> on a
+<a href="https://drafts.csswg.org/css-masking-1/#MaskElement">'mask'</a> element
+determines the color space in which mask luminance is computed.  See
+<a href="https://drafts.csswg.org/css-masking-1/#MaskValues">Mask processing</a>.
+[<a href="refs.html#ref-css-masking-1">css-masking-1</a>]</p>
 </div>
 
 <div class='ready-for-wider-review'>
-<p>The <a>'color-interpolation'</a> property chooses between color operations
-occurring in the sRGB color space or in a (light energy linear) linearized RGB
-color space. Having chosen the appropriate color space, component-wise linear
-interpolation is used.  Values for <a>'color-interpolation'</a> have the
-following meanings:</p>
+<p>Values for <a>'color-interpolation'</a> have the following meanings:</p>
 
 <dl>
   <dt><span class='prop-value'>auto</span></dt>
@@ -2473,107 +2482,51 @@ following meanings:</p>
   interpolation occur in a particular color space.</dd>
 
   <dt><span class='prop-value'>sRGB</span></dt>
-  <dd>Indicates that color interpolation occurs in the sRGB
-  color space.</dd>
+  <dd>Indicates that the interpolation color space is
+  <a href="https://drafts.csswg.org/css-color-4/#predefined-sRGB">sRGB</a>,
+  the gamma encoded sRGB color space.</dd>
 
   <dt><span class='prop-value'>linearRGB</span></dt>
-  <dd>Indicates that color interpolation occurs in the
-  linearized RGB color space as described below.</dd>
+  <dd>Indicates that the interpolation color space is
+  <a href="https://drafts.csswg.org/css-color-4/#predefined-sRGB-linear">srgb-linear</a>,
+  which has the same primaries and white point as
+  <span class='prop-value'>sRGB</span> and a linear transfer function, so that
+  its component values are proportional to light intensity.</dd>
 </dl>
 
-<p id="sRGBlinearRGBConversionFormulas">The conversion formulas between the
-sRGB color space (i.e., nonlinear with 2.2 gamma curve) and the linearized RGB
-color space (i.e., color values expressed as sRGB tristimulus values without a
-gamma curve) can be found in <a href="https://webstore.iec.ch/publication/6168">the sRGB specification</a>
-[<a href="refs.html#ref-srgb">SRGB</a>].
-For illustrative purposes, the following formula shows the conversion from
-sRGB to linearized RGB, where <var>C<sub>srgb</sub></var> is one of the
-three sRGB color components, <var>C<sub>linear</sub></var> is the corresponding
-linearized RGB color component, and all color values are between 0 and 1:</p>
+<p id="sRGBlinearRGBConversionFormulas">The conversion between the
+<span class='prop-value'>sRGB</span> and the
+<span class='prop-value'>linearRGB</span> color spaces is the one defined for
+<a href="https://drafts.csswg.org/css-color-4/#predefined-sRGB-linear">srgb-linear</a>
+in CSS Color 4. [<a href="refs.html#ref-css-color-4">css-color-4</a>]</p>
 
-<div role="math" aria-describedby="math-linearRGB">
-  <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
-    <mrow>
-      <msub>
-        <mi>C</mi>
-        <mi>linear</mi>
-      </msub>
-      <mo>=</mo>
-      <mo>{</mo>
-      <mtable columnalign="left">
-        <mtr>
-          <mtd>
-            <mfrac>
-              <msub>
-                <mi>C</mi>
-                <mi>srgb</mi>
-              </msub>
-              <mn>12.92</mn>
-            </mfrac>
-          </mtd>
-          <mtd>
-            <mtext>if&#160;</mtext>
-            <msub>
-              <mi>C</mi>
-              <mi>srgb</mi>
-            </msub>
-            <mo>≤</mo>
-            <mn>0.04045</mn>
-          </mtd>
-        </mtr>
-        <mtr>
-          <mtd>
-            <msup>
-              <mfenced>
-                <mfrac>
-                  <mrow>
-                    <msub>
-                      <mi>C</mi>
-                      <mi>srgb</mi>
-                    </msub>
-                    <mo>+</mo>
-                    <mn>0.055</mn>
-                  </mrow>
-                  <mn>1.055</mn>
-                </mfrac>
-              </mfenced>
-              <mn>2.4</mn>
-            </msup>
-          </mtd>
-          <mtd>
-            <mtext>if&#160;</mtext>
-            <msub>
-              <mi>C</mi>
-              <mi>srgb</mi>
-            </msub>
-            <mo>></mo>
-            <mn>0.04045</mn>
-          </mtd>
-        </mtr>
-      </mtable>
-    </mrow>
-  </math>
-  <pre id="math-linearRGB">
-if C_srgb &lt;= 0.04045
-  C_linear = C_srgb / 12.92
-else if c_srgb &gt; 0.04045
-  C_linear = ((C_srgb + 0.055) / 1.055) ^ 2.4
-</pre>
-</div>
+<p>Having determined the interpolation color space, component-wise linear
+interpolation is used.</p>
 
-<p>Out-of-range color values, if supported by the user agent, also are
-converted using the above formulas.</p>
+<p class="annotation">CSS Color 4 defines a fuller
+<a href="https://drafts.csswg.org/css-color-4/#interpolation">color
+interpolation</a> procedure, which interpolates
+<a href="https://drafts.csswg.org/css-color-4/#premultiplied">premultiplied</a>
+values and defines the treatment of
+<a href="https://drafts.csswg.org/css-color-4/#missing">missing components</a>.
+It is not adopted here because it differs from what implementations do.  Gradient
+stops and color animations are interpolated straight rather than premultiplied,
+so the two procedures part company when the color and the alpha both change
+between one stop, or one animation value, and the next.  See
+<a href="https://github.com/w3c/svgwg/issues/366">issue 366</a>.</p>
 
-<p>When a child element is blended into a background, the value of the
-<a>'color-interpolation'</a> property on the child determines the type of
-blending, not the value of the <a>'color-interpolation'</a> on the parent.
-For <a href="pservers.html#Gradients">gradients</a> which make use of the
+<p>For <a href="pservers.html#Gradients">gradients</a> which make use of the
 <span class='attr-name'>'href'</span> attribute to reference another
 gradient, the gradient uses the <a>'color-interpolation'</a> property value
 from the gradient element which is directly referenced by the <a>'fill'</a> or
 <a>'stroke'</a> property. When animating colors, color interpolation is
 performed according to the value of the <a>'color-interpolation'</a> property
 on the element being animated.</p>
+
+<p class="note">This property does not affect the interpolation of color
+properties by CSS Transitions or CSS Animations, which interpolate as defined
+by CSS Color 4 for those host syntaxes.
+[<a href="refs.html#ref-css-color-4">css-color-4</a>]</p>
 
 
 <h2 id="RenderingHints">Rendering hints</h2>

--- a/master/painting.html
+++ b/master/painting.html
@@ -2406,7 +2406,7 @@ has the same rendering behavior as
   </tr>
   <tr>
     <th>Value:</th>
-    <td>auto | sRGB | linearRGB</td>
+    <td>auto | sRGB | linearRGB | <a>&lt;color-interpolation-method&gt;</a></td>
   </tr>
   <tr>
     <th>Initial:</th>
@@ -2484,15 +2484,29 @@ determines the color space in which mask luminance is computed.  See
   <dt><span class='prop-value'>sRGB</span></dt>
   <dd>Indicates that the interpolation color space is
   <a href="https://drafts.csswg.org/css-color-4/#predefined-sRGB">sRGB</a>,
-  the gamma encoded sRGB color space.</dd>
+  the gamma encoded sRGB color space.  Equivalent to
+  <span class='prop-value'>in srgb</span>.</dd>
 
   <dt><span class='prop-value'>linearRGB</span></dt>
   <dd>Indicates that the interpolation color space is
   <a href="https://drafts.csswg.org/css-color-4/#predefined-sRGB-linear">srgb-linear</a>,
   which has the same primaries and white point as
   <span class='prop-value'>sRGB</span> and a linear transfer function, so that
-  its component values are proportional to light intensity.</dd>
+  its component values are proportional to light intensity.  Equivalent to
+  <span class='prop-value'>in srgb-linear</span>.</dd>
+
+  <dt><a>&lt;color-interpolation-method&gt;</a></dt>
+  <dd>Indicates the interpolation color space, and for a polar color space the
+  hue interpolation method, as defined in CSS Color 4.  For a polar color space
+  the hues are fixed up as described there before they are interpolated.
+  [<a href="refs.html#ref-css-color-4">css-color-4</a>]</dd>
 </dl>
+
+<p class="note">The <a>&lt;color-interpolation-method&gt;</a> values give access
+to the other interpolation color spaces of CSS Color 4, so that a gradient can
+be interpolated in a perceptually uniform space such as
+<span class='prop-value'>in oklab</span>, or around the hue circle with
+<span class='prop-value'>in oklch</span>.</p>
 
 <p id="sRGBlinearRGBConversionFormulas">The conversion between the
 <span class='prop-value'>sRGB</span> and the

--- a/master/propidx.html
+++ b/master/propidx.html
@@ -37,7 +37,7 @@
       <tbody>
         <tr>
           <th><a>'color-interpolation'</a></th>
-          <td>auto | sRGB | linearRGB </td>
+          <td>auto | sRGB | linearRGB | <a>&lt;color-interpolation-method&gt;</a> </td>
           <td>sRGB</td>
           <td><a>container elements</a>, <a>graphics elements</a>, <a>gradient elements</a>, <a>'use'</a> and <a>'animate'</a></td>
           <td>yes</td>

--- a/master/pservers.html
+++ b/master/pservers.html
@@ -243,7 +243,11 @@ or <a>'stroke'</a> properties to reference the gradient.</p>
 <p class='ready-for-wider-review'>
   For linear and radial gradients, the color value between two stops along the
   gradient vector is the linear interpolation, per channel, of the color for
-  each stop, weighted by the distance from each stop.
+  each stop, weighted by the distance from each stop.  The interpolation is
+  performed in the
+  <a href="https://drafts.csswg.org/css-color-4/#interpolation-color-space">interpolation
+  color space</a> given by the <a>'color-interpolation'</a> property.
+  [<a href="refs.html#ref-css-color-4">css-color-4</a>]
 </p>
 <div role="math" aria-describedby="math-gradient-linear-interpolation" class='ready-for-wider-review'>
   <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">

--- a/master/refs.html
+++ b/master/refs.html
@@ -44,6 +44,9 @@
   <dt id="ref-css-color-3" class="normref">[<a href="https://www.w3.org/TR/css-color-3">css-color-3</a>]</dt>
   <dd><div>Tantek Çelik; Chris Lilley; David Baron. <a href="https://www.w3.org/TR/css-color-3"><cite>CSS Color Module Level 3</cite></a>. 19 June 2018. W3C Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-color-3">https://www.w3.org/TR/css-color-3</a></div></dd>
 
+  <dt id="ref-css-color-4" class="normref">[<a href="https://www.w3.org/TR/css-color-4/">css-color-4</a>]</dt>
+  <dd><div>Tab Atkins Jr.; Chris Lilley; Lea Verou. <a href="https://www.w3.org/TR/css-color-4/"><cite>CSS Color Module Level 4</cite></a>. 1 September 2026. W3C Candidate Recommendation Draft. URL:&nbsp;<a href="https://www.w3.org/TR/css-color-4/">https://www.w3.org/TR/css-color-4/</a> ED:&nbsp;<a href="https://drafts.csswg.org/css-color-4/">https://drafts.csswg.org/css-color-4/</a></div></dd>
+
   <dt id="ref-css-fonts-3" class="normref">[<a href="https://www.w3.org/TR/css-fonts-3/">css-fonts-3</a>]</dt>
   <dd><div>John Daggett, Myles Maxfield, Chris Lilley. <a href="https://www.w3.org/TR/css-fonts-3/"><cite>CSS Fonts Module Level 3</cite></a>. 14 August 2018. W3C Proposed Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/css-fonts-3/">https://www.w3.org/TR/css-fonts-3/</a> ED:&nbsp;<a href="https://drafts.csswg.org/css-fonts/">https://drafts.csswg.org/css-fonts/</a></div></dd>
 
@@ -235,15 +238,6 @@
   <dt id="ref-selectors-3" class="informref">[<a href="https://www.w3.org/TR/selectors-3/">css-selectors-3</a>]</dt>
   <dd><div>Tantek Çelik; Elika Etemad; Daniel Glazman; Ian Hickson; Peter Linss; John Williams et al. <a href="https://www.w3.org/TR/selectors-3/"><cite>Selectors Level 3</cite></a>. 30 January 2018. W3C Candidate Recommendation. URL:&nbsp;<a href="https://www.w3.org/TR/selectors-3/">https://www.w3.org/TR/selectors-3/</a></div></dd>
 
-  <dt id="ref-css-color-4" class="informref">[<a href="https://www.w3.org/TR/css-color-4/">css-color-4</a>]</dt>
-  <dd>
-    <cite class="w3cwd"><a href="https://www.w3.org/TR/css-color-4/">CSS Color Module Level 4</a></cite>,
-    Tab Atkins; Chris Lilley eds.
-    World Wide Web Consortium, 5 July 2016.
-    <br/>The <a href="https://www.w3.org/TR/css-color-4/">latest
-      edition of CSS Color 4</a> is available at
-      https://www.w3.org/TR/css-color-4/.
-  </dd>
   <dt id="ref-css-shapes-2" class="informref">[<a href="https://drafts.csswg.org/css-shapes-2/">css-shapes-2</a>]</dt>
   <dd>
     <cite class="w3cwd"><a href="https://drafts.csswg.org/css-shapes-2/">CSS Shapes Module Level 2</a></cite>,


### PR DESCRIPTION
Closes #366.

`color-interpolation` no longer claims to control compositing and blending of graphics elements into the background. No engine implements it, which is what this issue has said since 2017.

The values stop naming colour spaces that SVG defines for itself. `sRGB` and `linearRGB` become the [srgb](https://drafts.csswg.org/css-color-4/#predefined-sRGB) and [srgb-linear](https://drafts.csswg.org/css-color-4/#predefined-sRGB-linear) interpolation colour spaces of CSS Color 4, and the local sRGB to linear conversion formulas go with them. The Paint Servers chapter says which colour space gradient stops are interpolated in and otherwise keeps its formula.

**The interpolation procedure is deliberately not taken from CSS Color 4.** Step 7 of that procedure premultiplies, and SVG does not. In one page, a colour running from `rgba(255,0,0,1)` to `rgba(0,0,255,0)` over white reads `rgb(191,127,191)` halfway along as an SVG `linearGradient`, as an SVG `radialGradient` and as an `animate` on `fill`, and `rgb(255,127,127)` as the CSS `linear-gradient()`, `radial-gradient()` and CSS animation with the same two colours. Measured in Safari 27.0, Firefox 157.0 and Chrome 155.0.0.0, with controls confirming that each engine really is interpolating both the colour and the alpha. No engine disagrees with any other: the disagreement is between SVG and CSS. Adopting the CSS procedure would change what SVG content renders as, so this PR records the difference as a working group annotation instead of picking a side inside an editorial cleanup. Measurements and a pastable probe are in the issue.

The property is kept rather than removed. CSS Masking 1 reads it normatively on the `mask` element to pick the colour space for mask luminance, all three engines implement that, and Filter Effects defines `color-interpolation-filters` by contrast with it. Two notes are added so the shortened section does not read as saying a container's own value never matters.

**The second commit is separable.** It adds `<color-interpolation-method>` to the value grammar, so an author can write `in oklab` or `in oklch shorter hue`. A new feature with no implementations, so it can be dropped here or moved to a later level. The first commit changes nothing observable.

Questions for the working group:

1. Should SVG be premultiplied, matching CSS? Premultiplication is the only step that changes anything for content that exists today. For stop colours written in legacy sRGB syntax, steps 1 to 6 of the CSS Color 4 procedure are all no-ops: nothing is `none`, nothing is powerless, the conversion is the identity for `srgb` and the one SVG already does for `srgb-linear`, and there is no hue to fix up. And CSS Color 4 names the at-risk content itself: results differ "only ... when both the color and transparency differ between the two endpoints". The common fade-out idiom, same colour with `stop-opacity` going to 0, is identical either way. Where it does differ, what SVG produces today is the greyish fringe that CSS Images 3 calls out and that CSS gradients were changed to avoid. So this is a small, deliberate rendering change, not an impossible one. What is missing is a count of how much content has adjacent stops differing in both colour and alpha, which is asked for in the issue.
2. The initial value stays `sRGB`, so SVG never reaches the CSS Color 4 default. A CSS gradient with modern colour syntax interpolates in Oklab; an SVG gradient with the same stops still interpolates in sRGB. Changing the initial value to `auto` would align them, and would change existing content.
3. What `auto` should mean under the CSS model. Left as user agent choice between `sRGB` and `linearRGB`.
4. Whether the compositing removal reads better as a note in Painting, as here, or as a sentence in the Rendering Model chapter.
5. Whether `<color-interpolation-method>` belongs in SVG 2.

Adding `<color-interpolation-method>` needs three WPT parsing tests updated: `svg/painting/parsing/color-interpolation-{valid,invalid,computed}.svg`. Nothing anywhere covers question 1, which is worth a test whichever way it goes.
